### PR TITLE
refactor: coherencia transversal post-MVP (health dinámico, topic/days, renames)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,9 @@ Se añade `backend/integrations/nyt/tool.py` con la función `register(mcp)`, si
 - `test_search_articles_valid_use` — drift detection del schema: con la API key real, asserta que cada artículo de la respuesta contiene `title`, `url` y `date`. Si NYT renombra o anida distinto algún campo, el test falla y se entera el dev.
 - `test_search_articles_invalid_topic` — topic improbable (`"nonexistingtopicabcde"`) que actualmente no devuelve resultados; asserta `not result.success` y `"No articles found" in result.error`, conectando el contrato del cliente con el string que finalmente recibe el LLM. **Aceptado como potencialmente flaky** (algún día puede aparecer un artículo con ese topic); documentado en el propio archivo como warning.
 
+#### 2.4 — E1-13 · Tests de integración para Guardian (cierre de asimetría)
 
-AÑADIDO TAMBIEN TESTS DE INTEGRACIÓN PARA GUARDIAN API
-
+Como follow-up de E2-03 se replicó el patrón mixto unit + integration en `tests/test_news_guardian.py`, que hasta entonces solo tenía cobertura con mocks. Cierra la asimetría: ahora las dos integraciones de noticias (Guardian y NYT) tienen el mismo nivel de cobertura, incluyendo drift detection del contrato real con la API.
 
 ### Decisiones de diseño relevantes
 
@@ -282,3 +282,41 @@ AÑADIDO TAMBIEN TESTS DE INTEGRACIÓN PARA GUARDIAN API
 |---|---|
 | Schema común `{title, url, date}` entre Guardian y NYT | Permite que la futura tool MCP (E2-02) y el analizador NLP (E3) consuman datos sin ramificar lógica por fuente |
 | Hereda de `BaseAPI` igual que Guardian/Weather | Reutiliza la inyección automática de `api-key`, manejo uniforme de timeout y errores HTTP; cualquier mejora futura en `BaseAPI` aplica a las tres integraciones |
+
+---
+
+## Refactor transversal de coherencia (post-MVP)
+
+Tras cerrar E2, un repaso del proyecto destapó deuda e inconsistencias acumuladas entre épicas. Se abordaron en un PR de refactor (sin nueva funcionalidad de producto), agrupadas por tema.
+
+### Health check dinámico (+ NYT)
+
+`backend/core/health.py` tenía una función `_probe_*` por integración (`_probe_weather`, `_probe_guardian`) con estructura `try/except/raise_for_status` **idéntica** — repetición real. Se extrajo un único `_probe(url, params)` genérico y las integraciones se declaran como **datos** en un diccionario `PROBES`. Beneficio doble: añadir una API = una entrada (no más funciones), y **NYT entró de paso** (el health check ignoraba NYT pese a ser la tercera integración — incoherencia heredada de cuando se diseñó E1-08, antes de que NYT existiera). Los integration tests pasaron a `@pytest.mark.parametrize` sobre `PROBES`, generándose uno por integración automáticamente.
+
+Se distinguió esta repetición **real** de la **aparente** del registro de tools en `main.py`: ahí cada `*.register(mcp)` invoca módulos distintos sin patrón que extraer, así que el "register dinámico" se descartó (YAGNI) — explícito es más legible que un loop o autodescubrimiento mágico con `importlib`.
+
+### `topic` opcional + `days` configurable en clientes y tools
+
+Los clientes de noticias tenían `topic` obligatorio y rango temporal fijo (7 días hardcodeado). Se hizo `topic: str | None = None` (si se omite, devuelve lo más reciente sin filtrar) y `days: int = 7` configurable. Los params se construyen condicionalmente: la clave `q` solo se envía si hay `topic`.
+
+Decisión clave de **frontera de confianza**: al exponer `days` también en las tools (para que el usuario final pueda pedir rangos vía el LLM), `days` pasó de input interno a input **no confiable** del LLM. Por eso se validó **en la tool** con `pydantic.Field(ge=1, le=30)` — el rango aparece en el schema que ve el LLM y FastMCP rechaza valores fuera de rango antes de ejecutar. El cliente no revalida: la frontera ya filtró.
+
+### Rename por coherencia
+
+`get_news_this_week_call` (cliente Guardian) pasó a `search_articles`, idéntico a NYT — ambos clientes exponen ahora la misma interfaz, reforzando el schema común. La tool `get_news_this_week` pasó a `get_guardian_news`, simétrica con `get_nyt_news` y nombrando la fuente para que el LLM desambigüe mejor. El nombre viejo (`this_week`) además se había vuelto engañoso al hacer `days` configurable.
+
+### Limpieza
+
+- Eliminado `tests/simple_test.py` (código muerto de E0: importaba de `backend.api.the_guardian_api`, ruta que desapareció en la migración E1-03; pytest no lo recogía por no matchear `test_*.py`).
+- `tests/test_logging.py` y `tests/test_observability.py` leían `capsys` desde **stdout**, pero desde el fix de stderr de E1-08 los logs salen por **stderr**. Tests desincronizados (latentes hasta correrlos juntos): se corrigieron a `captured.err`. Ahora además verifican que los logs van a stderr, justo lo que el protocolo MCP stdio exige.
+- Start del servidor más descriptivo: el log `server.start` incluye ahora `log_level` y `log_format` (QoL para diagnóstico al arrancar).
+- Imports muertos (`Optional`, `ToolResult` sin usar), `f""` sin interpolación y TODOs vagos eliminados.
+
+### Decisiones de diseño relevantes
+
+| Decisión | Motivo |
+|---|---|
+| `_probe` genérico + dict `PROBES` (health) | Repetición real entre probes; añadir integración = una entrada de datos. Distinto del register de `main.py`, donde la repetición es aparente y explícito gana |
+| Validar `days` con `Field` en la tool, no en el cliente | La frontera de confianza está en la tool (input del LLM); validar una vez en el borde, el cliente confía en lo que recibe |
+| `topic` opcional construyendo params condicionalmente | Evita enviar `q=None` a la API; permite el caso "titulares recientes sin tema" |
+| Rename a `search_articles` / `get_guardian_news` | Interfaz idéntica entre clientes y tools simétricas que nombran la fuente; el nombre viejo era engañoso con `days` configurable |

--- a/backend/core/health.py
+++ b/backend/core/health.py
@@ -10,27 +10,27 @@ from backend.core.observability import log_tool_invocation
 
 PROBE_TIMEOUT = 5
 
+PROBES = {
+    "weather": {
+        "url": "https://api.weather.gov/",
+    },
+    "guardian": {
+        "url": "https://content.guardianapis.com/search",
+        "params": {"page-size": 1, "api-key": settings.guardian_api_key},
+    },
+    "nyt": {
+        "url": "https://api.nytimes.com/svc/search/v2/articlesearch.json",
+        "params": {"api-key": settings.nyt_api_key},
+    },
+}
 
-async def _probe_weather() -> dict:
-    """Probe weather.gov homepage (no auth required)."""
+
+async def _probe(url: str, params: dict | None = None) -> dict:
+    """Hace una petición ligera a una API y reporta si responde correctamente."""
     try:
         async with httpx.AsyncClient(timeout=PROBE_TIMEOUT) as client:
-            response = await client.get("https://api.weather.gov/")
-            response.raise_for_status()  # EVita que se trate 500 como respuesta aceptable
-        return {"reachable": True, "error": None}
-    except httpx.HTTPError as exc:
-        return {"reachable": False, "error": str(exc)}
-
-
-async def _probe_guardian() -> dict:
-    """Probe Guardian search endpoint with the configured API key."""
-    try:
-        async with httpx.AsyncClient(timeout=PROBE_TIMEOUT) as client:
-            response = await client.get(
-                "https://content.guardianapis.com/search",
-                params={"page-size": 1, "api-key": settings.guardian_api_key},
-            )
-            response.raise_for_status()
+            response = await client.get(url, params=params)
+            response.raise_for_status()  # Evita tratar 4xx/5xx como respuesta aceptable
         return {"reachable": True, "error": None}
     except httpx.HTTPError as exc:
         return {"reachable": False, "error": str(exc)}
@@ -46,7 +46,6 @@ def _aggregate_status(integrations: dict) -> Literal["ok", "degraded", "down"]:
     return "degraded"
 
 
-# TODO: Estático, pasar a dinamico si se incorporan más APIs.
 def register(mcp: FastMCP):
     @mcp.tool()
     @log_tool_invocation
@@ -56,11 +55,8 @@ def register(mcp: FastMCP):
         Returns:
             dict: Diccionario con estado, timestamp e integraciones
         """
-        weather, guardian = await asyncio.gather(
-            _probe_weather(),
-            _probe_guardian(),
-        )
-        integrations = {"weather": weather, "guardian": guardian}
+        results = await asyncio.gather(*(_probe(**cfg) for cfg in PROBES.values()))
+        integrations = dict(zip(PROBES, results))
         return {
             "status": _aggregate_status(integrations),
             "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/backend/integrations/news/client.py
+++ b/backend/integrations/news/client.py
@@ -1,6 +1,4 @@
 # Constants
-from typing import Optional
-
 from backend.core.base_api import BaseAPI
 from backend.core.models import ToolResult
 from datetime import date
@@ -17,13 +15,40 @@ class GuardianAPI(BaseAPI):
     API_KEY = settings.guardian_api_key  # Key ya validada
     API_KEY_PARAM = "api-key"
 
-    # TODO: Make topic optional
-    async def get_news_this_week_call(self, topic: str) -> ToolResult:
-        today = date.today()
-        new_date = today - timedelta(days=7)
-        params = {"q": topic, "from-date": new_date}
+    async def search_articles(
+        self, topic: str | None = None, days: int = 7
+    ) -> ToolResult:
+        """Buscar artículos de The Guardian.
 
-        endpoint = f"search"
+
+        Args:
+            topic (str, optional): keyword(s) de búsqueda libre. Si se omite, devuelve
+                los artículos más recientes sin filtrar por tema. Defaults to None.
+
+            days (int, optional): número de días hacia atrás desde hoy para acotar la
+                búsqueda. Defaults to 7.
+
+        Params enviados:
+            - q: <topic> CONDICIONAL!
+            - from-date:  YYYY-MM-DD
+            - sort: newest
+
+        Respuesta de llamada a endpoint (campos consumidos):
+            response.results[].webUrl    → url
+            response.results[].webTitle  → title
+            response.results[].webPublicationDate   → date
+
+        Returns:
+            ToolResult.ok([{title, url, date}, ...]) si hay artículos.
+            ToolResult.fail("No articles found") si results está vacío o ausente.
+        """
+        today = date.today()
+        new_date = today - timedelta(days=days)
+        params = {"from-date": new_date}
+        if topic:
+            params["q"] = topic
+
+        endpoint = "search"
         response = await self.make_request(endpoint, "get", params)
 
         if not response.success or not response.has_content():
@@ -44,18 +69,3 @@ class GuardianAPI(BaseAPI):
         ]
 
         return ToolResult.ok(articles)
-
-
-# Formato respuesta
-# {
-#     "response": {
-#         "results": [
-#             {
-#                 "webTitle": "...",
-#                 "webUrl": "...",
-#                 "webPublicationDate": "...",
-#             },
-#             ...
-#         ]
-#     }
-# }

--- a/backend/integrations/news/tool.py
+++ b/backend/integrations/news/tool.py
@@ -2,35 +2,38 @@
 News API for The Guardian
 """
 
-
-
 import json
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
 from backend.core.observability import log_tool_invocation
 from backend.integrations.news.client import GuardianAPI
-from backend.core.models import ToolResult
 
 
-#TODO: Implementar validador? Acaso hay campos cerrados
-#TODO: Esta tool podría inferir! (Preguntar que temas quiere)
 def register(mcp: FastMCP):
 
     api = GuardianAPI()
 
     @mcp.tool()
     @log_tool_invocation
-    async def get_news_this_week(topic: str) -> str:
-        
-        """Get latest news.
+    async def get_guardian_news(
+        topic: str | None = None,
+        days: int = Field(
+            default=7, ge=1, le=30, description="Días hacia atrás desde hoy (1-30)."
+        ),
+    ) -> str:
+        """Busca noticias de The Guardian. Se puede indicar de hace cuantos días buscar(por defecto, última semana)
 
         Args:
-            topic: the topic to search for
+            topic (str, Optional): keyword(s) sobre los que buscar artículos (ej. "AI", "elecciones", "climate change").
+            days (int, Optional): número de días que se incluyen en la busqueda desde hoy (Default = 7)
+
+        Returns:
+            JSON serializado con lista de artículos {title, url, date}, o un mensaje de error
+            si no hay resultados o la API falla
         """
-        response = await api.get_news_this_week_call(topic)
+        response = await api.search_articles(topic, days)
         if not response.has_content():
             return response.error or "Error fetching news"
         return json.dumps(response.data)
-        
-        

--- a/backend/integrations/nyt/client.py
+++ b/backend/integrations/nyt/client.py
@@ -14,19 +14,25 @@ class NYTAPI(BaseAPI):
     API_KEY = settings.nyt_api_key  # Key ya validada
     API_KEY_PARAM = "api-key"
 
-    async def search_articles(self, topic: str) -> ToolResult:
-        """Buscar artículos del NYT de la última semana por topic.
+    async def search_articles(
+        self, topic: str | None = None, days: int = 7
+    ) -> ToolResult:
+        """Buscar artículos del NYT.
 
 
         Llama a Article Search API (https://developer.nytimes.com/docs/articlesearch-product/1/overview).
 
 
         Args:
-            topic (str): keyword(s) de búsqueda libre (param `q`).
+            topic (str, optional): keyword(s) de búsqueda libre. Si se omite, devuelve
+                los artículos más recientes sin filtrar por tema. Defaults to None.
+
+            days (int, optional): número de días hacia atrás desde hoy para acotar la
+                búsqueda. Defaults to 7.
 
         Params enviados:
-            - q: <topic>
-            - begin_date: YYYYMMDD (hoy menos 7 días) #TODO: Configurar fecha dinámica (dejar semana por defecto)
+            - q: <topic> CONDICIONAL!
+            - begin_date: YYYYMMDD
             - sort: newest
 
         Respuesta de llamada a endpoint (campos consumidos):
@@ -39,8 +45,10 @@ class NYTAPI(BaseAPI):
             ToolResult.fail("No articles found") si docs está vacío o ausente.
         """
         today = date.today()
-        new_date = (today - timedelta(days=7)).strftime("%Y%m%d")  # Formato YYYYMMDD
-        params = {"q": topic, "begin_date": new_date, "sort": "newest"}
+        new_date = (today - timedelta(days=days)).strftime("%Y%m%d")  # Formato YYYYMMDD
+        params = {"begin_date": new_date, "sort": "newest"}
+        if topic:
+            params["q"] = topic
 
         endpoint = "articlesearch.json"
         response = await self.make_request(endpoint, "get", params)
@@ -55,9 +63,8 @@ class NYTAPI(BaseAPI):
 
         articles = [
             {
-                "title": article.get("headline", {}).get(
-                    "main"
-                ),  # De nuevo, sin {}, el primer get devuelve none y ahí no se puede hacer get.
+                "title": article.get("headline", {}).get("main"),
+                # De nuevo, sin {}, el primer get devuelve none y ahí no se puede hacer get.
                 "url": article.get("web_url"),
                 "date": article.get("pub_date"),
             }
@@ -65,19 +72,3 @@ class NYTAPI(BaseAPI):
         ]
 
         return ToolResult.ok(articles)
-
-
-# {
-#   "response": {
-#     "docs": [
-#       {
-#         "web_url": "https://...",
-#         "headline": {"main": "Title"},
-#         "pub_date": "2026-05-28T10:30:00+0000",
-#         "section_name": "Technology",
-#         "byline": {"original": "By X"}
-#       }
-#     ],
-#     "meta": {"hits": 1234}
-#   }
-# }

--- a/backend/integrations/nyt/tool.py
+++ b/backend/integrations/nyt/tool.py
@@ -5,10 +5,9 @@ News API for The New York Times (NYT)
 import json
 
 from mcp.server.fastmcp import FastMCP
-
+from pydantic import Field
 from backend.core.observability import log_tool_invocation
 from backend.integrations.nyt.client import NYTAPI
-from backend.core.models import ToolResult
 
 
 def register(mcp: FastMCP):
@@ -17,17 +16,23 @@ def register(mcp: FastMCP):
 
     @mcp.tool()
     @log_tool_invocation
-    async def get_nyt_news(topic: str) -> str:
-        """Buscar noticias del New York Times de la última semana sobre un tema concreto.
+    async def get_nyt_news(
+        topic: str | None = None,
+        days: int = Field(
+            default=7, ge=1, le=30, description="Días hacia atrás desde hoy (1-30)."
+        ),
+    ) -> str:
+        """Busca noticias del New York Times. Se puede indicar de hace cuantos días buscar(por defecto, última semana)
 
         Args:
-            topic (str): keyword(s) sobre los que buscar artículos (ej. "AI", "elecciones", "climate change").
+            topic (str, Optional): keyword(s) sobre los que buscar artículos (ej. "AI", "elecciones", "climate change").
+            days (int, Optional): número de días que se incluyen en la busqueda desde hoy (Default = 7)
 
         Returns:
             JSON serializado con lista de artículos {title, url, date}, o un mensaje de error
             si no hay resultados o la API falla
         """
-        response = await api.search_articles(topic)
+        response = await api.search_articles(topic, days)
         if not response.has_content():
             return response.error or "Error fetching news"
         return json.dumps(response.data)

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,10 +18,13 @@ mcp = FastMCP("tfg-mcp-server")
 
 # TODO: Implementar register dinámico
 
+# APIS
 weather_tool.register(mcp)
 news_tool.register(mcp)
-health.register(mcp)
 nyt_tool.register(mcp)
+
+# Health check
+health.register(mcp)
 
 
 # TODO: Start más descriptivo

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ Servidor MCP principal.
 from backend.core.logging import configure_logging
 import structlog
 from backend.core import health
-
+from backend.config.settings import settings
 
 from mcp.server.fastmcp import FastMCP
 
@@ -16,7 +16,6 @@ from backend.integrations.nyt import tool as nyt_tool
 log = structlog.get_logger()
 mcp = FastMCP("tfg-mcp-server")
 
-# TODO: Implementar register dinámico
 
 # APIS
 weather_tool.register(mcp)
@@ -27,11 +26,16 @@ nyt_tool.register(mcp)
 health.register(mcp)
 
 
-# TODO: Start más descriptivo
 def main():
     # Initialize and run the server
     configure_logging()
-    log.info("server.start", transport="stdio")
+    log.info(
+        "server.start",
+        server="tfg-mcp-server",
+        transport="stdio",
+        log_level=settings.log_level,
+        log_format=settings.log_format,
+    )
     mcp.run(transport="stdio")
 
 

--- a/tests/simple_test.py
+++ b/tests/simple_test.py
@@ -1,8 +1,0 @@
-import asyncio
-from backend.api.the_guardian_api import get_news_this_week_call
-
-async def test():
-    result = await get_news_this_week_call("technology")
-    print(result)
-
-asyncio.run(test())

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,12 +1,13 @@
 import pytest
 
-from backend.core.health import _aggregate_status, _probe_guardian, _probe_weather
+from backend.core.health import PROBES, _aggregate_status, _probe
 
 
 def test_aggregate_status_all_ok():
     integrations = {
         "weather": {"reachable": True, "error": None},
         "guardian": {"reachable": True, "error": None},
+        "nyt": {"reachable": True, "error": None},
     }
     assert _aggregate_status(integrations) == "ok"
 
@@ -15,6 +16,16 @@ def test_aggregate_status_one_fails():
     integrations = {
         "weather": {"reachable": True, "error": None},
         "guardian": {"reachable": False, "error": "boom"},
+        "nyt": {"reachable": True, "error": None},
+    }
+    assert _aggregate_status(integrations) == "degraded"
+
+
+def test_aggregate_status_some_fail():
+    integrations = {
+        "weather": {"reachable": False, "error": "boom"},
+        "guardian": {"reachable": False, "error": "boom"},
+        "nyt": {"reachable": True, "error": None},
     }
     assert _aggregate_status(integrations) == "degraded"
 
@@ -23,21 +34,15 @@ def test_aggregate_status_all_fail():
     integrations = {
         "weather": {"reachable": False, "error": "boom"},
         "guardian": {"reachable": False, "error": "boom"},
+        "nyt": {"reachable": False, "error": "boom"},
     }
     assert _aggregate_status(integrations) == "down"
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_probe_weather_reaches_api():
-    result = await _probe_weather()
-    assert result["reachable"] is True
-    assert result["error"] is None
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_probe_guardian_reaches_api():
-    result = await _probe_guardian()
+@pytest.mark.parametrize("name", list(PROBES))
+async def test_probe_reaches_api(name):
+    result = await _probe(**PROBES[name])
     assert result["reachable"] is True
     assert result["error"] is None

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -15,7 +15,7 @@ def test_logger_emits_structured_output_with_kwargs(monkeypatch, capsys):
     log.info("test", key="value")
 
     captured = capsys.readouterr()
-    payload = json.loads(captured.out)
+    payload = json.loads(captured.err)
 
     assert payload["event"] == "test"
     assert payload["key"] == "value"

--- a/tests/test_news_guardian.py
+++ b/tests/test_news_guardian.py
@@ -70,7 +70,7 @@ async def test_article_valid_response(fake_payload):
         )
 
         api = GuardianAPI()
-        result = await api.get_news_this_week_call("technology")
+        result = await api.search_articles("technology")
 
         assert result.success
         assert len(result.data) == 1
@@ -89,7 +89,7 @@ async def test_article_no_results():
         )
 
         api = GuardianAPI()
-        result = await api.get_news_this_week_call("asdfghjkl")
+        result = await api.search_articles("asdfghjkl")
 
         assert not result.success
         assert "No articles found" in result.error
@@ -103,7 +103,7 @@ async def test_article_missing_results_key():
         )
 
         api = GuardianAPI()
-        result = await api.get_news_this_week_call("anything")
+        result = await api.search_articles("anything")
 
         assert not result.success
         assert "No articles found" in result.error
@@ -114,7 +114,7 @@ async def test_article_missing_results_key():
 async def test_get_news_real_schema_contract():
 
     api = GuardianAPI()
-    result = await api.get_news_this_week_call("technology")
+    result = await api.search_articles("technology")
 
     assert result.success
     # print(result.data)
@@ -130,7 +130,7 @@ async def test_get_news_real_schema_contract():
 async def test_get_news_invalid_topic():
 
     api = GuardianAPI()
-    result = await api.get_news_this_week_call("nonexistingtopicabcde")
+    result = await api.search_articles("nonexistingtopicabcde")
     # print(result.data)
     assert not result.success
     assert result.error

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -20,7 +20,7 @@ async def test_log_tool_invocation_logs_success(monkeypatch, capsys):
     assert result == "alerts for CA"
 
     captured = capsys.readouterr()
-    payload = json.loads(captured.out)
+    payload = json.loads(captured.err)
 
     assert payload["event"] == "tool.invoke"
     assert payload["tool"] == "fake_tool"
@@ -46,7 +46,7 @@ async def test_log_tool_invocation_logs_failure(monkeypatch, capsys):
 
     captured = capsys.readouterr()
 
-    payload = json.loads(captured.out)
+    payload = json.loads(captured.err)
     # print(payload)
     assert payload["event"] == "tool.invoke.failed"
     assert payload["tool"] == "failing_tool"


### PR DESCRIPTION
## Contexto
Refactor sin nueva funcionalidad de producto. Tras cerrar E2, un repaso destapó deuda e inconsistencias acumuladas entre épicas. No vinculado a un issue (excepción puntual a la convención `Closes #N`).

## Cambios

### Health check dinámico (+ NYT)
- `_probe_weather`/`_probe_guardian` (estructura idéntica) consolidados en un único `_probe(url, params)` genérico.
- Integraciones declaradas como datos en un dict `PROBES`. Añadir una API = una entrada.
- **NYT entró al health check** — antes lo ignoraba pese a ser la tercera integración (incoherencia heredada de E1-08, anterior a NYT).
- Integration tests pasados a `@pytest.mark.parametrize` sobre `PROBES`.
- Descartado el "register dinámico" de `main.py`: repetición aparente (módulos distintos), explícito gana (YAGNI).

### `topic` opcional + `days` configurable
- Clientes y tools de Guardian y NYT: `topic: str | None = None` (sin tema → lo más reciente) y `days` configurable (default 7).
- Params construidos condicionalmente (`q` solo si hay `topic`).
- `days` expuesto en las tools → input del LLM → validado en la frontera con `pydantic.Field(ge=1, le=30)`. El cliente no revalida.

### Renames por coherencia
- Cliente Guardian: `get_news_this_week_call` → `search_articles` (interfaz idéntica a NYT).
- Tool Guardian: `get_news_this_week` → `get_guardian_news` (simétrica con `get_nyt_news`, nombra la fuente).

### Limpieza
- Eliminado `tests/simple_test.py` (código muerto de E0).
- `test_logging.py` / `test_observability.py`: corregido `capsys` de `.out` → `.err` (los logs van a stderr desde el fix de E1-08; tests desincronizados, latentes).
- `server.start` más descriptivo (incluye `log_level`, `log_format`).
- Imports muertos, `f""` sin interpolación y TODOs vagos eliminados.

## Tests
Todos los unit verdes (`pytest -m "not integration"`). Integration de health ahora cubre las 3 integraciones vía parametrize.

Documentado en README: sección "Refactor transversal de coherencia (post-MVP)".