### PR TITLE
test(nlp): tests para HFClient con respx (E3-04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,3 +426,14 @@ Tool `analyze_sentiment(text)` que **reutiliza `classify`** (es *text-classifica
 **Por qué `cardiffnlp` (3 vías) y no `distilbert` (binario):** en titulares de noticias el **neutral** es frecuente (enunciados factuales); forzarlos a *positive/negative* distorsiona. cardiffnlp clasifica en `positive` / `neutral` / `negative`. Verificado: *"The committee will meet on Tuesday"* → `neutral` (0.94). Ambos están servidos en remoto; `distilbert` quedaría como opción si se priorizara latencia.
 
 > **Fiabilidad:** la inferencia remota da *timeouts* puntuales (HF); el cliente ya los reporta como `ToolResult.fail("Request timed out.")`. El reintento queda como mejora futura.
+
+### E3-04 · Tests NLP
+
+`tests/test_nlp.py` con **respx** (mockeando el `POST` al router de HF), cubriendo las dos formas de respuesta:
+
+- **`classify`:** etiqueta ganadora `data[0][0]`; forma inesperada → `fail` (no excepción); HTTP `503` → propaga el error.
+- **`zero_shot`:** etiqueta ganadora `data[0]`, y que la petición incluye `parameters.candidate_labels`.
+- Que la petición lleva el header `Authorization: Bearer` (cubre `_apply_auth`).
+- **Integration** (marcados `@pytest.mark.integration`): llamadas reales a `classify` y `zero_shot` que validan el contrato `{label, score}`, fuera de la CI.
+
+Cierra la **Épica 3** (las 2 tools núcleo —clickbait y sentimiento— sobre el cliente HF, con tests).

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -1,0 +1,137 @@
+import json
+
+import pytest
+import respx  # Usamos en vez de htttp, ya que no hacemos llamadas de verdad, mockeamos
+from httpx import Response
+
+from backend.integrations.nlp.client import HFClient
+
+MODELS_URL = "https://router.huggingface.co/hf-inference/models/"
+
+
+# classify
+@pytest.mark.asyncio
+async def test_classify_returns_top_label():
+    model = "distilbert/distilbert-base-uncased-finetuned-sst-2-english"
+    payload = [
+        [
+            {"label": "POSITIVE", "score": 0.99},
+            {"label": "NEGATIVE", "score": 0.01},
+        ]
+    ]  # respuesta doble-anidada [[{label, score}]]
+    with respx.mock:
+        respx.post(f"{MODELS_URL}{model}").mock(
+            return_value=Response(200, json=payload)
+        )
+        result = await HFClient().classify("great movie", model)
+
+    assert result.success
+    assert result.data == {"label": "POSITIVE", "score": 0.99}
+
+
+@pytest.mark.asyncio
+async def test_classify_unexpected_shape_returns_fail():
+    model = "some/model"
+    with respx.mock:
+        respx.post(f"{MODELS_URL}{model}").mock(
+            return_value=Response(200, json={"unexpected": "shape"})
+        )
+        result = await HFClient().classify("text", model)
+
+    assert not result.success
+    assert result.error
+
+
+@pytest.mark.asyncio
+async def test_classify_http_error_propagates():
+    model = "some/model"
+    with respx.mock:
+        respx.post(f"{MODELS_URL}{model}").mock(
+            return_value=Response(503, text="Model is currently loading")
+        )
+        result = await HFClient().classify("text", model)
+
+    assert not result.success
+    assert "503" in result.error
+
+
+# zero_shot
+
+
+@pytest.mark.asyncio
+async def test_zero_shot_returns_top_label():
+    model = "facebook/bart-large-mnli"
+    payload = [
+        {"label": "clickbait", "score": 0.79},
+        {"label": "factual news", "score": 0.21},
+    ]
+    with respx.mock:
+        respx.post(f"{MODELS_URL}{model}").mock(
+            return_value=Response(200, json=payload)
+        )
+        result = await HFClient().zero_shot(
+            "headline", model, ["clickbait", "factual news"]
+        )
+
+    assert result.success
+    assert result.data == {"label": "clickbait", "score": 0.79}
+
+
+@pytest.mark.asyncio
+async def test_zero_shot_sends_candidate_labels():
+    model = "facebook/bart-large-mnli"
+    labels = ["clickbait", "factual news"]
+    with respx.mock:
+        route = respx.post(f"{MODELS_URL}{model}").mock(
+            return_value=Response(200, json=[{"label": "clickbait", "score": 0.9}])
+        )
+        await HFClient().zero_shot("headline", model, labels)
+
+    # El cuerpo de la petición debe incluir inputs + candidate_labels.
+    sent = json.loads(route.calls.last.request.content)
+    assert sent["inputs"] == "headline"
+    assert sent["parameters"]["candidate_labels"] == labels
+
+
+# auth
+
+
+@pytest.mark.asyncio
+async def test_request_sends_bearer_header():
+    model = "some/model"
+    with respx.mock:
+        route = respx.post(f"{MODELS_URL}{model}").mock(
+            return_value=Response(200, json=[[{"label": "X", "score": 1.0}]])
+        )
+        await HFClient().classify("t", model)
+
+    assert route.calls.last.request.headers["Authorization"].startswith("Bearer ")
+
+
+# Integration
+
+
+# No poner valores concretos ahora, ya haremos tests de valores, solo revisar que el fomrado del resultado es correcto
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_classify_real_contract():
+    result = await HFClient().classify(
+        "I love this", "cardiffnlp/twitter-roberta-base-sentiment-latest"
+    )
+    assert result.success
+    assert "label" in result.data
+    assert "score" in result.data
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_zero_shot_real_contract():
+    result = await HFClient().zero_shot(
+        "You will not believe what happened next",
+        "facebook/bart-large-mnli",
+        ["clickbait", "factual news"],
+    )
+    assert result.success
+    assert result.data["label"] in {"clickbait", "factual news"}


### PR DESCRIPTION
## E3-04 — Tests NLP

Closes #39

### Qué incluye
- `tests/test_nlp.py` con **respx** (mockeando el `POST` al router de HF):
  - `classify`: etiqueta ganadora `data[0][0]`; forma inesperada → `fail`; HTTP `503` → propaga.
  - `zero_shot`: etiqueta ganadora `data[0]`; la petición incluye `parameters.candidate_labels`.
  - header `Authorization: Bearer` presente (cubre `_apply_auth`).
  - 2 *integration tests* (marcados, fuera de CI) que validan el contrato `{label, score}` contra HF real.
- README: iteración E3-04 + cierre de la Épica 3.

Suite: **27 passed**, 9 deselected (integration).

Cierra la **Épica 3** (cliente HF + 2 tools núcleo —clickbait zero-shot y sentiment 3-vías— con tests).