### PR TITLE
fix(integrations): manejar respuestas sin results en Guardian client

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,30 @@ En caso de éxito se emite el evento `tool.invoke`. Si la tool lanza una excepci
 
 El test `tests/test_observability.py` cubre dos casos con `pytest-asyncio`: invocación correcta (assert sobre `event`, `tool`, `params`, `success=True`, `duration_ms`) y excepción (assert sobre `event=tool.invoke.failed`, `success=False`, presencia del traceback en `exception`, valor devuelto = mensaje genérico).
 
+#### 1.9 — E1-12 · Fix: `get_news_this_week` con respuestas sin `results`
+
+`backend/integrations/news/client.py:get_news_this_week_call` rompía con `TypeError: 'NoneType' object is not iterable` cuando la respuesta de The Guardian no incluía la clave `results` (o llegaba como `null`). El list comprehension iteraba directamente sobre `response.data.get("response", {}).get("results")` sin validar.
+
+Con el decorador `log_tool_invocation` (E1-07) la excepción se capturaba ahora como `tool.invoke.failed` y el cliente MCP recibía `"Internal error while executing tool"` — funcional, pero "no hay artículos" no debería ser un error técnico, sino un resultado legible.
+
+**Fix:** un guard antes del list comprehension:
+
+```python
+results = response.data.get("response", {}).get("results")
+
+if not results:
+    return ToolResult.fail("No articles found")
+```
+
+`not results` cubre con una sola línea tanto `None` (clave ausente o `null` explícito) como `[]` (lista vacía).
+
+**Contrato:** se eligió `ToolResult.fail("No articles found")` sobre la alternativa `ToolResult.ok("...")` por dos razones:
+
+1. **Tipo único de `data`:** en éxito, `data` siempre es `list[dict]`; un string vacío como `data` rompería esa consistencia.
+2. **Output limpio al cliente:** la tool serializa `response.data` con `json.dumps(...)` solo cuando `has_content()`; si `data` fuera un string, saldrían comillas dobles literales (`'"No articles found."'`). Por el camino `fail`, la tool devuelve `response.error` directamente — string limpio.
+
+El test `tests/test_news_guardian.py` cubre tres casos con `respx`: respuesta válida con artículos (verifica `success=True` y campos `title`/`url`/`date`), `results=[]` (verifica el guard sobre lista vacía) y respuesta sin la clave `results` (verifica el guard sobre `None`, que era el escenario del bug original).
+
 ### Decisiones de diseño relevantes
 
 | Decisión | Motivo |

--- a/backend/integrations/news/client.py
+++ b/backend/integrations/news/client.py
@@ -1,4 +1,3 @@
-
 # Constants
 from typing import Optional
 
@@ -8,43 +7,55 @@ from datetime import date
 from datetime import timedelta
 
 
-
 from backend.config.settings import settings
-
 
 
 class GuardianAPI(BaseAPI):
 
+    BASE_URL = "https://content.guardianapis.com/"
 
-    BASE_URL  = "https://content.guardianapis.com/"
-    
-    API_KEY  = settings.guardian_api_key #Key ya validada
+    API_KEY = settings.guardian_api_key  # Key ya validada
     API_KEY_PARAM = "api-key"
-            
-        
-    #TODO: Make topic optional
+
+    # TODO: Make topic optional
     async def get_news_this_week_call(self, topic: str) -> ToolResult:
         today = date.today()
         new_date = today - timedelta(days=7)
-        params = {"q": topic, 
-                "from-date": new_date 
-        }
-                
+        params = {"q": topic, "from-date": new_date}
+
         endpoint = f"search"
         response = await self.make_request(endpoint, "get", params)
-        
+
         if not response.success or not response.has_content():
             return ToolResult.fail("No articles found")
-        
+
         results = response.data.get("response", {}).get("results")
-        
+
+        if not results:
+            return ToolResult.fail("No articles found")
+
         articles = [
-        {
-            "title": article.get("webTitle"),
-            "url": article.get("webUrl"),
-            "date": article.get("webPublicationDate"),
-        }
-        for article in results
+            {
+                "title": article.get("webTitle"),
+                "url": article.get("webUrl"),
+                "date": article.get("webPublicationDate"),
+            }
+            for article in results
         ]
 
         return ToolResult.ok(articles)
+
+
+# Formato respuesta
+# {
+#     "response": {
+#         "results": [
+#             {
+#                 "webTitle": "...",
+#                 "webUrl": "...",
+#                 "webPublicationDate": "...",
+#             },
+#             ...
+#         ]
+#     }
+# }

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,0 +1,64 @@
+import pytest
+import respx
+from httpx import Response
+
+from backend.integrations.news.client import GuardianAPI
+
+
+@pytest.fixture
+def fake_guardian_article():
+    return {
+        "webTitle": "‘We’re expanding the cinematic toolbox’: AI fault lines on show at Cannes",
+        "webUrl": "https://www.theguardian.com/technology/2026/may/24/cinematic-toolbox-ai-fault-lines-cannes",
+        "webPublicationDate": "2026-05-24T05:00:48Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_news_valid_response(fake_guardian_article):
+    with respx.mock:
+        respx.get("https://content.guardianapis.com/search").mock(
+            return_value=Response(
+                200,
+                json={"response": {"results": [fake_guardian_article]}},
+            )
+        )
+
+        api = GuardianAPI()
+        result = await api.get_news_this_week_call("technology")
+
+        assert result.success
+        assert len(result.data) == 1
+        assert result.data[0]["title"] == fake_guardian_article["webTitle"]
+        assert result.data[0]["url"] == fake_guardian_article["webUrl"]
+        assert result.data[0]["date"] == fake_guardian_article["webPublicationDate"]
+
+
+@pytest.mark.asyncio
+async def test_news_missing_results_field():
+    """Bug fix #14: payload sin 'results' no debe lanzar TypeError."""
+    with respx.mock:
+        respx.get("https://content.guardianapis.com/search").mock(
+            return_value=Response(200, json={"response": {}})
+        )
+
+        api = GuardianAPI()
+        result = await api.get_news_this_week_call("technology")
+
+        assert not result.success
+        assert "No articles found" in result.error
+
+
+@pytest.mark.asyncio
+async def test_news_empty_results():
+    """Lista vacía se trata igual que ausencia de campo (mismo guard)."""
+    with respx.mock:
+        respx.get("https://content.guardianapis.com/search").mock(
+            return_value=Response(200, json={"response": {"results": []}})
+        )
+
+        api = GuardianAPI()
+        result = await api.get_news_this_week_call("technology")
+
+        assert not result.success
+        assert "No articles found" in result.error

--- a/tests/test_news_guardian.py
+++ b/tests/test_news_guardian.py
@@ -1,0 +1,109 @@
+from datetime import date, timedelta
+
+from backend.integrations.news.client import GuardianAPI
+import respx
+import pytest
+from httpx import Response
+
+# TODO: Better tests organizations and integration tests.
+
+
+@pytest.fixture
+def fake_payload():
+    return {
+        "webTitle": "‘We’re expanding the cinematic toolbox’: AI fault lines on show at Cannes",
+        "webUrl": "https://www.theguardian.com/technology/2026/may/24/cinematic-toolbox-ai-fault-lines-cannes",
+        "webPublicationDate": "2026-05-24T05:00:48Z",
+    }
+
+
+@pytest.fixture
+def fake_forecast_periods():
+    return [
+        {
+            "number": 1,
+            "name": "This Afternoon",
+            "startTime": "2026-05-21T12:00:00-04:00",
+            "endTime": "2026-05-21T18:00:00-04:00",
+            "isDaytime": True,
+            "temperature": 63,
+            "temperatureUnit": "F",
+            "temperatureTrend": None,
+            "probabilityOfPrecipitation": {
+                "unitCode": "wmoUnit:percent",
+                "value": 92,
+            },
+            "windSpeed": "7 to 10 mph",
+            "windDirection": "NE",
+            "icon": "https://api.weather.gov/icons/land/day/rain,90?size=medium",
+            "shortForecast": "Light Rain",
+            "detailedForecast": "Rain. Cloudy, with a high near 63. Northeast wind 7 to 10 mph. Chance of precipitation is 90%. New rainfall amounts between a tenth and quarter of an inch possible.",
+        },
+        {
+            "number": 2,
+            "name": "Tonight",
+            "startTime": "2026-05-21T18:00:00-04:00",
+            "endTime": "2026-05-22T06:00:00-04:00",
+            "isDaytime": False,
+            "temperature": 54,
+            "temperatureUnit": "F",
+            "temperatureTrend": None,
+            "probabilityOfPrecipitation": {
+                "unitCode": "wmoUnit:percent",
+                "value": 27,
+            },
+            "windSpeed": "2 to 9 mph",
+            "windDirection": "E",
+            "icon": "https://api.weather.gov/icons/land/night/rain,30/bkn?size=medium",
+            "shortForecast": "Chance Light Rain then Mostly Cloudy",
+            "detailedForecast": "A chance of rain before 8pm. Mostly cloudy. Low around 54, with temperatures rising to around 57 overnight. East wind 2 to 9 mph. Chance of precipitation is 30%.",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_article_valid_response(fake_payload):
+
+    with respx.mock:
+        respx.get("https://content.guardianapis.com/search").mock(
+            return_value=Response(200, json={"response": {"results": [fake_payload]}})
+        )
+
+        api = GuardianAPI()
+        result = await api.get_news_this_week_call("technology")
+
+        assert result.success
+        assert len(result.data) == 1
+        assert result.success
+        assert len(result.data) == 1
+        assert result.data[0]["title"] == fake_payload["webTitle"]
+        assert result.data[0]["url"] == fake_payload["webUrl"]
+        assert result.data[0]["date"] == fake_payload["webPublicationDate"]
+
+
+@pytest.mark.asyncio
+async def test_article_no_results():
+    with respx.mock:
+        respx.get("https://content.guardianapis.com/search").mock(
+            return_value=Response(200, json={"response": {"results": []}})
+        )
+
+        api = GuardianAPI()
+        result = await api.get_news_this_week_call("asdfghjkl")
+
+        assert not result.success
+        assert "No articles found" in result.error
+
+
+@pytest.mark.asyncio
+async def test_article_missing_results_key():
+    with respx.mock:
+        respx.get("https://content.guardianapis.com/search").mock(
+            return_value=Response(200, json={"response": {}})
+        )
+
+        api = GuardianAPI()
+        result = await api.get_news_this_week_call("anything")
+
+        assert not result.success
+        assert "No articles found" in result.error


### PR DESCRIPTION
## Summary
- `backend/integrations/news/client.py`: añadido guard `if not results: return ToolResult.fail("No articles found")` antes del list comprehension. Cubre tanto `None` (clave `results` ausente o `null`) como `[]` (lista vacía) en una sola línea.
- Decisión sobre el contrato de retorno: se elige `ToolResult.fail` sobre `ToolResult.ok("...")` para mantener `data` como `list[dict]` único (consistencia de tipo) y evitar las comillas dobles literales que añadiría `json.dumps` sobre un string en la tool.
- `tests/test_news_guardian.py`: tres tests con `respx` — respuesta válida (verifica serialización a `title`/`url`/`date`), `results=[]` (verifica guard sobre lista vacía), respuesta sin la clave `results` (verifica guard sobre `None` — el escenario original del bug).
- README: nueva sección 1.9 (E1-12) documentando el bug, el fix y la decisión sobre el contrato.

## Contexto
Reduce parcialmente la limitación conocida documentada en E1-07 (PR #23): "errores suaves" desde el cliente ahora se modelan explícitamente como `ToolResult.fail`, en lugar de propagarse como excepción al decorador.

Closes #14