### PR TITLE
feat(core): registrar invocaciones de tools con decorador log_tool_invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,33 @@ Ambas se declaran como `Literal[...]` en pydantic-settings, de modo que un valor
 
 En `backend/main.py` se invoca `configure_logging()` al inicio de `main()` y se reemplaza el `logging.info("Starting server...")` por `log.info("server.start", transport="stdio")`, ya con campos estructurados. El test `tests/test_logging.py` valida el DoD del issue forzando `LOG_FORMAT=json` con `monkeypatch` y verificando que la salida JSON contiene `event`, `key`, `level` y `timestamp`.
 
+#### 1.8 — E1-07 · Registro de invocaciones de tools
+
+Se añade `backend/core/observability.py` con el decorador `log_tool_invocation`, que envuelve cada tool MCP para registrar cada invocación con `tool` (nombre), `params` (kwargs recibidos, ya que MCP transmite los parámetros como JSON object), `duration_ms` medido con `time.perf_counter()` y un booleano `success`.
+
+El decorador se aplica en cascada con `@mcp.tool()`:
+
+```python
+@mcp.tool()
+@log_tool_invocation
+async def get_alerts(state: str) -> str | dict: ...
+```
+
+El orden importa — Python aplica los decoradores de abajo a arriba, así que `@mcp.tool()` registra ya la versión envuelta con logging. Aplicado a las tres tools existentes (`get_alerts`, `get_forecast`, `get_news_this_week`).
+
+En caso de éxito se emite el evento `tool.invoke`. Si la tool lanza una excepción, se emite `tool.invoke.failed` con el traceback completo (`traceback.format_exc()` en el campo `exception`) y la tool devuelve al cliente MCP un mensaje genérico (`"Internal error while executing tool"`) — el detalle interno solo aparece en el log.
+
+**Limitación conocida:** cuando una tool retorna un string de error sin lanzar excepción (patrón actual de `get_alerts` y `get_news_this_week`: `return response.error or "Error fetching..."`), el decorador no puede distinguir éxito real de error suave y lo loguea como `success=True`. Estabilizar ese contrato queda fuera del scope de E1-07 y será cubierto por los issues #13 (`[E1-11]`) y #14 (`[E1-12]`).
+
+El test `tests/test_observability.py` cubre dos casos con `pytest-asyncio`: invocación correcta (assert sobre `event`, `tool`, `params`, `success=True`, `duration_ms`) y excepción (assert sobre `event=tool.invoke.failed`, `success=False`, presencia del traceback en `exception`, valor devuelto = mensaje genérico).
+
 ### Decisiones de diseño relevantes
 
 | Decisión | Motivo |
 |---|---|
 | Uso de pydantic-settings | Evitar filtraciones de variables críticas y valores hardcodeados |
 | `structlog` sobre `logging` stdlib | Soporta kwargs estructurados (`log.info("evt", key=value)`) sin recurrir a `extra={...}`; pipeline de processors configurable con renderer condicional console/json |
+| Decorador `log_tool_invocation` sobre middleware | FastMCP no expone un punto claro de middleware; un decorador propio es portable, fácil de testear de forma aislada y se compone explícitamente con `@mcp.tool()` |
+| Mensaje genérico al cliente en error | Evita filtrar detalles internos (paths, librerías, stack) en la respuesta MCP; el detalle solo vive en el log interno (Req 1.5) |
 
 

--- a/backend/core/observability.py
+++ b/backend/core/observability.py
@@ -1,0 +1,52 @@
+# Decorador que registra cada invocación de una tool
+
+import functools
+import time
+import traceback
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def log_tool_invocation(func):
+    @functools.wraps(
+        func
+    )  # Preserva el nombre y docstring de la función original. functools.wraps es un decorador que se utiliza para preservar la información de la función original.
+    async def wrapper(
+        **kwargs,
+    ):  # * y **=> acepta cualquier número de argumentos posicionales y de palabras clave.
+        #
+        start = time.perf_counter()  # perf_counte = time.time() avanzado.
+        try:
+            result = await func(**kwargs)
+            duration_ms = round(
+                (time.perf_counter() - start) * 1000, 2
+            )  # 2 decimales, ms
+            log.info(
+                "tool.invoke",
+                tool=func.__name__,
+                params={
+                    "kwargs": kwargs,
+                },
+                # todo es kwargs ya que pasamos los parámetros como JSON objects
+                duration_ms=duration_ms,
+                success=True,
+            )  # recuerda, key-value del logger.
+            # __name__ => nombre de la función original, sin el decorador. __ se utiliza para acceder a atributos especiales de los objetos en Python.
+            return result
+        except Exception:
+            duration_ms = round((time.perf_counter() - start) * 1000, 2)
+            log.error(
+                "tool.invoke.failed",
+                tool=func.__name__,
+                params={
+                    "kwargs": kwargs,
+                },
+                duration_ms=duration_ms,
+                success=False,
+                exception=traceback.format_exc(),  # Guarda el traceback completo como string
+            )
+            return "Internal error while executing tool"
+
+    return wrapper

--- a/backend/integrations/news/tool.py
+++ b/backend/integrations/news/tool.py
@@ -7,6 +7,8 @@ News API for The Guardian
 import json
 
 from mcp.server.fastmcp import FastMCP
+
+from backend.core.observability import log_tool_invocation
 from backend.integrations.news.client import GuardianAPI
 from backend.core.models import ToolResult
 
@@ -14,10 +16,11 @@ from backend.core.models import ToolResult
 #TODO: Implementar validador? Acaso hay campos cerrados
 #TODO: Esta tool podría inferir! (Preguntar que temas quiere)
 def register(mcp: FastMCP):
-    
+
     api = GuardianAPI()
-    
+
     @mcp.tool()
+    @log_tool_invocation
     async def get_news_this_week(topic: str) -> str:
         
         """Get latest news.

--- a/backend/integrations/weather/tool.py
+++ b/backend/integrations/weather/tool.py
@@ -1,4 +1,6 @@
 from mcp.server.fastmcp import FastMCP
+
+from backend.core.observability import log_tool_invocation
 from backend.integrations.weather.client import WeatherAPI
 
 
@@ -7,6 +9,7 @@ def register(mcp: FastMCP):
     api = WeatherAPI()
 
     @mcp.tool()
+    @log_tool_invocation
     async def get_alerts(state: str) -> str | dict:
         """Get weather alerts for a US state.
 
@@ -20,6 +23,7 @@ def register(mcp: FastMCP):
         return response.data  # type: ignore
 
     @mcp.tool()
+    @log_tool_invocation
     async def get_forecast(latitude: float, longitude: float) -> str:
         """Get weather forecast for a location.
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,61 @@
+import json
+
+import pytest
+
+from backend.core.logging import configure_logging
+from backend.core.observability import log_tool_invocation
+
+
+@pytest.mark.asyncio
+async def test_log_tool_invocation_logs_success(monkeypatch, capsys):
+    monkeypatch.setattr("backend.config.settings.settings.log_format", "json")
+    configure_logging()
+
+    @log_tool_invocation
+    async def fake_tool(state: str) -> str:
+        return f"alerts for {state}"
+
+    result = await fake_tool(state="CA")
+
+    assert result == "alerts for CA"
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert payload["event"] == "tool.invoke"
+    assert payload["tool"] == "fake_tool"
+    assert payload["params"] == {"kwargs": {"state": "CA"}}
+    assert payload["success"] is True
+    assert payload["level"] == "info"
+    assert isinstance(payload["duration_ms"], (int, float))
+    assert "timestamp" in payload
+
+
+@pytest.mark.asyncio
+async def test_log_tool_invocation_logs_failure(monkeypatch, capsys):
+    monkeypatch.setattr("backend.config.settings.settings.log_format", "json")
+    configure_logging()
+
+    @log_tool_invocation
+    async def failing_tool(state: str) -> str:
+        raise RuntimeError("boom")
+
+    result = await failing_tool(state="CA")
+
+    assert result == "Internal error while executing tool"
+
+    captured = capsys.readouterr()
+
+    payload = json.loads(captured.out)
+    # print(payload)
+    assert payload["event"] == "tool.invoke.failed"
+    assert payload["tool"] == "failing_tool"
+    assert payload["params"] == {"kwargs": {"state": "CA"}}
+    assert payload["success"] is False
+    assert payload["level"] == "error"
+    assert (
+        "RuntimeError: boom" in payload["exception"]
+    )  # Campo exception explicitamente creado ya que log. exception = log.error"",exc_info=True
+
+    # Ya tenemos nuestro binario success
+    assert "timestamp" in payload


### PR DESCRIPTION
## Summary
- Nuevo módulo `backend/core/observability.py` con decorador `log_tool_invocation` que registra cada invocación de tool MCP: `tool`, `params` (kwargs), `duration_ms` (via `time.perf_counter`), `success`
- En caso de éxito emite `tool.invoke`; en excepción emite `tool.invoke.failed` con `exception` (traceback completo) y devuelve al cliente un mensaje genérico (`"Internal error while executing tool"`) — sin filtrar detalles internos
- Decorador aplicado en cascada `@mcp.tool() / @log_tool_invocation` en las 3 tools existentes: `get_alerts`, `get_forecast`, `get_news_this_week`
- Test `tests/test_observability.py` con dos casos asíncronos: invocación exitosa (asserts sobre `event`, `tool`, `params`, `success=True`, `duration_ms`) y excepción (asserts sobre `event=tool.invoke.failed`, `success=False`, traceback en `exception`, valor devuelto = mensaje genérico)
- README actualizado: nueva sección 1.8 (E1-07), filas en la tabla de decisiones (decorador sobre middleware, mensaje genérico al cliente)

## Limitación conocida
Los errores "suaves" (tools que retornan un string de error sin lanzar excepción, como `get_alerts` actual con `return response.error or "Error fetching alerts"`) se loguean como `success=True`. Estabilizar el contrato de retorno queda fuera de scope y será cubierto por #13 (`[E1-11]`) y #14 (`[E1-12]`).

Closes #8