### PR TITLE
feat(integrations): registrar tool MCP get_nyt_news

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ Se añade `backend/integrations/nyt/` con `NYTAPI` heredando de `BaseAPI`, repli
 
 El único método público es `search_articles(topic: str)`, que llama a [Article Search API](https://developer.nytimes.com/docs/articlesearch-product/1/overview) con `q=<topic>`, `begin_date=YYYYMMDD` (hoy menos 7 días) y `sort=newest`. Devuelve `ToolResult.ok(list[dict])` con el mismo schema común que Guardian — `{title, url, date}` — para que el consumidor (la tool MCP de E2-02) no tenga que distinguir el origen.
 
+#### 2.2 — E2-02 · Tool MCP `get_nyt_news`
+
+Se añade `backend/integrations/nyt/tool.py` con la función `register(mcp)`, siguiendo el mismo patrón de `news/tool.py`, y maneja el `ToolResult` con el mismo contrato que Guardian — `if not response.has_content(): return response.error or "Error fetching news"` y `json.dumps(response.data)` en éxito.
+
+`backend/main.py` registra la nueva tool junto a las anteriores (`nyt_tool.register(mcp)`), elevando a **5 las tools expuestas** al cliente MCP: `get_alerts`, `get_forecast`, `get_news_this_week`, `health_check` y `get_nyt_news`.
+
 
 ### Decisiones de diseño relevantes
 

--- a/backend/integrations/nyt/tool.py
+++ b/backend/integrations/nyt/tool.py
@@ -1,0 +1,33 @@
+"""
+News API for The New York Times (NYT)
+"""
+
+import json
+
+from mcp.server.fastmcp import FastMCP
+
+from backend.core.observability import log_tool_invocation
+from backend.integrations.nyt.client import NYTAPI
+from backend.core.models import ToolResult
+
+
+def register(mcp: FastMCP):
+
+    api = NYTAPI()
+
+    @mcp.tool()
+    @log_tool_invocation
+    async def get_nyt_news(topic: str) -> str:
+        """Buscar noticias del New York Times de la última semana sobre un tema concreto.
+
+        Args:
+            topic (str): keyword(s) sobre los que buscar artículos (ej. "AI", "elecciones", "climate change").
+
+        Returns:
+            JSON serializado con lista de artículos {title, url, date}, o un mensaje de error
+            si no hay resultados o la API falla
+        """
+        response = await api.search_articles(topic)
+        if not response.has_content():
+            return response.error or "Error fetching news"
+        return json.dumps(response.data)

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from mcp.server.fastmcp import FastMCP
 
 from backend.integrations.news import tool as news_tool
 from backend.integrations.weather import tool as weather_tool
+from backend.integrations.nyt import tool as nyt_tool
 
 log = structlog.get_logger()
 mcp = FastMCP("tfg-mcp-server")
@@ -20,8 +21,10 @@ mcp = FastMCP("tfg-mcp-server")
 weather_tool.register(mcp)
 news_tool.register(mcp)
 health.register(mcp)
+nyt_tool.register(mcp)
 
 
+# TODO: Start más descriptivo
 def main():
     # Initialize and run the server
     configure_logging()


### PR DESCRIPTION
## Summary
- Nuevo `backend/integrations/nyt/tool.py` con `register(mcp)` que expone la tool MCP `get_nyt_news(topic)`. Patrón idéntico a `news/tool.py`: instancia `NYTAPI()`, decora con `@mcp.tool()` + `@log_tool_invocation` (orden importa) y maneja `ToolResult` con el contrato común — `response.error` si no hay contenido, `json.dumps(response.data)` en éxito.
- `backend/main.py` registra la nueva tool junto a las anteriores. Total expuesto al cliente MCP: **5 tools** (`get_alerts`, `get_forecast`, `get_news_this_week`, `health_check`, `get_nyt_news`).
- README: sección 2.2 documentando la tool y la decisión de docstring explícito.

## Fuera de scope
Tests del cliente y de la tool → issue #22 (E2-03).

Closes #21