### PR TITLE
feat(nlp): tool analyze_sentiment con cardiffnlp (E3-03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,3 +418,11 @@ Lo **único** viable para clickbait en remoto es **zero-shot vía `facebook/bart
 **Decisión:** zero-shot remoto con `bart-large-mnli` para el MVP. Definimos nosotros las etiquetas (`["clickbait", "factual"]`) y dejamos `elozano` (modelo dedicado, más preciso) como **mejora futura** en backend local, si llega la infra.
 
 **Implicación de código:** la respuesta zero-shot del router es una **lista plana** `[{label, score}, ...]` (ordenada), distinta del text-classification `[[...]]`. Por eso `classify` (que normaliza `data[0][0]`) **no sirve** tal cual: E3-02 añade una **variante `zero_shot(text, labels)`** que envía `parameters.candidate_labels` y normaliza `data[0]`.
+
+### E3-03 · Análisis de sentimiento — decisión
+
+Tool `analyze_sentiment(text)` que **reutiliza `classify`** (es *text-classification*, no necesita variante nueva) sobre `cardiffnlp/twitter-roberta-base-sentiment-latest`.
+
+**Por qué `cardiffnlp` (3 vías) y no `distilbert` (binario):** en titulares de noticias el **neutral** es frecuente (enunciados factuales); forzarlos a *positive/negative* distorsiona. cardiffnlp clasifica en `positive` / `neutral` / `negative`. Verificado: *"The committee will meet on Tuesday"* → `neutral` (0.94). Ambos están servidos en remoto; `distilbert` quedaría como opción si se priorizara latencia.
+
+> **Fiabilidad:** la inferencia remota da *timeouts* puntuales (HF); el cliente ya los reporta como `ToolResult.fail("Request timed out.")`. El reintento queda como mejora futura.

--- a/backend/integrations/nlp/tool.py
+++ b/backend/integrations/nlp/tool.py
@@ -40,3 +40,26 @@ def register(mcp: FastMCP):
         if not response.has_content():
             return response.error or "Error al analizar el titular"
         return json.dumps(response.data)
+
+    @mcp.tool()
+    @log_tool_invocation
+    async def analyze_sentiment(text: str) -> str:
+        """Analiza el sentimiento de un texto (p.ej. un titular de noticia).
+
+        Clasifica en tres clases: positive, neutral o negative (modelo en
+        inglés, afinado para texto corto). Útil para medir el tono.
+
+        Args:
+            text (str): texto a analizar (en inglés).
+
+        Returns:
+            JSON con la etiqueta ganadora y su confianza (0-1),
+            p.ej. {"label": "neutral", "score": 0.62}. Devuelve un mensaje
+            de error si la llamada al modelo falla.
+        """
+        response = await api.classify(
+            text, "cardiffnlp/twitter-roberta-base-sentiment-latest"
+        )
+        if not response.has_content():
+            return response.error or "Error al analizar el sentimiento"
+        return json.dumps(response.data)


### PR DESCRIPTION
## E3-03 — Análisis de sentimiento

Closes #38

### Qué incluye
- **Tool `analyze_sentiment(text)`** (`backend/integrations/nlp/tool.py`): clasifica el sentimiento de un texto en `positive` / `neutral` / `negative` vía `cardiffnlp/twitter-roberta-base-sentiment-latest`. **Reutiliza `HFClient.classify`** (text-classification, sin variante nueva). Modelo fijo dentro de la tool. Se añade al `register()` existente (sin tocar `main.py`).
- **Docs** (commit aparte): iteración E3-03 en el README con el motivo de elegir cardiffnlp (3 vías) frente a distilbert (binario).

### Decisiones
- **cardiffnlp (3 vías)** porque en titulares de noticias el `neutral` es frecuente; forzar pos/neg distorsiona. Verificado: *"The committee will meet on Tuesday"* → `neutral` (0.94).
- La inferencia remota da *timeouts* puntuales (HF); el cliente los reporta como `ToolResult.fail`. Reintento = mejora futura.

Tras este PR queda **#39 (tests NLP)** para cerrar la Épica 3.