### PR TITLE
feat(integrations): get_*_news devuelven el teaser/content (E5-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,3 +531,14 @@ Desacopla el NLP del proveedor concreto para poder ejecutarlo **en local** (con 
 **Motivo:** mitigar el riesgo de fiabilidad/disponibilidad del backend remoto (ver Épicas 3 y 4) y ganar control total del modelo — precondición de **R3.7** (incoherencia) y del **fine-tuning** local. La inferencia local es viable en el hardware de desarrollo (GTX 1650 SUPER 4 GB / CPU Ryzen 5).
 
 **Dependencias y tests:** `transformers` (con sus dependencias) está en `requirements.txt`. **`torch`** es dependiente del hardware (CPU o CUDA), así que **no se fija** en `requirements.txt` — se instala aparte para usar el backend local (CI y los tests **no** lo necesitan, porque mockean el `pipeline`). Cobertura: `LocalNLPClient` (normalización de `classify`/`zero_shot`, manejo de errores, cache por `(task, model)`) y la factoría — todo sin descargar modelos ni tocar la red.
+
+### E5-02 · Enriquecer la salida de noticias con el contenido
+
+`get_guardian_news` y `get_nyt_news` ahora devuelven un campo **`content`** (el teaser/resumen del artículo) además de `title`/`url`/`date` — **prerequisito de la detección por incoherencia (E5-03)**, que compara titular ↔ contenido.
+
+- **Guardian:** el teaser **no viene por defecto** → se pide con el param `show-fields=trailText` y se extrae de `fields.trailText`.
+- **NYT:** el `abstract` **ya viene** en la respuesta → solo se extrae. Bonus: también se devuelve `print_headline` (titular impreso), que habilita la variante **titular web vs. impreso** de R3.7.
+- **Acceso defensivo:** el teaser está anidado (`fields.trailText`, `headline.print_headline`) → patrón `.get("...", {}).get(...)` para no petar si falta.
+- **Tests (`respx`):** los `fake_payload` incluyen los campos fuente y se verifica que el cliente los mapea a `content` (y `print_headline` en NYT).
+
+**Motivo:** sin el contenido no hay con qué comparar el titular; E5-02 es el **habilitador** de E5-03.

--- a/backend/integrations/guardian/client.py
+++ b/backend/integrations/guardian/client.py
@@ -41,14 +41,15 @@ class GuardianAPI(BaseAPI):
             response.results[].webUrl    → url
             response.results[].webTitle  → title
             response.results[].webPublicationDate   → date
+            response.results[].fields.trailText   → content
 
         Returns:
-            ToolResult.ok([{title, url, date}, ...]) si hay artículos.
+            ToolResult.ok([{title, url, date, content}, ...]) si hay artículos.
             ToolResult.fail("No articles found") si results está vacío o ausente.
         """
         today = date.today()
         new_date = today - timedelta(days=days)
-        params = {"from-date": new_date}
+        params = {"from-date": new_date, "show-fields": "trailText"}
         if topic:  # Usa buscador de tags
             tag_id = await self._find_tag(topic)
             if tag_id:
@@ -72,6 +73,7 @@ class GuardianAPI(BaseAPI):
                 "title": article.get("webTitle"),
                 "url": article.get("webUrl"),
                 "date": article.get("webPublicationDate"),
+                "content": article.get("fields", {}).get("trailText"),
             }
             for article in results
         ]

--- a/backend/integrations/nyt/client.py
+++ b/backend/integrations/nyt/client.py
@@ -43,10 +43,12 @@ class NYTAPI(BaseAPI):
         Respuesta de llamada a endpoint (campos consumidos):
             response.docs[].web_url    → url
             response.docs[].headline.main  → title
+            response.docs[].headline.print_headline  → print_headline
             response.docs[].pub_date   → date
+            response.docs[].abstract   → content
 
         Returns:
-            ToolResult.ok([{title, url, date}, ...]) si hay artículos.
+            ToolResult.ok([{title, print_headline, url, date, content}, ...]) si hay artículos.
             ToolResult.fail("No articles found") si docs está vacío o ausente.
         """
         today = date.today()
@@ -69,9 +71,11 @@ class NYTAPI(BaseAPI):
         articles = [
             {
                 "title": article.get("headline", {}).get("main"),
+                "print_headline": article.get("headline", {}).get("print_headline"),
                 # De nuevo, sin {}, el primer get devuelve none y ahí no se puede hacer get.
                 "url": article.get("web_url"),
                 "date": article.get("pub_date"),
+                "content": article.get("abstract"),
             }
             for article in results
         ]

--- a/tests/integrations/test_guardian.py
+++ b/tests/integrations/test_guardian.py
@@ -24,6 +24,7 @@ def fake_payload():
         "webTitle": "‘We’re expanding the cinematic toolbox’: AI fault lines on show at Cannes",
         "webUrl": "https://www.theguardian.com/technology/2026/may/24/cinematic-toolbox-ai-fault-lines-cannes",
         "webPublicationDate": "2026-05-24T05:00:48Z",
+        "fields": {"trailText": "AI fault lines on show at Cannes"},
     }
 
 
@@ -46,6 +47,7 @@ async def test_article_valid_response(fake_payload):
         assert result.data[0]["title"] == fake_payload["webTitle"]
         assert result.data[0]["url"] == fake_payload["webUrl"]
         assert result.data[0]["date"] == fake_payload["webPublicationDate"]
+        assert result.data[0]["content"] == fake_payload["fields"]["trailText"]
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/test_nyt.py
+++ b/tests/integrations/test_nyt.py
@@ -8,10 +8,12 @@ from httpx import Response
 def fake_payload():
     return {
         "headline": {
-            "main": "Want to ‘Optimize’ Your Happiness? This Happiness Expert Says: Don’t."
+            "main": "Want to ‘Optimize’ Your Happiness? This Happiness Expert Says: Don’t.",
+            "print_headline": "The Happiness Expert",
         },
         "web_url": "https://www.nytimes.com/2026/05/30/magazine/laurie-santos-interview.html",
         "pub_date": "2026-03-10T19:03:21Z",
+        "abstract": "A happiness expert on why optimizing happiness backfires.",
     }
 
 
@@ -31,6 +33,11 @@ async def test_search_articles_valid_response(fake_payload):
         assert result.data[0]["title"] == fake_payload["headline"]["main"]
         assert result.data[0]["url"] == fake_payload["web_url"]
         assert result.data[0]["date"] == fake_payload["pub_date"]
+        assert result.data[0]["content"] == fake_payload["abstract"]
+        assert (
+            result.data[0]["print_headline"]
+            == fake_payload["headline"]["print_headline"]
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Parte de la Épica 5. Enriquece la salida de las tools de noticias con el **contenido** del artículo, prerequisito de la detección por incoherencia (E5-03).

## Qué incluye
- **Guardian:** param `show-fields=trailText` + extracción de `fields.trailText` -> campo `content`.
- **NYT:** extracción de `abstract` -> `content`; bonus `print_headline` (habilita la variante titular web vs. impreso de R3.7). Sin param extra (el abstract ya viene en la respuesta).
- **Acceso defensivo** a los campos anidados (`.get("...", {}).get(...)`) para no petar si faltan.
- **Tests `respx`:** los fixtures incluyen los campos fuente y se verifica que el cliente los mapea a `content` (y `print_headline` en NYT). Docstrings de `search_articles` actualizados.

Closes #55