### PR TITLE
test(integrations): cobertura completa del cliente NYT (unit + integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,22 @@ Se añade `backend/integrations/nyt/tool.py` con la función `register(mcp)`, si
 
 `backend/main.py` registra la nueva tool junto a las anteriores (`nyt_tool.register(mcp)`), elevando a **5 las tools expuestas** al cliente MCP: `get_alerts`, `get_forecast`, `get_news_this_week`, `health_check` y `get_nyt_news`.
 
+#### 2.3 — E2-03 · Tests del cliente NYT
+
+`tests/test_news_nyt.py` combina **dos niveles** siguiendo el patrón establecido en E1-08 (health check):
+
+**Unit tests (4 con `respx`)**, deterministas, cubren todas las ramas de parseo:
+
+- `test_search_articles_valid_response` — payload OK con artículos, asserta `success=True` y mapeo de campos `headline.main`/`web_url`/`pub_date` al schema común `{title, url, date}`.
+- `test_search_articles_no_results` — `docs=[]`, asserta `success=False` con `"No articles found"` en `error`. Cubre el guard `if not docs`.
+- `test_search_articles_missing_docs_key` — payload sin la clave `docs`, cubre el mismo guard sobre `None`.
+- `test_search_articles_http_error` — respuesta HTTP 500, asserta que `BaseAPI` propaga el fallo y `search_articles` retorna `ToolResult.fail`.
+
+**Integration tests (2 con `@pytest.mark.integration`)**, hacen petición real a NYT:
+
+- `test_search_articles_valid_use` — drift detection del schema: con la API key real, asserta que cada artículo de la respuesta contiene `title`, `url` y `date`. Si NYT renombra o anida distinto algún campo, el test falla y se entera el dev.
+- `test_search_articles_invalid_topic` — topic improbable (`"nonexistingtopicabcde"`) que actualmente no devuelve resultados; asserta `not result.success` y `"No articles found" in result.error`, conectando el contrato del cliente con el string que finalmente recibe el LLM. **Aceptado como potencialmente flaky** (algún día puede aparecer un artículo con ese topic); documentado en el propio archivo como warning.
+
 
 ### Decisiones de diseño relevantes
 

--- a/backend/integrations/nyt/client.py
+++ b/backend/integrations/nyt/client.py
@@ -65,3 +65,19 @@ class NYTAPI(BaseAPI):
         ]
 
         return ToolResult.ok(articles)
+
+
+# {
+#   "response": {
+#     "docs": [
+#       {
+#         "web_url": "https://...",
+#         "headline": {"main": "Title"},
+#         "pub_date": "2026-05-28T10:30:00+0000",
+#         "section_name": "Technology",
+#         "byline": {"original": "By X"}
+#       }
+#     ],
+#     "meta": {"hits": 1234}
+#   }
+# }

--- a/tests/test_news_nyt.py
+++ b/tests/test_news_nyt.py
@@ -73,3 +73,30 @@ async def test_search_articles_http_error():
 
         assert not result.success
         assert "No articles found" in result.error
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_search_articles_valid_use():
+
+    api = NYTAPI()
+    result = await api.search_articles("technology")
+
+    assert result.success
+    # print(result.data)
+    assert result.data[0]["title"] is not None
+    assert result.data[0]["url"] is not None
+    assert result.data[0]["date"] is not None
+
+
+# WARNING!!!!
+# COMPROBAR MANUALMENTE QUE EL TEMA SELECCIONADO NO EXISTE Y NO DEVUELVE RESULTADOS
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_search_articles_invalid_topic():
+
+    api = NYTAPI()
+    result = await api.search_articles("nonexistingtopicabcde")
+    # print(result.data)
+    assert not result.success
+    assert result.error

--- a/tests/test_news_nyt.py
+++ b/tests/test_news_nyt.py
@@ -1,5 +1,3 @@
-from datetime import date, timedelta
-
 from backend.integrations.nyt.client import NYTAPI
 import respx
 import pytest
@@ -35,29 +33,43 @@ async def test_search_articles_valid_response(fake_payload):
         assert result.data[0]["date"] == fake_payload["pub_date"]
 
 
-# @pytest.mark.asyncio
-# async def test_article_no_results():
-#     with respx.mock:
-#         respx.get("https://content.guardianapis.com/search").mock(
-#             return_value=Response(200, json={"response": {"results": []}})
-#         )
+@pytest.mark.asyncio
+async def test_search_articles_no_results():
+    with respx.mock:
+        respx.get(f"{NYTAPI.BASE_URL}articlesearch.json").mock(
+            return_value=Response(200, json={"response": {"docs": []}})
+        )
 
-#         api = GuardianAPI()
-#         result = await api.get_news_this_week_call("asdfghjkl")
+        api = NYTAPI()
+        result = await api.search_articles("anything")
 
-#         assert not result.success
-#         assert "No articles found" in result.error
+        assert not result.success
+        assert "No articles found" in result.error
 
 
-# @pytest.mark.asyncio
-# async def test_article_missing_results_key():
-#     with respx.mock:
-#         respx.get("https://content.guardianapis.com/search").mock(
-#             return_value=Response(200, json={"response": {}})
-#         )
+@pytest.mark.asyncio
+async def test_search_articles_missing_docs_key():
+    with respx.mock:
+        respx.get(f"{NYTAPI.BASE_URL}articlesearch.json").mock(
+            return_value=Response(200, json={"response": {}})
+        )
 
-#         api = GuardianAPI()
-#         result = await api.get_news_this_week_call("anything")
+        api = NYTAPI()
+        result = await api.search_articles("anything")
 
-#         assert not result.success
-#         assert "No articles found" in result.error
+        assert not result.success
+        assert "No articles found" in result.error
+
+
+@pytest.mark.asyncio
+async def test_search_articles_http_error():
+    with respx.mock:
+        respx.get(f"{NYTAPI.BASE_URL}articlesearch.json").mock(
+            return_value=Response(500, json={"response": {}})
+        )
+
+        api = NYTAPI()
+        result = await api.search_articles("anything")
+
+        assert not result.success
+        assert "No articles found" in result.error

--- a/tests/test_news_nyt.py
+++ b/tests/test_news_nyt.py
@@ -100,3 +100,4 @@ async def test_search_articles_invalid_topic():
     # print(result.data)
     assert not result.success
     assert result.error
+    assert "No articles found" in result.error

--- a/tests/test_news_nyt.py
+++ b/tests/test_news_nyt.py
@@ -1,0 +1,63 @@
+from datetime import date, timedelta
+
+from backend.integrations.nyt.client import NYTAPI
+import respx
+import pytest
+from httpx import Response
+
+
+@pytest.fixture
+def fake_payload():
+    return {
+        "headline": {
+            "main": "Want to ‘Optimize’ Your Happiness? This Happiness Expert Says: Don’t."
+        },
+        "web_url": "https://www.nytimes.com/2026/05/30/magazine/laurie-santos-interview.html",
+        "pub_date": "2026-03-10T19:03:21Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_search_articles_valid_response(fake_payload):
+
+    with respx.mock:
+        respx.get(f"{NYTAPI.BASE_URL}articlesearch.json").mock(
+            return_value=Response(200, json={"response": {"docs": [fake_payload]}})
+        )
+
+        api = NYTAPI()
+        result = await api.search_articles("hapiness")
+
+        assert result.success
+        assert len(result.data) == 1
+        assert result.data[0]["title"] == fake_payload["headline"]["main"]
+        assert result.data[0]["url"] == fake_payload["web_url"]
+        assert result.data[0]["date"] == fake_payload["pub_date"]
+
+
+# @pytest.mark.asyncio
+# async def test_article_no_results():
+#     with respx.mock:
+#         respx.get("https://content.guardianapis.com/search").mock(
+#             return_value=Response(200, json={"response": {"results": []}})
+#         )
+
+#         api = GuardianAPI()
+#         result = await api.get_news_this_week_call("asdfghjkl")
+
+#         assert not result.success
+#         assert "No articles found" in result.error
+
+
+# @pytest.mark.asyncio
+# async def test_article_missing_results_key():
+#     with respx.mock:
+#         respx.get("https://content.guardianapis.com/search").mock(
+#             return_value=Response(200, json={"response": {}})
+#         )
+
+#         api = GuardianAPI()
+#         result = await api.get_news_this_week_call("anything")
+
+#         assert not result.success
+#         assert "No articles found" in result.error


### PR DESCRIPTION
## Summary
- `tests/test_news_nyt.py` con **6 tests** cubriendo el cliente NYT en dos niveles:
  - **4 unit tests con `respx`** (deterministas): respuesta válida (asserta mapeo `headline.main`/`web_url`/`pub_date` → `title`/`url`/`date`), `docs=[]`, payload sin la clave `docs`, HTTP 500.
  - **2 integration tests con `@pytest.mark.integration`** contra la API real de NYT: drift detection del schema (`title`/`url`/`date` presentes en cada artículo) y topic improbable que asserta `"No articles found" in result.error` — conectando el contrato del cliente con el string que recibe el LLM.
- Disclaimer del flaky del segundo integration documentado en el propio archivo (algún día puede aparecer un artículo con el topic raro).
- README sección 2.3 documentando ambos niveles y la decisión de mezclarlos.

## Follow-up
Se abrió el issue #28 para replicar el patrón mixto unit+integration en el cliente de Guardian, que actualmente solo tiene cobertura con mocks.

Closes #22