### PR TITLE
test(integrations): añadir tests de integración para Guardian API

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ Se añade `backend/integrations/nyt/tool.py` con la función `register(mcp)`, si
 - `test_search_articles_invalid_topic` — topic improbable (`"nonexistingtopicabcde"`) que actualmente no devuelve resultados; asserta `not result.success` y `"No articles found" in result.error`, conectando el contrato del cliente con el string que finalmente recibe el LLM. **Aceptado como potencialmente flaky** (algún día puede aparecer un artículo con ese topic); documentado en el propio archivo como warning.
 
 
+AÑADIDO TAMBIEN TESTS DE INTEGRACIÓN PARA GUARDIAN API
+
+
 ### Decisiones de diseño relevantes
 
 | Decisión | Motivo |

--- a/tests/test_news_guardian.py
+++ b/tests/test_news_guardian.py
@@ -107,3 +107,31 @@ async def test_article_missing_results_key():
 
         assert not result.success
         assert "No articles found" in result.error
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_news_real_schema_contract():
+
+    api = GuardianAPI()
+    result = await api.get_news_this_week_call("technology")
+
+    assert result.success
+    # print(result.data)
+    assert result.data[0]["title"] is not None
+    assert result.data[0]["url"] is not None
+    assert result.data[0]["date"] is not None
+
+
+# WARNING!!!!
+# COMPROBAR MANUALMENTE QUE EL TEMA SELECCIONADO NO EXISTE Y NO DEVUELVE RESULTADOS
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_news_invalid_topic():
+
+    api = GuardianAPI()
+    result = await api.get_news_this_week_call("nonexistingtopicabcde")
+    # print(result.data)
+    assert not result.success
+    assert result.error
+    assert "No articles found" in result.error


### PR DESCRIPTION
## Summary
Replicación del patrón mixto de NYT (E2-03) en `tests/test_news_guardian.py`: añadir cobertura con tests de integración contra la API real de Guardian, complementando los unit tests con `respx` ya existentes.

## Contexto
Hasta este PR, el cliente Guardian solo tenía cobertura con mocks (`respx`), igual que `weather`. NYT (E2-03) estableció el patrón de combinar unit tests deterministas + integration tests marcados con `@pytest.mark.integration` para drift detection del contrato real con la API externa. Este PR cierra esa asimetría.

Closes #28