### PR TITLE
feat(integrations): NYT sort, Guardian por tag y topic con Field (E4-04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,3 +451,15 @@ El smoke test confirmó que la inferencia remota de HF falla de forma **transito
 - **Tests (`respx`):** `503→200` y `timeout→200` (recupera al reintentar), y `503` perpetuo → agota reintentos (`MAX_RETRIES + 1` intentos). Usan `RETRY_BACKOFF = 0` para no esperar de verdad.
 
 Motivo: mejorar la fiabilidad del MVP frente a la *flakiness* del backend remoto, sin romper el contrato (sigue devolviendo `ToolResult.fail` si se agotan los reintentos).
+
+### E4-04 · Ajustes de tools tras validación E2E
+
+La validación destapó tres problemas al buscar por tema (p.ej. "artificial intelligence"), todos corregidos:
+
+- **NYT — relevancia:** el cliente forzaba `sort=newest`, que hacía que `q` **no filtrara** (devolvía lo más nuevo sin relación). Ahora `sort = "relevance" if topic else "newest"`. *(Verificado: devuelve IA limpia.)*
+- **Guardian — precisión:** el `q` libre matchea palabras sueltas ("intelligence" arrastraba espías/música). Ahora filtra por **tag** curado: `/tags?q=<topic>` → top tag → `/search?tag=<id>`, con **fallback** a `q` si no hay tag.
+- **Usabilidad del LLM:** `topic` no tenía `description` en el schema (solo en el docstring), así que el LLM a veces inventaba parámetros (`query`). Ahora usa `Field(description=…)` en ambas tools.
+
+**Lección de la validación:** fueron un bug de **comportamiento de API externa** (NYT `sort`) y uno de **precisión de búsqueda** (Guardian) que un test **mockeado no destapa** — solo la llamada real. La validación garantiza *forma*, no *corrección*; por eso aquí pesa la verificación empírica/integración.
+
+Tests (`respx`): NYT manda `sort=relevance`/`newest` según haya topic; Guardian usa `tag` o cae a `q`.

--- a/backend/integrations/guardian/client.py
+++ b/backend/integrations/guardian/client.py
@@ -22,16 +22,17 @@ class GuardianAPI(BaseAPI):
 
 
         Args:
-            topic (str, optional): keyword(s) de búsqueda libre. Si se omite, devuelve
-                los artículos más recientes sin filtrar por tema. Defaults to None.
+            topic (str, optional): tema a buscar. Se resuelve a un tag de The Guardian
+                (vía /tags) para filtrar con precisión; si no hay tag, se usa como
+                búsqueda libre `q` (fallback). Si se omite, devuelve lo más reciente.
+                Defaults to None.
 
             days (int, optional): número de días hacia atrás desde hoy para acotar la
                 búsqueda. Defaults to 7.
 
         Params enviados:
-            - q: <topic> CONDICIONAL!
-            - from-date:  YYYY-MM-DD
-            - sort: newest
+            - from-date: YYYY-MM-DD
+            - tag: <id> si /tags encuentra uno para `topic`; si no, q: <topic> (fallback)
 
         Respuesta de llamada a endpoint (campos consumidos):
             response.results[].webUrl    → url
@@ -45,8 +46,12 @@ class GuardianAPI(BaseAPI):
         today = date.today()
         new_date = today - timedelta(days=days)
         params = {"from-date": new_date}
-        if topic:
-            params["q"] = topic
+        if topic:  # Usa buscador de tags
+            tag_id = await self._find_tag(topic)
+            if tag_id:
+                params["tag"] = tag_id
+            else:
+                params["q"] = topic  # fallback
 
         endpoint = "search"
         response = await self.make_request(endpoint, "get", params)
@@ -69,3 +74,11 @@ class GuardianAPI(BaseAPI):
         ]
 
         return ToolResult.ok(articles)
+
+    # Busqueda por tags especifica de The guardian
+    async def _find_tag(self, topic: str) -> str | None:
+        result = await self.make_request("tags", "get", {"q": topic, "page-size": 10})
+        if not result.success:
+            return None
+        tags = result.data.get("response", {}).get("results", [])
+        return tags[0].get("id") if tags else None

--- a/backend/integrations/guardian/tool.py
+++ b/backend/integrations/guardian/tool.py
@@ -18,7 +18,10 @@ def register(mcp: FastMCP):
     @mcp.tool()
     @log_tool_invocation
     async def get_guardian_news(
-        topic: str | None = None,
+        topic: str | None = Field(
+            default=None,
+            description="Palabra(s) clave del tema a buscar, en inglés (ej. 'artificial intelligence', 'climate change'). Si se omite, devuelve las noticias más recientes.",
+        ),
         days: int = Field(
             default=7, ge=1, le=30, description="Días hacia atrás desde hoy (1-30)."
         ),

--- a/backend/integrations/nyt/client.py
+++ b/backend/integrations/nyt/client.py
@@ -46,7 +46,7 @@ class NYTAPI(BaseAPI):
         """
         today = date.today()
         new_date = (today - timedelta(days=days)).strftime("%Y%m%d")  # Formato YYYYMMDD
-        params = {"begin_date": new_date, "sort": "newest"}
+        params = {"begin_date": new_date, "sort": "relevance" if topic else "newest"}
         if topic:
             params["q"] = topic
 

--- a/backend/integrations/nyt/tool.py
+++ b/backend/integrations/nyt/tool.py
@@ -17,7 +17,10 @@ def register(mcp: FastMCP):
     @mcp.tool()
     @log_tool_invocation
     async def get_nyt_news(
-        topic: str | None = None,
+        topic: str | None = Field(
+            default=None,
+            description="Palabra(s) clave del tema a buscar, en inglés (ej. 'artificial intelligence', 'climate change'). Si se omite, devuelve las noticias más recientes.",
+        ),
         days: int = Field(
             default=7, ge=1, le=30, description="Días hacia atrás desde hoy (1-30)."
         ),

--- a/tests/test_guardian.py
+++ b/tests/test_guardian.py
@@ -5,7 +5,17 @@ import respx
 import pytest
 from httpx import Response
 
-# TODO: Better tests organizations and integration tests.
+TAGS_URL = "https://content.guardianapis.com/tags"
+SEARCH_URL = "https://content.guardianapis.com/search"
+
+
+def _mock_tags(tag_id="technology/test"):
+    """Mockea /tags: devuelve un tag (o ninguno si tag_id=None), para controlar
+    la rama tag vs fallback a `q` de search_articles."""
+    results = [{"id": tag_id}] if tag_id else []
+    respx.get(TAGS_URL).mock(
+        return_value=Response(200, json={"response": {"results": results}})
+    )
 
 
 @pytest.fixture
@@ -65,6 +75,7 @@ def fake_forecast_periods():
 async def test_article_valid_response(fake_payload):
 
     with respx.mock:
+        _mock_tags()
         respx.get("https://content.guardianapis.com/search").mock(
             return_value=Response(200, json={"response": {"results": [fake_payload]}})
         )
@@ -84,6 +95,7 @@ async def test_article_valid_response(fake_payload):
 @pytest.mark.asyncio
 async def test_article_no_results():
     with respx.mock:
+        _mock_tags()
         respx.get("https://content.guardianapis.com/search").mock(
             return_value=Response(200, json={"response": {"results": []}})
         )
@@ -98,6 +110,7 @@ async def test_article_no_results():
 @pytest.mark.asyncio
 async def test_article_missing_results_key():
     with respx.mock:
+        _mock_tags()
         respx.get("https://content.guardianapis.com/search").mock(
             return_value=Response(200, json={"response": {}})
         )
@@ -107,6 +120,40 @@ async def test_article_missing_results_key():
 
         assert not result.success
         assert "No articles found" in result.error
+
+
+@pytest.mark.asyncio
+async def test_topic_uses_tag(fake_payload):
+    # Con tag, búsqueda usa tag=<id> y NO q.
+    with respx.mock:
+        _mock_tags("technology/artificialintelligenceai")
+        search = respx.get(SEARCH_URL).mock(
+            return_value=Response(200, json={"response": {"results": [fake_payload]}})
+        )
+        api = GuardianAPI()
+        result = await api.search_articles("artificial intelligence")
+
+    assert result.success
+    sent = search.calls.last.request.url.params
+    assert sent["tag"] == "technology/artificialintelligenceai"
+    assert "q" not in sent
+
+
+@pytest.mark.asyncio
+async def test_no_tag_falls_back_to_q(fake_payload):
+    # Sin tag, fallback q=<topic>.
+    with respx.mock:
+        _mock_tags(None)
+        search = respx.get(SEARCH_URL).mock(
+            return_value=Response(200, json={"response": {"results": [fake_payload]}})
+        )
+        api = GuardianAPI()
+        result = await api.search_articles("tema-raro")
+
+    assert result.success
+    sent = search.calls.last.request.url.params
+    assert sent["q"] == "tema-raro"
+    assert "tag" not in sent
 
 
 @pytest.mark.integration

--- a/tests/test_news_nyt.py
+++ b/tests/test_news_nyt.py
@@ -75,6 +75,36 @@ async def test_search_articles_http_error():
         assert "No articles found" in result.error
 
 
+@pytest.mark.asyncio
+async def test_topic_uses_relevance_sort(fake_payload):
+    # Con topic, sort=relevance (el fix del bug) + q=<topic>.
+    with respx.mock:
+        route = respx.get(f"{NYTAPI.BASE_URL}articlesearch.json").mock(
+            return_value=Response(200, json={"response": {"docs": [fake_payload]}})
+        )
+        api = NYTAPI()
+        await api.search_articles("artificial intelligence")
+
+    sent = route.calls.last.request.url.params
+    assert sent["sort"] == "relevance"
+    assert sent["q"] == "artificial intelligence"
+
+
+@pytest.mark.asyncio
+async def test_no_topic_uses_newest_sort(fake_payload):
+    # Sin topic, sort=newest (lo más reciente) y sin q.
+    with respx.mock:
+        route = respx.get(f"{NYTAPI.BASE_URL}articlesearch.json").mock(
+            return_value=Response(200, json={"response": {"docs": [fake_payload]}})
+        )
+        api = NYTAPI()
+        await api.search_articles()
+
+    sent = route.calls.last.request.url.params
+    assert sent["sort"] == "newest"
+    assert "q" not in sent
+
+
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_search_articles_valid_use():


### PR DESCRIPTION
## E4-04 — Ajustes de tools tras validación E2E

Closes #47

La validación E2E destapó 3 problemas al buscar por tema (p.ej. "artificial intelligence"); todos corregidos.

### Cambios
- **NYT — `sort=relevance`** cuando hay topic (antes `sort=newest` hacía que `q` **no filtrara** → devolvía noticia general). `nyt/client.py`.
- **Guardian — búsqueda por `tag`**: `/tags?q=topic` → top tag → `/search?tag=…`, con **fallback** a `q`. Quita el ruido de palabra suelta ("intelligence" = espías/música). `guardian/client.py`.
- **`Field(description=…)` en `topic`** (NYT + Guardian) → el LLM deja de inventarse `query`.
- Docstring de Guardian corregido.

### Tests (`respx`)
- NYT: manda `sort=relevance`/`newest` según topic.
- Guardian: usa `tag` o cae a `q`; los existentes ahora son deterministas (mockean `/tags`).
- Suite: **34 passed**.

### Verificación empírica
Llamadas reales: NYT → IA limpia; Guardian tag → contenido curado de IA, sin falsos positivos de palabra suelta. *(Un test mockeado no destapaba esto — solo la llamada real.)*