### PR TITLE
feat(core): configurar logging estructurado con structlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 *.pyc
 .env
+.claude

--- a/README.md
+++ b/README.md
@@ -142,14 +142,28 @@ chore(settings): configurar pydantic-settings con validación al inicio
 
 Se instalaron pytest, pytest-asyncio y pytest-cov como dependencias de desarrollo. Se creó `pytest.ini` en la raíz del proyecto con configuración mínima (testpaths y pythonpath). Se añadió un smoke test (`tests/test_smoke.py`) que verifica que el servidor MCP importa sin errores.
 
-#### 1.6 — E1-10 · Tests unitarios para weather tools (en progreso)
+#### 1.6 — E1-10 · Tests unitarios para weather tools
 
-Se añadió `respx` para mockear llamadas HTTP en tests. Tests implementados para `get_alerts_API` (respuesta válida, vacía y error HTTP) y para `get_forecast` (respuesta válida con mockeo de dos llamadas encadenadas, error HTTP en `get_zone_by_points` y error HTTP en `get_forecast_API`). Durante el testing se descubrió y corrigió un bug en `get_zone_by_points` donde faltaba `/` en la URL construida. Se añadió validación de periods vacíos en `tool.py`, cuyo test queda pendiente al depender de la capa tool y no client.
+Se añadió `respx` para mockear llamadas HTTP en tests. Tests implementados para `get_alerts_API` (respuesta válida, vacía y error HTTP) y para `get_forecast` (respuesta válida con mockeo de dos llamadas encadenadas, error HTTP en `get_zone_by_points` y error HTTP en `get_forecast_API`). Durante el testing se descubrió y corrigió un bug en `get_zone_by_points` donde faltaba `/` en la URL construida. Se añadió también validación de periods vacíos en `tool.py`; el test correspondiente queda fuera del scope de esta iteración por depender de la capa tool y no del client.
+
+#### 1.7 — E1-06 · Logging estructurado con `structlog`
+
+El criterio de aceptación del issue (`logger.info("test", key="value")` debe producir salida estructurada) descartó el `logging` estándar de Python, que no acepta kwargs arbitrarios — se eligió `structlog` por soportar esa sintaxis de forma nativa. (Básicamente, el logging básico fija las salidas a ciertos argumentos. Utilizar structlog nos permite más libertad al configurarlos)
+
+La configuración vive en `backend/core/logging.py` (función `configure_logging()`) y se controla desde dos nuevas variables en `Settings` (`backend/config/settings.py`):
+
+- `LOG_LEVEL`: `DEBUG` / `INFO` / `WARNING` / `ERROR` (default `INFO`).
+- `LOG_FORMAT`: `console` (renderer legible y coloreado, default para desarrollo) o `json` (renderer estructurado para producción).
+
+Ambas se declaran como `Literal[...]` en pydantic-settings, de modo que un valor inválido falla al arrancar (fail-fast, coherente con la decisión de E1-04). La pipeline de processors aplica `merge_contextvars`, `add_log_level` y un `TimeStamper` ISO en UTC antes del renderer final.
+
+En `backend/main.py` se invoca `configure_logging()` al inicio de `main()` y se reemplaza el `logging.info("Starting server...")` por `log.info("server.start", transport="stdio")`, ya con campos estructurados. El test `tests/test_logging.py` valida el DoD del issue forzando `LOG_FORMAT=json` con `monkeypatch` y verificando que la salida JSON contiene `event`, `key`, `level` y `timestamp`.
 
 ### Decisiones de diseño relevantes
 
 | Decisión | Motivo |
 |---|---|
 | Uso de pydantic-settings | Evitar filtraciones de variables críticas y valores hardcodeados |
+| `structlog` sobre `logging` stdlib | Soporta kwargs estructurados (`log.info("evt", key=value)`) sin recurrir a `extra={...}`; pipeline de processors configurable con renderer condicional console/json |
 
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -1,12 +1,19 @@
-#Base Settings: Base class for settings, allowing values to be overridden by environment variables.
+# Base Settings: Base class for settings, allowing values to be overridden by environment variables.
 
 # This is useful in production for secrets you do not wish to save in code, it plays nicely with docker(-compose),
+from typing import Literal
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore") #Ignora valores extra añadidos, solo valida lo declarado. Util si se añaden más API-KEYS
-    guardian_api_key: str # PS mapea automáticamente
-    
-    
-settings = Settings() # type: ignore #Activa la validación al importar
-    
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )  # Ignora valores extra añadidos, solo valida lo declarado. Util si se añaden más API-KEYS
+
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
+    log_format: Literal["console", "json"] = "console"
+    guardian_api_key: str  # PS mapea automáticamente
+
+
+settings = Settings()  # type: ignore #Activa la validación al importar

--- a/backend/core/logging.py
+++ b/backend/core/logging.py
@@ -1,0 +1,24 @@
+import logging
+
+import structlog
+
+from backend.config.settings import settings
+
+
+def configure_logging():
+    level_int = logging.getLevelNamesMapping()[settings.log_level]
+    processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
+    ]
+
+    if settings.log_format == "console":
+        renderer = structlog.dev.ConsoleRenderer()
+    elif settings.log_format == "json":
+        renderer = structlog.processors.JSONRenderer()
+    processors.append(renderer)
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(level_int),
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,29 +2,29 @@
 Servidor MCP principal.
 """
 
-import logging
+from backend.core.logging import configure_logging
+import structlog
+
 
 from mcp.server.fastmcp import FastMCP
 
 from backend.integrations.news import tool as news_tool
 from backend.integrations.weather import tool as weather_tool
 
-
-
+log = structlog.get_logger()
 mcp = FastMCP("tfg-mcp-server")
 
-#TODO: Implementar register dinámico
+# TODO: Implementar register dinámico
 weather_tool.register(mcp)
 news_tool.register(mcp)
 
 
 def main():
     # Initialize and run the server
-    logging.info("Starting server...")
+    configure_logging()
+    log.info("server.start", transport="stdio")
     mcp.run(transport="stdio")
-    
 
 
 if __name__ == "__main__":
     main()
-

--- a/requirements.in
+++ b/requirements.in
@@ -8,3 +8,5 @@ pytest-asyncio
 pytest-cov
 
 respx 
+
+structlog

--- a/requirements.txt
+++ b/requirements.txt
@@ -198,6 +198,8 @@ starlette==0.52.1
     # via
     #   mcp
     #   sse-starlette
+structlog==25.5.0
+    # via -r requirements.in
 typing-extensions==4.15.0
     # via
     #   anyio

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,23 @@
+import json
+
+import structlog
+
+from backend.core.logging import configure_logging
+
+
+def test_logger_emits_structured_output_with_kwargs(monkeypatch, capsys):
+    # monkeypatch = modificar cosas temporalmente durante un test
+    # capsys = Captura lo que se escribe a sys.stdout y sys.stderr y se lee con readouterr()
+    monkeypatch.setattr("backend.config.settings.settings.log_format", "json")
+    configure_logging()
+
+    log = structlog.get_logger()
+    log.info("test", key="value")
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert payload["event"] == "test"
+    assert payload["key"] == "value"
+    assert payload["level"] == "info"
+    assert "timestamp" in payload


### PR DESCRIPTION
## Summary
- Nueva dependencia `structlog` (versión fija en `requirements.txt`)
- `Settings` extendido con `log_level` y `log_format` (`Literal[...]` con defaults `INFO` / `console`, fail-fast vía pydantic-settings)
- Módulo `backend/core/logging.py` con `configure_logging()`: pipeline structlog (`merge_contextvars`, `add_log_level`, `TimeStamper` ISO/UTC) y renderer condicional (`ConsoleRenderer` o `JSONRenderer`) según `LOG_FORMAT`
- Integración en `backend/main.py`: invocación de `configure_logging()` al inicio de `main()` y log estructurado `log.info("server.start", transport="stdio")`
- Test `tests/test_logging.py` que valida el DoD del issue: `logger.info("test", key="value")` produce salida JSON con `event`, `key`, `level` y `timestamp`
- README actualizado: nueva sección 1.7 (E1-06) y nota de cierre de E1-10

Closes #7