### PR TITLE
feat(integrations): añadir cliente NYTAPI con search_articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,4 +234,26 @@ Se descartó la opción de mockear las APIs con `respx` (patrón que sí se usa 
 | Logs por `sys.stderr` en transporte stdio | El protocolo MCP por stdio reserva stdout para JSON-RPC; sin redirigir, structlog corrompe el canal y Claude Desktop pierde el servidor |
 | Integration tests sobre mocks para health | Para un solo programador, automatizar la detección real de fallos vale más que mocks que reproducen exactamente la funcionalidad bajo test |
 
+---
 
+## Épica 2 — Integración New York Times
+
+Objetivo: añadir una segunda fuente de noticias al servidor MCP para alimentar el análisis de clickbait con titulares de procedencia distinta a The Guardian. La épica se descompone en cliente (E2-01), tool MCP (E2-02) y tests (E2-03), siguiendo el mismo patrón de integraciones ya consolidado.
+
+### Iteraciones
+
+#### 2.1 — E2-01 · Cliente NYT con búsqueda de titulares
+
+Se añade `backend/integrations/nyt/` con `NYTAPI` heredando de `BaseAPI`, replicando el patrón de `GuardianAPI`: constantes de clase (`BASE_URL`, `API_KEY`, `API_KEY_PARAM`) y `make_request` ya inyecta la `api-key` como query string sin tocar el método.
+
+`Settings` extendido con `nyt_api_key: str` (obligatoria, fail-fast vía pydantic-settings). En `.env` se carga como `NYT_API_KEY` (mayúsculas, convención 12-factor; pydantic-settings mapea automáticamente).
+
+El único método público es `search_articles(topic: str)`, que llama a [Article Search API](https://developer.nytimes.com/docs/articlesearch-product/1/overview) con `q=<topic>`, `begin_date=YYYYMMDD` (hoy menos 7 días) y `sort=newest`. Devuelve `ToolResult.ok(list[dict])` con el mismo schema común que Guardian — `{title, url, date}` — para que el consumidor (la tool MCP de E2-02) no tenga que distinguir el origen.
+
+
+### Decisiones de diseño relevantes
+
+| Decisión | Motivo |
+|---|---|
+| Schema común `{title, url, date}` entre Guardian y NYT | Permite que la futura tool MCP (E2-02) y el analizador NLP (E3) consuman datos sin ramificar lógica por fuente |
+| Hereda de `BaseAPI` igual que Guardian/Weather | Reutiliza la inyección automática de `api-key`, manejo uniforme de timeout y errores HTTP; cualquier mejora futura en `BaseAPI` aplica a las tres integraciones |

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
     log_format: Literal["console", "json"] = "console"
     guardian_api_key: str  # PS mapea automáticamente
+    nyt_api_key: str
 
 
 settings = Settings()  # type: ignore #Activa la validación al importar

--- a/backend/integrations/nyt/client.py
+++ b/backend/integrations/nyt/client.py
@@ -1,0 +1,67 @@
+from backend.core.base_api import BaseAPI
+from backend.core.models import ToolResult
+from datetime import date
+from datetime import timedelta
+
+
+from backend.config.settings import settings
+
+
+class NYTAPI(BaseAPI):
+
+    BASE_URL = "https://api.nytimes.com/svc/search/v2/"
+
+    API_KEY = settings.nyt_api_key  # Key ya validada
+    API_KEY_PARAM = "api-key"
+
+    async def search_articles(self, topic: str) -> ToolResult:
+        """Buscar artículos del NYT de la última semana por topic.
+
+
+        Llama a Article Search API (https://developer.nytimes.com/docs/articlesearch-product/1/overview).
+
+
+        Args:
+            topic (str): keyword(s) de búsqueda libre (param `q`).
+
+        Params enviados:
+            - q: <topic>
+            - begin_date: YYYYMMDD (hoy menos 7 días) #TODO: Configurar fecha dinámica (dejar semana por defecto)
+            - sort: newest
+
+        Respuesta de llamada a endpoint (campos consumidos):
+            response.docs[].web_url    → url
+            response.docs[].headline.main  → title
+            response.docs[].pub_date   → date
+
+        Returns:
+            ToolResult.ok([{title, url, date}, ...]) si hay artículos.
+            ToolResult.fail("No articles found") si docs está vacío o ausente.
+        """
+        today = date.today()
+        new_date = (today - timedelta(days=7)).strftime("%Y%m%d")  # Formato YYYYMMDD
+        params = {"q": topic, "begin_date": new_date, "sort": "newest"}
+
+        endpoint = "articlesearch.json"
+        response = await self.make_request(endpoint, "get", params)
+
+        if not response.success or not response.has_content():
+            return ToolResult.fail("No articles found")
+
+        results = response.data.get("response", {}).get("docs")
+
+        if not results:
+            return ToolResult.fail("No articles found")
+
+        articles = [
+            {
+                "title": article.get("headline", {}).get(
+                    "main"
+                ),  # De nuevo, sin {}, el primer get devuelve none y ahí no se puede hacer get.
+                "url": article.get("web_url"),
+                "date": article.get("pub_date"),
+            }
+            for article in results
+        ]
+
+        return ToolResult.ok(articles)


### PR DESCRIPTION
## Summary
- Nuevo paquete `backend/integrations/nyt/` con `__init__.py` y `client.py`. `NYTAPI` hereda de `BaseAPI` siguiendo el patrón consolidado de Guardian/Weather (`BASE_URL`, `API_KEY`, `API_KEY_PARAM` como constantes de clase; `make_request` inyecta la api-key automáticamente).
- `Settings` extendido con `nyt_api_key: str` (obligatoria, fail-fast vía pydantic-settings). Variable de entorno `NYT_API_KEY` en `.env` (MAYÚSCULAS por convención 12-factor).
- Método único `search_articles(topic)` que llama a Article Search API con `q=<topic>`, `begin_date=YYYYMMDD` (hoy menos 7 días, formato sin guiones específico de NYT) y `sort=newest`. Devuelve `ToolResult.ok(list[dict])` con el schema común `{title, url, date}` para alinear con Guardian.
- Mapeo de campos NYT → schema común: `headline.main` → `title` (anidado, navegado con `.get("headline", {}).get("main")` para evitar `NoneType.get`), `web_url` → `url`, `pub_date` → `date`.
- Guard `if not docs: return ToolResult.fail("No articles found")` aplicado desde el primer commit como lección directa del fix #14 (E1-12) — previene el mismo bug en el cliente nuevo ante respuestas sin `docs` o con lista vacía.
- README: nueva épica E2 con introducción, sección 2.1 documentando el cliente, tabla comparativa Guardian vs NYT y tabla de decisiones propia de la épica.


Closes #20