### PR TITLE
feat(core): reintento ante timeout/503 en llamadas a HF (E4-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,3 +437,17 @@ Tool `analyze_sentiment(text)` que **reutiliza `classify`** (es *text-classifica
 - **Integration** (marcados `@pytest.mark.integration`): llamadas reales a `classify` y `zero_shot` que validan el contrato `{label, score}`, fuera de la CI.
 
 Cierra la **Épica 3** (las 2 tools núcleo —clickbait y sentimiento— sobre el cliente HF, con tests).
+
+## Épica 4 — Validación E2E del MVP
+
+> Smoke test E2E del MVP OK (2026-06-03): `health_check` → `get_nyt_news` → `detect_clickbait`/`analyze_sentiment`, encadenado por el protocolo MCP real. Titulares del NYT salen `factual` (sin sobre-marcar; el *listicle* fue el de menor confianza factual); sentiment 3-vías discrimina bien. Dos hallazgos → issues **#44** (escenarios/evidencias) y **#45** (fiabilidad).
+
+### E4-02 · Reintento ante fallos transitorios de HF
+
+El smoke test confirmó que la inferencia remota de HF falla de forma **transitoria** (~1 de cada 5 llamadas dio *timeout*; recurrente durante E3). Se añadió un **reintento** en `BaseAPI.make_request`:
+
+- **Opt-in por clase:** `MAX_RETRIES` (default `0` → Guardian/NYT no reintentan) y `RETRY_BACKOFF`. `HFClient` lo activa con `MAX_RETRIES = 3`.
+- **Solo transitorios:** `httpx.TimeoutException` y HTTP `503`; cualquier otro error falla al instante (reintentar no lo arregla).
+- **Tests (`respx`):** `503→200` y `timeout→200` (recupera al reintentar), y `503` perpetuo → agota reintentos (`MAX_RETRIES + 1` intentos). Usan `RETRY_BACKOFF = 0` para no esperar de verdad.
+
+Motivo: mejorar la fiabilidad del MVP frente a la *flakiness* del backend remoto, sin romper el contrato (sigue devolviendo `ToolResult.fail` si se agotan los reintentos).

--- a/backend/core/base_api.py
+++ b/backend/core/base_api.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import httpx
 
 from backend.core.models import ToolResult
@@ -9,6 +11,10 @@ class BaseAPI:
     TIMEOUT: float = 30.0
     API_KEY_PARAM: str = "api-key"
 
+    # Variables para reintento
+    MAX_RETRIES: int = 0  # Guardian/NYT NO reintentan
+    RETRY_BACKOFF: float = 1.0  # segundos
+
     async def make_request(
         self,
         endpoint: str,
@@ -18,7 +24,6 @@ class BaseAPI:
     ) -> ToolResult:
         """Make a request to the  API with proper error handling."""
 
-        # Quizás tambíen sea condicional
         headers = {"Accept": "application/json"}
 
         params = params or {}
@@ -27,32 +32,39 @@ class BaseAPI:
         url = f"{self.BASE_URL}{endpoint}"
 
         async with httpx.AsyncClient() as client:
-            try:
-                if method.upper() == "GET":
-                    response = await client.get(
-                        url, headers=headers, params=params, timeout=self.TIMEOUT
+            for attempt in range(self.MAX_RETRIES + 1):
+                try:
+                    if method.upper() == "GET":
+                        response = await client.get(
+                            url, headers=headers, params=params, timeout=self.TIMEOUT
+                        )
+                        response.raise_for_status()
+                        return ToolResult.ok(response.json())
+                    elif method.upper() == "POST":
+                        response = await client.post(
+                            url,
+                            headers=headers,
+                            params=params,
+                            timeout=self.TIMEOUT,
+                            json=json,
+                        )
+                        response.raise_for_status()
+                        return ToolResult.ok(response.json())
+                    return ToolResult.fail(f"Unsupported HTTP method: {method}")
+                except httpx.TimeoutException:
+                    if attempt < self.MAX_RETRIES:
+                        await asyncio.sleep(self.RETRY_BACKOFF)
+                        continue
+                    return ToolResult.fail("Request timed out.")
+                except httpx.HTTPStatusError as e:
+                    if e.response.status_code == 503 and attempt < self.MAX_RETRIES:
+                        await asyncio.sleep(self.RETRY_BACKOFF)
+                        continue
+                    return ToolResult.fail(
+                        f"HTTP error: {e.response.status_code} - {e.response.text}"
                     )
-                    response.raise_for_status()
-                    return ToolResult.ok(response.json())
-                elif method.upper() == "POST":
-                    response = await client.post(
-                        url,
-                        headers=headers,
-                        params=params,
-                        timeout=self.TIMEOUT,
-                        json=json,
-                    )
-                    response.raise_for_status()
-                    return ToolResult.ok(response.json())
-                return ToolResult.fail(f"Unsupported HTTP method: {method}")
-            except httpx.TimeoutException:
-                return ToolResult.fail("Request timed out.")
-            except httpx.HTTPStatusError as e:
-                return ToolResult.fail(
-                    f"HTTP error: {e.response.status_code} - {e.response.text}"
-                )
-            except Exception as e:
-                return ToolResult.fail(f"An error occurred: {str(e)}")
+                except Exception as e:
+                    return ToolResult.fail(f"An error occurred: {str(e)}")
 
     # Luego reescribirmos en otra clase que herede de Base API y tenemos POLIMORFISMO!
 

--- a/backend/integrations/nlp/client.py
+++ b/backend/integrations/nlp/client.py
@@ -6,6 +6,7 @@ from backend.core.models import ToolResult
 class HFClient(BaseAPI):
     BASE_URL = "https://router.huggingface.co/hf-inference/models/"
     API_KEY = settings.hf_token
+    MAX_RETRIES = 3
 
     def _apply_auth(self, headers, params):
         headers["Authorization"] = f"Bearer {self.API_KEY}"

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 import respx  # Usamos en vez de htttp, ya que no hacemos llamadas de verdad, mockeamos
-from httpx import Response
+from httpx import Response, TimeoutException
 
 from backend.integrations.nlp.client import HFClient
 
@@ -46,13 +46,16 @@ async def test_classify_unexpected_shape_returns_fail():
 async def test_classify_http_error_propagates():
     model = "some/model"
     with respx.mock:
-        respx.post(f"{MODELS_URL}{model}").mock(
-            return_value=Response(503, text="Model is currently loading")
+        route = respx.post(f"{MODELS_URL}{model}").mock(
+            return_value=Response(
+                500, text="Internal Server Error"
+            )  # 500 para no propagar
         )
         result = await HFClient().classify("text", model)
 
     assert not result.success
-    assert "503" in result.error
+    assert "500" in result.error
+    assert route.call_count == 1  # Solo se llama una vez (usar count en reintentos)
 
 
 # zero_shot
@@ -106,6 +109,67 @@ async def test_request_sends_bearer_header():
         await HFClient().classify("t", model)
 
     assert route.calls.last.request.headers["Authorization"].startswith("Bearer ")
+
+
+# retry: timeout y 503 se reintentan
+# RETRY_BACKOFF = 0 en la instancia solo `para tests`
+
+
+@pytest.mark.asyncio
+async def test_make_request_retries_on_503_then_succeeds():
+    # 503 luego 200
+    model = "facebook/bart-large-mnli"
+    with respx.mock:
+        route = respx.post(f"{MODELS_URL}{model}").mock(
+            side_effect=[  # Si pasa lista son side_effects, recorre en orden
+                Response(503, text="Model is currently loading"),
+                Response(200, json=[{"label": "clickbait", "score": 0.9}]),
+            ]
+        )
+        client = HFClient()
+        client.RETRY_BACKOFF = 0
+        result = await client.zero_shot("h", model, ["clickbait", "factual news"])
+
+    assert result.success
+    assert result.data == {"label": "clickbait", "score": 0.9}
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_make_request_retries_on_timeout_then_succeeds():
+    # Reintentos tambien para Timeouts
+    model = "some/model"
+    with respx.mock:
+        route = respx.post(f"{MODELS_URL}{model}").mock(
+            side_effect=[
+                TimeoutException("boom"),
+                Response(200, json=[[{"label": "OK", "score": 1.0}]]),
+            ]
+        )
+        client = HFClient()
+        client.RETRY_BACKOFF = 0
+        result = await client.classify("t", model)
+
+    assert result.success
+    assert result.data == {"label": "OK", "score": 1.0}
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_make_request_gives_up_after_max_retries():
+    # 503 pero agota intentos.
+    model = "some/model"
+    with respx.mock:
+        route = respx.post(f"{MODELS_URL}{model}").mock(
+            return_value=Response(503, text="Model is currently loading")
+        )
+        client = HFClient()
+        client.RETRY_BACKOFF = 0
+        result = await client.classify("t", model)
+
+    assert not result.success
+    assert "503" in result.error
+    assert route.call_count == client.MAX_RETRIES + 1
 
 
 # Integration


### PR DESCRIPTION
## E4-02 — Reintento ante fallos transitorios de HF

Closes #45

### Contexto
El smoke test E2E del MVP (2026-06-03) confirmó que la inferencia remota de HF falla de forma **transitoria**: ~1 de cada 5 llamadas dio *timeout* (recurrente durante E3).

### Qué incluye
- **`BaseAPI.make_request`** — bucle de reintento **opt-in por clase**:
  - `MAX_RETRIES` (default `0` → Guardian/NYT no reintentan) y `RETRY_BACKOFF`; `HFClient` lo activa con `MAX_RETRIES = 3`.
  - Solo reintenta **transitorios**: `httpx.TimeoutException` y HTTP `503`. Cualquier otro error falla al instante.
  - Contrato intacto: sigue devolviendo `ToolResult.fail` si se agotan los reintentos.
- **Tests (`respx`)**: `503→200` y `timeout→200` (recupera al reintentar), `503` perpetuo → agota (`MAX_RETRIES+1` intentos), y `500` → falla inmediato. Usan `RETRY_BACKOFF = 0` para no esperar.
- **README**: arranque de la Épica 4 + iteración E4-02.

Suite: **30 passed**, 9 deselected.