### PR TITLE
test(integrations): añadir tests unitarios para weather tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Se instalaron pytest, pytest-asyncio y pytest-cov como dependencias de desarroll
 
 #### 1.6 — E1-10 · Tests unitarios para weather tools (en progreso)
 
-Se añadió `respx` para mockear llamadas HTTP en tests. Tests implementados para `get_alerts_API` (respuesta válida, vacía y error HTTP) y test de respuesta válida para `get_forecast` (mockeo de dos llamadas encadenadas). Durante el testing se descubrió y corrigió un bug en `get_zone_by_points` donde faltaba `/` en la URL construida. Se añadió validación de periods vacíos en `tool.py` mientras se intentaba hacer su test correspondiente, pero se ha aplazado al depender de tool y no client. Pendientes: tests de error de red para `get_forecast`.
+Se añadió `respx` para mockear llamadas HTTP en tests. Tests implementados para `get_alerts_API` (respuesta válida, vacía y error HTTP) y para `get_forecast` (respuesta válida con mockeo de dos llamadas encadenadas, error HTTP en `get_zone_by_points` y error HTTP en `get_forecast_API`). Durante el testing se descubrió y corrigió un bug en `get_zone_by_points` donde faltaba `/` en la URL construida. Se añadió validación de periods vacíos en `tool.py`, cuyo test queda pendiente al depender de la capa tool y no client.
 
 ### Decisiones de diseño relevantes
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ chore(settings): configurar pydantic-settings con validación al inicio
 
 Se instalaron pytest, pytest-asyncio y pytest-cov como dependencias de desarrollo. Se creó `pytest.ini` en la raíz del proyecto con configuración mínima (testpaths y pythonpath). Se añadió un smoke test (`tests/test_smoke.py`) que verifica que el servidor MCP importa sin errores.
 
+#### 1.6 — E1-10 · Tests unitarios para weather tools (en progreso)
+
+Se añadió `respx` para mockear llamadas HTTP en tests. Primer test implementado: verificación de respuesta válida para `get_alerts_API` usando fixtures con datos falsos. Pendientes: casos de respuesta vacía, error de red, y tests para `get_forecast`.
+
 ### Decisiones de diseño relevantes
 
 | Decisión | Motivo |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Se instalaron pytest, pytest-asyncio y pytest-cov como dependencias de desarroll
 
 #### 1.6 — E1-10 · Tests unitarios para weather tools (en progreso)
 
-Se añadió `respx` para mockear llamadas HTTP en tests. Primer test implementado: verificación de respuesta válida para `get_alerts_API` usando fixtures con datos falsos. Pendientes: casos de respuesta vacía, error de red, y tests para `get_forecast`.
+Se añadió `respx` para mockear llamadas HTTP en tests. Tests implementados para `get_alerts_API` (respuesta válida, vacía y error HTTP) y test de respuesta válida para `get_forecast` (mockeo de dos llamadas encadenadas). Durante el testing se descubrió y corrigió un bug en `get_zone_by_points` donde faltaba `/` en la URL construida. Se añadió validación de periods vacíos en `tool.py` mientras se intentaba hacer su test correspondiente, pero se ha aplazado al depender de tool y no client. Pendientes: tests de error de red para `get_forecast`.
 
 ### Decisiones de diseño relevantes
 

--- a/backend/integrations/weather/client.py
+++ b/backend/integrations/weather/client.py
@@ -5,15 +5,12 @@ from backend.core.base_api import BaseAPI
 from backend.core.models import ToolResult
 
 
-
-
-
 class WeatherAPI(BaseAPI):
 
     # Constants
     BASE_URL = "https://api.weather.gov"
 
-    #Seguramente mover a un archivo de formatters en el futuro
+    # Seguramente mover a un archivo de formatters en el futuro
     def format_alert(self, feature: dict) -> str:
         """Format an alert feature into a readable string."""
         props = feature["properties"]
@@ -25,13 +22,10 @@ class WeatherAPI(BaseAPI):
     Instructions: {props.get("instruction", "No specific instructions provided")}
     """
 
-
-    
-
-    async def get_alerts_API(self,state: str) -> ToolResult:
+    async def get_alerts_API(self, state: str) -> ToolResult:
         endpoint = f"/alerts/active/area/{state}"
         response = await self.make_request(endpoint, "get")
-        
+
         if not response.success:
             return ToolResult.fail(f"Error fetching alerts: {response.error}")
 
@@ -41,25 +35,25 @@ class WeatherAPI(BaseAPI):
         alerts = [self.format_alert(feature) for feature in response.data["features"]]
         return ToolResult.ok("\n---\n".join(alerts))
 
-    async def get_zone_by_points(self,latitude: float, longitude: float) -> ToolResult:
+    async def get_zone_by_points(self, latitude: float, longitude: float) -> ToolResult:
         endpoint = f"/points/{latitude},{longitude}"
-        points_json =  await self.make_request(endpoint, "get")
-        
+        points_json = await self.make_request(endpoint, "get")
+
         if not points_json.success or not points_json.has_content():
             return ToolResult.fail("Unable to find requested zone")
-        
-        #Eliminamos la URL Base ya que el json contiene la URL completa y no solo el endpoint
+
+        # Eliminamos la URL Base ya que el json contiene la URL completa y no solo el endpoint
         forecast = points_json.data.get("properties", {}).get("forecast")
         if not forecast:
             return ToolResult.fail("Forecast URL not found")
-        points_url = forecast.replace(f"{self.BASE_URL}/", "")
+        points_url = forecast.replace(f"{self.BASE_URL}", "")
         return ToolResult.ok(points_url)
 
     async def get_forecast_API(self, zone: str) -> ToolResult:
         endpoint = zone
-        forecast =  await self.make_request(endpoint, "get")
-        
+        forecast = await self.make_request(endpoint, "get")
+
         if not forecast.success or not forecast.data:
-                return ToolResult.fail("Unable to fetch detailed forecast.")
-            
+            return ToolResult.fail("Unable to fetch detailed forecast.")
+
         return ToolResult.ok(forecast.data)

--- a/backend/integrations/weather/tool.py
+++ b/backend/integrations/weather/tool.py
@@ -36,9 +36,12 @@ def register(mcp: FastMCP):
         # Get the forecast URL from the points response
         response = await api.get_forecast_API(zone_url.data)  # type: ignore
         if not response.has_content():
-            return response.error or "Unknown error while retreiving forecast"
+            return response.error or "Unknown error while retrieving forecast"
 
         periods = response.data.get("properties", {}).get("periods")  # type: ignore
+        if not periods:
+            return "No forecast periods available"
+
         forecasts = []
         for period in periods[:5]:  # Only show next 5 periods
             forecast = f"""

--- a/backend/integrations/weather/tool.py
+++ b/backend/integrations/weather/tool.py
@@ -1,16 +1,11 @@
-
-
-
 from mcp.server.fastmcp import FastMCP
 from backend.integrations.weather.client import WeatherAPI
 
 
-
 def register(mcp: FastMCP):
-    
+
     api = WeatherAPI()
-    
-    
+
     @mcp.tool()
     async def get_alerts(state: str) -> str | dict:
         """Get weather alerts for a US state.
@@ -21,11 +16,8 @@ def register(mcp: FastMCP):
         response = await api.get_alerts_API(state)
         if not response.has_content():
             return response.error or "Error fetching alerts"
-        
-        
-        return response.data # type: ignore
-        
 
+        return response.data  # type: ignore
 
     @mcp.tool()
     async def get_forecast(latitude: float, longitude: float) -> str:
@@ -37,18 +29,16 @@ def register(mcp: FastMCP):
         """
         # First get the forecast grid endpoint
         zone_url = await api.get_zone_by_points(latitude, longitude)
-        
+
         if not zone_url.has_content():
             return zone_url.error or "Unknown error while fetching zone"
-            
 
         # Get the forecast URL from the points response
-        response = await api.get_forecast_API(zone_url.data) # type: ignore
+        response = await api.get_forecast_API(zone_url.data)  # type: ignore
         if not response.has_content():
             return response.error or "Unknown error while retreiving forecast"
-        
-        
-        periods = response.data.get("properties", {}).get("periods") # type: ignore
+
+        periods = response.data.get("properties", {}).get("periods")  # type: ignore
         forecasts = []
         for period in periods[:5]:  # Only show next 5 periods
             forecast = f"""
@@ -58,8 +48,5 @@ def register(mcp: FastMCP):
     Forecast: {period["detailedForecast"]}
     """
             forecasts.append(forecast)
-        
 
         return "\n---\n".join(forecasts)
-
-

--- a/requirements.in
+++ b/requirements.in
@@ -6,3 +6,5 @@ pydantic-settings
 pytest
 pytest-asyncio
 pytest-cov
+
+respx 

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,7 @@ httpx==0.28.1
     #   -r requirements.in
     #   fastmcp
     #   mcp
+    #   respx
 httpx-sse==0.4.3
     # via mcp
 idna==3.11
@@ -176,6 +177,8 @@ referencing==0.37.0
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
+respx==0.23.1
+    # via -r requirements.in
 rich==14.3.3
     # via
     #   cyclopts

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -97,8 +97,6 @@ async def test_alerts_bad_response():
 
         api = WeatherAPI()
         result = await api.get_alerts_API("CA")
-        # print()
-        # print(result.error)
         assert not result.success
         assert "500" in result.error
 
@@ -126,7 +124,6 @@ async def test_get_forecast(fake_forecast_periods):
         api = WeatherAPI()
         zone_url = await api.get_zone_by_points(40.7128, -74.006)
 
-        print(zone_url)
         response = await api.get_forecast_API(zone_url.data)
 
         assert zone_url.success
@@ -135,3 +132,47 @@ async def test_get_forecast(fake_forecast_periods):
         assert response.success
         assert response.data is not None
         assert "periods" in response.data.get("properties", {})
+
+
+@pytest.mark.asyncio
+async def test_get_zone_by_points_bad_response():
+    with respx.mock:
+        respx.get("https://api.weather.gov/points/40.7128,-74.006").mock(
+            return_value=Response(500)
+        )
+
+        api = WeatherAPI()
+        zone_url = await api.get_zone_by_points(40.7128, -74.006)
+        assert not zone_url.success
+        assert "Unable to find requested zone" in zone_url.error
+
+
+@pytest.mark.asyncio
+async def test_get_forecast_API_bad_response():
+    with respx.mock:
+        respx.get("https://api.weather.gov/points/40.7128,-74.006").mock(
+            return_value=Response(
+                200,
+                json={
+                    "properties": {
+                        "forecast": "https://api.weather.gov/gridpoints/OKX/33,42/forecast",
+                    }
+                },
+            )
+        )
+
+        respx.get("https://api.weather.gov/gridpoints/OKX/33,42/forecast").mock(
+            return_value=Response(500)
+        )
+
+        api = WeatherAPI()
+        zone_url = await api.get_zone_by_points(40.7128, -74.006)
+
+        response = await api.get_forecast_API(zone_url.data)
+
+        assert zone_url.success
+        assert "gridpoints" in zone_url.data
+
+        assert not response.success
+        assert not response.data
+        assert "Unable to fetch detailed forecast" in response.error

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -17,6 +17,50 @@ def fake_alert():
     }
 
 
+@pytest.fixture
+def fake_forecast_periods():
+    return [
+        {
+            "number": 1,
+            "name": "This Afternoon",
+            "startTime": "2026-05-21T12:00:00-04:00",
+            "endTime": "2026-05-21T18:00:00-04:00",
+            "isDaytime": True,
+            "temperature": 63,
+            "temperatureUnit": "F",
+            "temperatureTrend": None,
+            "probabilityOfPrecipitation": {
+                "unitCode": "wmoUnit:percent",
+                "value": 92,
+            },
+            "windSpeed": "7 to 10 mph",
+            "windDirection": "NE",
+            "icon": "https://api.weather.gov/icons/land/day/rain,90?size=medium",
+            "shortForecast": "Light Rain",
+            "detailedForecast": "Rain. Cloudy, with a high near 63. Northeast wind 7 to 10 mph. Chance of precipitation is 90%. New rainfall amounts between a tenth and quarter of an inch possible.",
+        },
+        {
+            "number": 2,
+            "name": "Tonight",
+            "startTime": "2026-05-21T18:00:00-04:00",
+            "endTime": "2026-05-22T06:00:00-04:00",
+            "isDaytime": False,
+            "temperature": 54,
+            "temperatureUnit": "F",
+            "temperatureTrend": None,
+            "probabilityOfPrecipitation": {
+                "unitCode": "wmoUnit:percent",
+                "value": 27,
+            },
+            "windSpeed": "2 to 9 mph",
+            "windDirection": "E",
+            "icon": "https://api.weather.gov/icons/land/night/rain,30/bkn?size=medium",
+            "shortForecast": "Chance Light Rain then Mostly Cloudy",
+            "detailedForecast": "A chance of rain before 8pm. Mostly cloudy. Low around 54, with temperatures rising to around 57 overnight. East wind 2 to 9 mph. Chance of precipitation is 30%.",
+        },
+    ]
+
+
 @pytest.mark.asyncio
 async def test_alert_exists(fake_alert):
     with respx.mock:
@@ -57,3 +101,37 @@ async def test_alerts_bad_response():
         # print(result.error)
         assert not result.success
         assert "500" in result.error
+
+
+@pytest.mark.asyncio
+async def test_get_forecast(fake_forecast_periods):
+    with respx.mock:
+        respx.get("https://api.weather.gov/points/40.7128,-74.006").mock(
+            return_value=Response(
+                200,
+                json={
+                    "properties": {
+                        "forecast": "https://api.weather.gov/gridpoints/OKX/33,42/forecast",
+                    }
+                },
+            )
+        )
+
+        respx.get("https://api.weather.gov/gridpoints/OKX/33,42/forecast").mock(
+            return_value=Response(
+                200, json={"properties": {"periods": fake_forecast_periods}}
+            )
+        )
+
+        api = WeatherAPI()
+        zone_url = await api.get_zone_by_points(40.7128, -74.006)
+
+        print(zone_url)
+        response = await api.get_forecast_API(zone_url.data)
+
+        assert zone_url.success
+        assert "gridpoints" in zone_url.data
+
+        assert response.success
+        assert response.data is not None
+        assert "periods" in response.data.get("properties", {})

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,32 @@
+from backend.integrations.weather.client import WeatherAPI
+import respx
+import pytest
+from httpx import Response
+
+
+@pytest.fixture
+def fake_alert():
+    return {
+        "properties": {
+            "event": "Flood Warning",
+            "areaDesc": "San Francisco County",
+            "severity": "Severe",
+            "description": "Flooding expected in low-lying areas",
+            "instruction": "Move to higher ground immediately"
+        }
+    }
+@pytest.mark.asyncio
+async def test_alert_exists(fake_alert):
+    with respx.mock:
+        respx.get("https://api.weather.gov/alerts/active/area/CA").mock(
+            return_value=Response(200, json={"features": [fake_alert]})
+        )
+        
+        # Llamas a tu código normalmente
+        api = WeatherAPI()
+        result = await api.get_alerts_API("CA")
+        # print(result)
+        
+        # Verificas
+        assert result.success
+        assert "Flood Warning" in result.data

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -22,11 +22,21 @@ async def test_alert_exists(fake_alert):
             return_value=Response(200, json={"features": [fake_alert]})
         )
         
-        # Llamas a tu código normalmente
         api = WeatherAPI()
         result = await api.get_alerts_API("CA")
-        # print(result)
         
-        # Verificas
         assert result.success
         assert "Flood Warning" in result.data
+        
+        
+@pytest.mark.asyncio
+async def test_alerts_empty_features():
+    with respx.mock:
+        respx.get("https://api.weather.gov/alerts/active/area/CA").mock(
+            return_value=Response(200, json={"features": []})
+        )
+        
+        api = WeatherAPI()
+        result = await api.get_alerts_API("CA")
+        
+        assert "No active alerts for this state." in result.data

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -12,31 +12,48 @@ def fake_alert():
             "areaDesc": "San Francisco County",
             "severity": "Severe",
             "description": "Flooding expected in low-lying areas",
-            "instruction": "Move to higher ground immediately"
+            "instruction": "Move to higher ground immediately",
         }
     }
+
+
 @pytest.mark.asyncio
 async def test_alert_exists(fake_alert):
     with respx.mock:
         respx.get("https://api.weather.gov/alerts/active/area/CA").mock(
             return_value=Response(200, json={"features": [fake_alert]})
         )
-        
+
         api = WeatherAPI()
         result = await api.get_alerts_API("CA")
-        
+
         assert result.success
         assert "Flood Warning" in result.data
-        
-        
+
+
 @pytest.mark.asyncio
 async def test_alerts_empty_features():
     with respx.mock:
         respx.get("https://api.weather.gov/alerts/active/area/CA").mock(
             return_value=Response(200, json={"features": []})
         )
-        
+
         api = WeatherAPI()
         result = await api.get_alerts_API("CA")
-        
+
         assert "No active alerts for this state." in result.data
+
+
+@pytest.mark.asyncio
+async def test_alerts_bad_response():
+    with respx.mock:
+        respx.get("https://api.weather.gov/alerts/active/area/CA").mock(
+            return_value=Response(500, json={"features": []})
+        )
+
+        api = WeatherAPI()
+        result = await api.get_alerts_API("CA")
+        # print()
+        # print(result.error)
+        assert not result.success
+        assert "500" in result.error


### PR DESCRIPTION
﻿## Summary
- Tests unitarios para `get_alerts_API` (respuesta válida, vacía, error HTTP 500)
- Tests unitarios para `get_forecast` (respuesta válida, error HTTP en `get_zone_by_points` y `get_forecast_API`)
- Corregido bug en `get_zone_by_points`: faltaba `/` en la URL construida
- Añadida validación de periods vacíos en `tool.py`

Closes #12
