### PR TITLE
Feat/e5 04 explicabilidad

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,3 +556,14 @@ Segunda señal de clickbait, **complementaria** a `detect_clickbait` (que juzga 
 **Dependencias:** `sentence-transformers` **no se fija** en `requirements.txt` — arrastra `torch` + CUDA (varios GB, dependientes del hardware), así que sigue la **misma política que `torch` en E5-01**: se instala **aparte** para usar la incoherencia en local. CI y los tests **no** lo necesitan (mockean `_get_model`).
 
 **Motivo:** R3.7 — segunda señal de clickbait complementaria al zero-shot. La incoherencia captura el desajuste titular↔cuerpo (la promesa incumplida) y es **intrínsecamente explicable** (la similitud es el motivo), reforzando el eje de explicabilidad del TFG.
+
+
+
+"Aplico Rudin donde puedo —incoherencia(A MEDIAS, YA QUE EL MODELO NO) y léxico son intrínsecamente interpretables— y reservo lo post-hoc (LIME/SHAP), con sus límites de fidelidad, solo para la parte que depende de un transformer preentrenado que no puedo abrir de otro modo." !!!IMPORTANTE (NO MODIFICAR, RECORDAR POSTURA DEFINIDA)
+
+
+Omitir contenido decisivo = curiosity / information gap (Loewenstein) — el clásico teórico del clickbait.
+Catáfora / forward-reference ("this", "these", "here's why") — Blom & Hansen (2015), marcador lingüístico de clickbait.
+Léxico afectivo vs neutral = sensacionalismo.
+Activa/pasiva según el foco ("Police shoot man" vs "Man dies after police encounter") = framing de agencia (quién es agente/responsable). Tu intuición de la voz es teoría del framing pura.
+Perspectiva (dos personas: de quién es el punto de vista).

--- a/README.md
+++ b/README.md
@@ -557,6 +557,25 @@ Segunda señal de clickbait, **complementaria** a `detect_clickbait` (que juzga 
 
 **Motivo:** R3.7 — segunda señal de clickbait complementaria al zero-shot. La incoherencia captura el desajuste titular↔cuerpo (la promesa incumplida) y es **intrínsecamente explicable** (la similitud es el motivo), reforzando el eje de explicabilidad del TFG.
 
+### E5-04 · Explicabilidad: explicador léxico + formalización de R3.8 (R3.8–R3.11)
+
+Formaliza la **explicabilidad** —eje del TFG— y entrega la primera señal **genuinamente white-box**.
+
+**Requisitos:** se añaden a R3 cuatro criterios (ver `docs/requisitos.md`): **R3.8** explicar veredictos priorizando lo intrínsecamente interpretable; **R3.9** divulgar e intercambiar modelos; **R3.10** exponer ≥2 señales contrastables; **R3.11** post-hoc opcional (LIME/SHAP).
+
+- **Detector léxico `lexical.detect(headline)`** (`nlp/lexical.py`): busca **pistas de clickbait** y devuelve **cuáles dispararon y dónde**. A diferencia de la incoherencia (decisión transparente pero *feature* opaca), esta señal es **íntegramente interpretable**: las pistas **son** la explicación.
+  - **Pistas categorizadas + regex** (palabras y frases separadas a propósito): `WORD_CUES` (hipérbole, forward-reference) por `set`, `PHRASE_CUES` (curiosity-gap) por subcadena con `re.escape`, y `PATTERNS` estructurales (número inicial, `?` final, MAYÚSCULAS, elipsis) por regex. Sembradas de las listas de **Chakraborty et al. 2016** (citadas).
+  - **Salida auto-descriptiva:** `{score, is_clickbait (score ≥ THRESHOLD), matches:[{category, cue, span}], headline}` — los `span` dejan preparado el **resaltado en el frontend** futuro.
+  - **Función pura y síncrona** (no hay modelo ni red) → sin `async`/`to_thread`; guard de entrada vacía (R3.5).
+- **Tool nueva `detect_clickbait_lexical(headline)`** — tercera señal independiente → habilita el **contraste** (R3.10): el LLM puede cruzar zero-shot + incoherencia + léxico.
+- **Sin dependencias nuevas** (solo `re` de la stdlib). **Tests sin mocks** (determinista): positivo / negativo / guard de entrada.
+
+**Postura (Rudin):** se aplica lo intrínseco donde se puede (léxico = white-box; incoherencia = a medias, el modelo de embeddings es opaco) y se reserva lo post-hoc (LIME/SHAP) solo para el zero-shot, que no se puede abrir de otro modo.
+
+**Backlog (en memoria, fuera de este PR):** fichas de modelos (R3.9 divulgación), meta-tool de contraste con cascada, post-hoc (R3.11). La **combinación calibrada** de señales depende de un dataset etiquetado (Webis-17 CC0 / Chakraborty 16k) → sube **E4-03** de prioridad.
+
+**Motivo:** R3.8 — la explicabilidad es el eje del TFG; el explicador léxico es la pieza que responde *"qué palabras"*, la única señal plenamente interpretable, y completa las tres señales contrastables.
+
 
 
 "Aplico Rudin donde puedo —incoherencia(A MEDIAS, YA QUE EL MODELO NO) y léxico son intrínsecamente interpretables— y reservo lo post-hoc (LIME/SHAP), con sus límites de fidelidad, solo para la parte que depende de un transformer preentrenado que no puedo abrir de otro modo." !!!IMPORTANTE (NO MODIFICAR, RECORDAR POSTURA DEFINIDA)

--- a/backend/integrations/nlp/incoherence.py
+++ b/backend/integrations/nlp/incoherence.py
@@ -4,7 +4,7 @@ from backend.core.models import ToolResult
 
 class IncoherenceDetector:
     MODEL = "all-MiniLM-L6-v2"
-    THRESHOLD = 0.3  # Lower es clickbait
+    THRESHOLD = 0.3  # Lower es clickbait #TODO: Parametrizable
 
     def __init__(self) -> None:
         self._model = None  # Singleton

--- a/backend/integrations/nlp/lexical.py
+++ b/backend/integrations/nlp/lexical.py
@@ -1,0 +1,83 @@
+import re
+
+from backend.core.models import ToolResult
+
+WORD_CUES = {
+    "hyperbole": {"amazing", "astonishing"},
+    "forward_reference": {"this", "that", "things", "reasons", "ways"},
+}
+PHRASE_CUES = {
+    "curiosity_gap": {"what happened next", "doesn't want you to see"},
+}
+PATTERNS = {
+    "leading_number": re.compile(r"^\s*\d+"),
+    # Números iniciales (tras espacios en blanco)
+    "question": re.compile(r"\?\s*$"),
+    # Interrogacion (no entre comillas para excluir citas) Solo pilla comilla cierre
+    "all_caps": re.compile(r"\b[A-Z]{4,}\b"),
+    # 4 mayúsculas seguidas (evitar pillar ALGUNAS siglas) NASA, NATO...
+    "ellipsis": re.compile(r"\.\.\.|…"),  # ... o …
+}
+
+# Pistas necesarias para considerarse clickbait. TODO: Parametrizar
+THRESHOLD = 2
+
+
+def detect(headline: str) -> ToolResult:
+
+    if not headline or not headline.strip():
+        return ToolResult.fail("El titular está vacío o no es válido")
+
+    original = headline
+    lowered = headline.lower()
+    matches = []
+    # Palabras + '. Usar finditter para recibir posiciones
+
+    # Words
+    for m in re.finditer(r"[\w']+", lowered):  # Cada palabra
+        token = m.group()  # Token (string)
+        for category, words in WORD_CUES.items():
+            # Ej: Hyperbole, amazing
+            if token in words:
+                matches.append(
+                    {
+                        "category": category,
+                        "cue": token,  # Palabra que encontró
+                        "span": list(m.span()),
+                        # Posicion Tupla[Inicio, fin] convertida a lista por comodidad, básicamente
+                    }
+                )
+
+    # Phrases
+
+    for category, phrases in PHRASE_CUES.items():
+        for phrase in phrases:  # Cada frase
+            for m in re.finditer(re.escape(phrase), lowered):
+                # Escapamos para incluir puntuaciones y otros signos
+                matches.append(
+                    {
+                        "category": category,
+                        "cue": phrase,  # Frase que encontró
+                        "span": list(m.span()),
+                    }
+                )
+
+    # Estructures:
+
+    for category, pattern in PATTERNS.items():  # Categoría + patrón regex
+        for m in pattern.finditer(original):
+            matches.append(
+                {"category": category, "cue": m.group(), "span": list(m.span())}
+            )
+
+    # Recuento final:
+    score = len(matches)
+    is_clickbait = score >= THRESHOLD
+    return ToolResult.ok(
+        {
+            "score": score,
+            "is_clickbait": is_clickbait,
+            "matches": matches,
+            "headline": headline,
+        }
+    )

--- a/backend/integrations/nlp/tool.py
+++ b/backend/integrations/nlp/tool.py
@@ -6,6 +6,7 @@ import json
 
 from mcp.server.fastmcp import FastMCP
 from backend.core.observability import log_tool_invocation
+from backend.integrations.nlp import lexical
 from backend.integrations.nlp.factory import get_nlp_backend
 from backend.integrations.nlp.incoherence import IncoherenceDetector
 
@@ -92,4 +93,29 @@ def register(mcp: FastMCP):
         response = await detector.detect(headline, content)
         if not response.has_content():
             return response.error or "Error al analizar incoherencia en el titular"
+        return json.dumps(response.data)
+
+    @mcp.tool()
+    @log_tool_invocation
+    async def detect_clickbait_lexical(headline: str) -> str:
+        """
+        Detecta clickbait por pistas léxicas y estructurales del titular (señal explicable).
+
+        Busca marcas típicas de clickbait —hipérbole, referencias vagas (this/these),
+        frases gancho, número inicial (listicle), interrogación, mayúsculas, elipsis—
+        y devuelve qué pistas dispararon y dónde. Señal white-box (la evidencia ES la
+        explicación), complementaria a `detect_clickbait` (zero-shot) y
+        `detect_clickbait_incoherence`. Pensada para titulares en inglés.
+
+        Args:
+            headline (str): titular a evaluar (en inglés).
+
+        Returns:
+            JSON con `score` (nº de pistas), `is_clickbait` (score ≥ umbral),
+            `matches` (lista de {category, cue, span}) y `headline`. Mensaje de
+            error si el titular está vacío.
+        """
+        response = lexical.detect(headline)
+        if not response.has_content():
+            return response.error or "Error al analizar léxico en el titular"
         return json.dumps(response.data)

--- a/docs/requisitos.md
+++ b/docs/requisitos.md
@@ -59,6 +59,10 @@ Este documento define los requisitos para un Trabajo de Fin de Grado (TFG) que i
 5. CUANDO el texto esté vacío o no sea válido, EL NLP_Analyzer DEBERÁ devolver un mensaje de error adecuado.
 6. EL NLP_Analyzer DEBERÁ procesar las solicitudes de análisis de texto dentro de unos límites de tiempo razonables.
 7. EL NLP_Analyzer DEBERÁ soportar la detección de clickbait por **incoherencia** entre el titular y su contenido (titular vs. teaser/cuerpo, o titular web vs. impreso), además de clasificar el titular de forma aislada. _(Requiere enriquecer la salida de las herramientas de noticias — ver Requisito 2.)_
+8. EL NLP_Analyzer DEBERÁ acompañar cada veredicto de clickbait con una **explicación legible** de aquello en lo que se basa, **priorizando medios intrínsecamente interpretables** (marcas léxicas que disparan la señal y/o el grado de incoherencia titular↔contenido) frente a explicaciones post-hoc sobre modelos opacos. _(Eje de explicabilidad del TFG. Matiz: el score de incoherencia es transparente en su **decisión** pero su **feature** —embeddings— es opaca, y su umbral está sin calibrar — ver memoria de cambios.)_
+9. EL NLP_Analyzer DEBERÁ **divulgar los modelos** que emplea (nombre, tarea y limitaciones conocidas) y DEBERÁ permitir **intercambiarlos por configuración**, sin cambios de código. _(Transparencia de sistema / model cards — ver memoria de cambios.)_
+10. EL NLP_Analyzer DEBERÁ exponer **al menos dos señales independientes** de clickbait (p.ej. clasificación del titular e incoherencia titular↔contenido) que puedan **contrastarse** para reducir falsos positivos. _(La combinación **calibrada** de señales depende de un dataset etiquetado —ver E4-03—; el contraste inicial puede recaer en el agente orquestador.)_
+11. DONDE se empleen clasificadores de caja negra (p.ej. zero-shot), EL NLP_Analyzer PODRÁ ofrecer explicaciones **post-hoc** por atribución (p.ej. LIME/SHAP) que resalten los términos más influyentes, **asumiendo sus límites de fidelidad**. _(Mejora opcional / comparativa de técnicas XAI.)_
 
 ### Requisito 4: API REST backend
 

--- a/tests/integrations/test_nlp.py
+++ b/tests/integrations/test_nlp.py
@@ -5,6 +5,7 @@ import pytest
 import respx  # Usamos en vez de htttp, ya que no hacemos llamadas de verdad, mockeamos
 from httpx import Response, TimeoutException
 
+from backend.integrations.nlp import lexical
 from backend.integrations.nlp.client import HFClient
 from backend.integrations.nlp.incoherence import IncoherenceDetector
 from backend.integrations.nlp.local import LocalNLPClient
@@ -370,3 +371,40 @@ async def test_detector_error_returns_fail(monkeypatch):
 
     assert not result.success
     assert "Error inesperado calculando incoherencia" in result.error
+
+
+# --Léxico
+
+
+def test_lexical_detector_true():
+
+    headline = "7 reasons to avoid ketchup"
+
+    result = lexical.detect(headline)
+    assert result.success
+    assert result.data["is_clickbait"] is True
+    assert result.data["score"] >= lexical.THRESHOLD
+
+    cats = {m["category"] for m in result.data["matches"]}
+    assert "leading_number" in cats
+    assert "forward_reference" in cats
+
+
+def test_lexical_detector_false():
+
+    headline = "Spain wins the 2026 World Cup"
+
+    result = lexical.detect(headline)
+    assert result.success
+    assert result.data["is_clickbait"] is False
+    assert not (result.data["score"] >= lexical.THRESHOLD)
+
+
+def test_lexical_detector_no_headline():
+
+    headline1 = " "
+    headline2 = ""
+
+    result1 = lexical.detect(headline1)
+    result2 = lexical.detect(headline2)
+    assert not (result1.success) and (not result2.success)


### PR DESCRIPTION
## E5-04 · Explicabilidad: explicador léxico + formalización de R3.8

Formaliza la **explicabilidad** (eje del TFG) y añade la primera señal
**genuinamente white-box**.

### Requisitos
Cuatro criterios nuevos en R3 (`docs/requisitos.md`): **R3.8** explicar
veredictos priorizando lo intrínsecamente interpretable; **R3.9** divulgar
e intercambiar modelos; **R3.10** ≥2 señales contrastables; **R3.11**
post-hoc opcional (LIME/SHAP).

### Código
- **`lexical.detect(headline)`** (`nlp/lexical.py`): detecta clickbait por
  **pistas léxicas y estructurales** y devuelve qué dispararon y dónde
  (`matches: [{category, cue, span}]`) → la evidencia **es** la explicación.
  Pistas categorizadas (`WORD_CUES`/`PHRASE_CUES` + `PATTERNS` regex)
  sembradas de Chakraborty et al. 2016 (citadas). Función **pura y síncrona**;
  guard de entrada vacía (R3.5).
- **Tool `detect_clickbait_lexical(headline)`** — tercera señal independiente,
  habilita el contraste (R3.10): zero-shot + incoherencia + léxico.
- Sin dependencias nuevas (`re` stdlib). Tests **sin mocks** (determinista):
  positivo / negativo / guard. Suite: 50 ✓.

### Postura (Rudin)
Intrínseco donde se puede (léxico = white-box; incoherencia = a medias) y
post-hoc (LIME/SHAP) reservado solo al zero-shot opaco.

### Fuera de alcance (backlog, en notas)
Fichas de modelos (R3.9), meta-tool de contraste con cascada, post-hoc
(R3.11). La combinación **calibrada** depende de un dataset (Webis-17 CC0 /
Chakraborty 16k) → sube E4-03 de prioridad.

Closes #57