### PR TITLE
chore(ci): añadir workflow de GitHub Actions para tests en PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    env: #Usar env para evadir fallo fail fast por falta de keys
+      GUARDIAN_API_KEY: dummy
+      NYT_API_KEY: dummy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4 # usando organización actions por defecto
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip #Evita instalación en cada run
+      - name: Instalando dependencias...
+      - run: pip install -r requirements.txt
+      - name: Corriendo tests...
+      - run: pytest -m "not integration"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
           python-version: "3.12"
           cache: pip #Evita instalación en cada run
       - name: Instalando dependencias...
-      - run: pip install -r requirements.txt
+        run: pip install -r requirements.txt
       - name: Corriendo tests...
-      - run: pytest -m "not integration"
+        run: pytest -m "not integration"

--- a/README.md
+++ b/README.md
@@ -320,3 +320,12 @@ Decisión clave de **frontera de confianza**: al exponer `days` también en las 
 | Validar `days` con `Field` en la tool, no en el cliente | La frontera de confianza está en la tool (input del LLM); validar una vez en el borde, el cliente confía en lo que recibe |
 | `topic` opcional construyendo params condicionalmente | Evita enviar `q=None` a la API; permite el caso "titulares recientes sin tema" |
 | Rename a `search_articles` / `get_guardian_news` | Interfaz idéntica entre clientes y tools simétricas que nombran la fuente; el nombre viejo era engañoso con `days` configurable |
+
+---
+
+## Integración continua
+
+### E1-14 · CI con GitHub Actions
+
+Se añadió `.github/workflows/ci.yml`, un workflow que ejecuta la suite de tests en cada `pull_request` hacia `main` (y en `push` a `main`). El job configura Python 3.12, instala `requirements.txt` y corre `pytest -m "not integration"`. Es la red de seguridad que da sentido al esfuerzo de testing acumulado: un cambio que rompa el código se detecta en el PR, antes del merge.
+


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml`: workflow que corre la suite de tests en cada PR a `main` (y push a `main`).
- Python 3.12, instala `requirements.txt`, ejecuta `pytest -m "not integration"`.
- API keys dummy (`GUARDIAN_API_KEY`, `NYT_API_KEY`) en el entorno del job: los unit tests usan respx (mocks), no necesitan keys reales, pero el fail-fast de pydantic-settings exige que las variables existan al importar. Los integration tests, que sí requieren keys reales + red, quedan excluidos por el marker.

## Verificación
Este mismo PR dispara el workflow (es `on: pull_request: branches: [main]`), así que el check de Actions valida el setup en un entorno limpio.

Closes #32