### PR TITLE
feat(nlp): cliente HuggingFace Inference API (E3-01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     env: #Usar env para evadir fallo fail fast por falta de keys
       GUARDIAN_API_KEY: dummy
       NYT_API_KEY: dummy
+      HF_TOKEN: dummy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4 # usando organización actions por defecto

--- a/README.md
+++ b/README.md
@@ -335,3 +335,31 @@ El paquete `backend/integrations/news/` contenía en realidad la integración de
 
 Fue el **primer PR validado por el CI de E1-14** antes del merge — estreno de la red de seguridad sobre un cambio mecánico pero con riesgo real de romper imports.
 
+## Épica 3 — NLP via HuggingFace (en planificación)
+
+> Estado: épica definida (issues #36–#39), implementación no iniciada. Esta sección recoge las decisiones de diseño previas a codificar.
+
+### Evaluación de modelos candidatos
+
+Para el análisis de los titulares en el servidor MCP se han evaluado las siguientes opciones de modelos ligeros de Hugging Face, priorizando un balance entre baja latencia y precisión. Son **candidatos**: el modelo definitivo de cada tarea se fija en su issue (E3-02 clickbait, E3-03 sentimiento).
+
+| Categoría | Modelo (Hugging Face) | Ventajas (Pros) | Desventajas (Contras) |
+| :--- | :--- | :--- | :--- |
+| **Sentimiento (Inglés)** | `cardiffnlp/twitter-roberta-base-sentiment-latest` | • Excelente precisión con texto corto.<br>• Entiende matices periodísticos y sarcasmo.<br>• Clasificación en 3 vías (Positivo, Negativo, Neutral). | • Ligeramente más pesado en RAM/VRAM.<br>• Inferencia marginalmente más lenta que modelos destilados. |
+| **Sentimiento (Inglés)** | `distilbert/distilbert-base-uncased-finetuned-sst-2-english` | • Inferencia ultra-rápida (ideal para latencia crítica).<br>• Consumo mínimo de recursos (modelo *distilled*). | • Solo clasificación binaria (Positivo/Negativo, omite neutralidad).<br>• Menor capacidad para captar ironías complejas. |
+| **Clickbait (Específico)** | `elozano/bert-base-cased-clickbait-news` | • Solución "Plug & Play" (enchufar y listo).<br>• Entrenado específicamente con titulares de noticias. | • Difícil de ajustar (no puedes redefinir qué es "clickbait").<br>• Puede fallar con el clickbait sutil o "elegante" (ej. NYT). |
+| **Clickbait (Zero-Shot)** | `cross-encoder/nli-deberta-v3-small` | • Control total: permite definir tus propias etiquetas (ej. `["factual", "sensationalism"]`).<br>• Excelente capacidad de razonamiento lógico e inferencia. | • Requiere afinar empíricamente las etiquetas de entrada.<br>• Inferencia ligeramente más computacional al evaluar múltiples etiquetas. |
+| **Traducción (EN ➔ ES)** | `Helsinki-NLP/opus-mt-en-es` | • Ejecución 100% local y privada (sin costes de API externa).<br>• Extremadamente ligero (~300MB).<br>• Traducciones rápidas de oraciones cortas. | • Calidad ligeramente inferior a APIs comerciales (DeepL/OpenAI) en textos muy literarios.<br>• Añade un paso extra de procesamiento al pipeline del MCP. |
+
+#### Backend de inferencia: pendiente (remoto vs local)
+
+Dónde se ejecutan estos modelos está **sin decidir**, a la espera de confirmar si hay infraestructura de cómputo disponible (p. ej. de la universidad):
+
+- **Remoto — HF Inference API:** disponible ya, sin GPU propia. HF asume el cómputo; a cambio se paga en latencia de red, *rate limits* y dependencia de un token (`HF_TOKEN`). Encaja con `BaseAPI` (HTTP) extendiéndola a `POST` + header `Authorization: Bearer`.
+- **Local — `transformers`:** descarga los pesos y usa RAM/VRAM propias, pero da privacidad total y sin *rate limits*. No usa `BaseAPI`.
+
+**Decisión para no bloquear la épica:** el cliente NLP se programa contra una **interfaz estable** (`classify(text, model) → {label, score}`) y el backend se elige con un setting `nlp_backend: Literal["remote", "local"]`. Así las tools (`detect_clickbait`, `analyze_sentiment`) y sus tests dependen del *contrato*, no de la implementación: pasar de remoto a local más adelante es escribir otra implementación detrás de la misma interfaz, sin tocar las tools. Se empieza por **remoto**, que no depende de infraestructura externa.
+
+> **Sobre la tabla:** las ventajas/inconvenientes de **RAM/VRAM, "100% local" y tamaño en disco** solo aplican al backend local; en remoto ese coste lo absorbe HF. Los modelos son los mismos en ambos casos.
+
+> **Alcance:** la **traducción EN→ES** (`Helsinki-NLP/opus-mt-en-es`) es una capacidad candidata adicional, aún no comprometida en el MVP (las 2 tools núcleo son clickbait y sentimiento).

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     log_format: Literal["console", "json"] = "console"
     guardian_api_key: str  # PS mapea automáticamente
     nyt_api_key: str
+    hf_token: str
 
 
 settings = Settings()  # type: ignore #Activa la validación al importar

--- a/backend/core/base_api.py
+++ b/backend/core/base_api.py
@@ -1,6 +1,3 @@
-
-
-
 import httpx
 
 from backend.core.models import ToolResult
@@ -11,35 +8,54 @@ class BaseAPI:
     API_KEY: str | None = None
     TIMEOUT: float = 30.0
     API_KEY_PARAM: str = "api-key"
-    
-
 
     async def make_request(
-    self,
-    endpoint: str,
-    method: str,
-    params : dict | None = None
+        self,
+        endpoint: str,
+        method: str,
+        params: dict | None = None,
+        json: dict | None = None,  # Para llamadas HF
     ) -> ToolResult:
         """Make a request to the  API with proper error handling."""
-        
+
         # Quizás tambíen sea condicional
         headers = {"Accept": "application/json"}
 
-        key_param = {self.API_KEY_PARAM: self.API_KEY} if self.API_KEY else {}
-        params = key_param | (params or {})
-            
+        params = params or {}
+        self._apply_auth(headers, params)
+
         url = f"{self.BASE_URL}{endpoint}"
-        
+
         async with httpx.AsyncClient() as client:
             try:
                 if method.upper() == "GET":
-                    response = await client.get(url, headers=headers, params=params, timeout=self.TIMEOUT)
+                    response = await client.get(
+                        url, headers=headers, params=params, timeout=self.TIMEOUT
+                    )
+                    response.raise_for_status()
+                    return ToolResult.ok(response.json())
+                elif method.upper() == "POST":
+                    response = await client.post(
+                        url,
+                        headers=headers,
+                        params=params,
+                        timeout=self.TIMEOUT,
+                        json=json,
+                    )
                     response.raise_for_status()
                     return ToolResult.ok(response.json())
                 return ToolResult.fail(f"Unsupported HTTP method: {method}")
             except httpx.TimeoutException:
                 return ToolResult.fail("Request timed out.")
             except httpx.HTTPStatusError as e:
-                return ToolResult.fail(f"HTTP error: {e.response.status_code} - {e.response.text}")
+                return ToolResult.fail(
+                    f"HTTP error: {e.response.status_code} - {e.response.text}"
+                )
             except Exception as e:
                 return ToolResult.fail(f"An error occurred: {str(e)}")
+
+    # Luego reescribirmos en otra clase que herede de Base API y tenemos POLIMORFISMO!
+
+    def _apply_auth(self, headers: dict, params: dict) -> None:
+        if self.API_KEY:
+            params[self.API_KEY_PARAM] = self.API_KEY

--- a/backend/integrations/nlp/client.py
+++ b/backend/integrations/nlp/client.py
@@ -11,6 +11,13 @@ class HFClient(BaseAPI):
         headers["Authorization"] = f"Bearer {self.API_KEY}"
 
     async def classify(self, text: str, model: str) -> ToolResult:
-        return await self.make_request(
+        result = await self.make_request(
             endpoint=model, method="POST", json={"inputs": text}
         )
+
+        if not result.success:
+            return result
+        try:
+            return ToolResult.ok(result.data[0][0])
+        except (IndexError, KeyError, TypeError):
+            return ToolResult.fail(f"Respuesta inesperada de HF: {result.data}")

--- a/backend/integrations/nlp/client.py
+++ b/backend/integrations/nlp/client.py
@@ -1,0 +1,16 @@
+from backend.config.settings import settings
+from backend.core.base_api import BaseAPI
+from backend.core.models import ToolResult
+
+
+class HFClient(BaseAPI):
+    BASE_URL = "https://router.huggingface.co/hf-inference/models/"
+    API_KEY = settings.hf_token
+
+    def _apply_auth(self, headers, params):
+        headers["Authorization"] = f"Bearer {self.API_KEY}"
+
+    async def classify(self, text: str, model: str) -> ToolResult:
+        return await self.make_request(
+            endpoint=model, method="POST", json={"inputs": text}
+        )


### PR DESCRIPTION
## E3-01 — Cliente HuggingFace Inference API

Closes #36

### Qué incluye
- **Settings:** nueva variable obligatoria `hf_token` (`HF_TOKEN` en `.env`), con fail-fast.
- **`BaseAPI`:** soporte para `POST` con body JSON y auth delegada en un método sobreescribible `_apply_auth` (por defecto api-key en query → Guardian/NYT intactos; polimorfismo en vez de `if` por tipo).
- **`HFClient(BaseAPI)`** (`backend/integrations/nlp/`): `classify(text, model)` hace POST al endpoint serverless y normaliza la respuesta a `{label, score}` (clase ganadora), con parseo defensivo ante formas inesperadas.
- **CI:** `HF_TOKEN: dummy` añadido al workflow (la nueva key obligatoria rompía el fail-fast en CI).
- **Docs:** planificación de la Épica 3 en el README (evaluación de modelos candidatos + decisión de backend remoto/local).

### Notas
- Endpoint corregido: `api-inference.huggingface.co` deprecado → `router.huggingface.co/hf-inference/models/{model}`.
- `nlp_backend` (selector remoto/local) **aplazado** (YAGNI) hasta que exista el backend local.
- Reintento ante 503 ("model loading") fuera de alcance; el handler genérico ya da un mensaje claro.
- Tests NLP (#39) y tools `detect_clickbait` (#37) / `analyze_sentiment` (#38) en sus issues.