### PR TITLE
## E5-06 · Modelo lineal interpretable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       HF_TOKEN: dummy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # usando organización actions por defecto
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5 # usando organización actions por defecto
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip #Evita instalación en cada run

--- a/README.md
+++ b/README.md
@@ -610,6 +610,39 @@ Formaliza la **explicabilidad** —eje del TFG— y entrega la primera señal **
 
 **Motivo:** R3.8 — la explicabilidad es el eje del TFG; el explicador léxico es la pieza que responde *"qué palabras"*, la única señal plenamente interpretable, y completa las tres señales contrastables.
 
+### E5-06 · Modelo lineal interpretable (peldaño 2 hacia el "modelo propio")
+
+Issue #65. Primer modelo **entrenado** del proyecto: una **regresión logística** que *aprende* un peso por señal en vez de contar pistas con un umbral fijo. Sigue siendo **interpretable** (los pesos son la explicación, R3.8) — peldaño 2 alineado con Rudin (interpretable-primero, medir el hueco antes de plantear una caja negra).
+
+- **Featurización (opción A, por categoría):** `featurize(headline)` corre `lexical.detect`, cuenta los `matches` por categoría con `Counter` y emite un vector de 7 enteros en el orden de la nueva constante `lexical.CATEGORIES` (multi-hot / bag-of-words simplificado **por categoría**, no por palabra).
+- **Tubería** (`backend/evaluation/linear_model.py`): `load_dataset` (reusa E4-03) → `featurize` → **split train/test estratificado** (`test_size=0.2`, semilla fija → corrige el **sesgo optimista**) → `LogisticRegression.fit` (minimiza **log-loss**) → `predict` → métricas + pesos.
+
+**Resultado (held-out test, `random_state=24`):**
+
+| | Reglas (t=1, todo el dataset) | Lineal (held-out) |
+|---|---|---|
+| Precision | 0.847 | **0.863** |
+| Recall | **0.850** | 0.842 |
+| F1 | 0.849 | **0.852** |
+
+**Veredicto:** **empate en F1** (~0.850). El lineal lo logra sobre un **test honesto** (las reglas medían sobre **todo** el dataset → optimista) y gana **precisión** a cambio de algo de recall. Con 7 features gruesas, contar reglas y aprender pesos extraen casi lo mismo → el modelo no es el cuello de botella, **la granularidad de las features lo es**.
+
+**Explicabilidad (R3.8) — pesos aprendidos:**
+
+| Categoría | Peso | Lectura |
+|---|---|---|
+| forward_reference | +2.79 | señal de clickbait más fuerte ("this/these/you") |
+| leading_number | +2.61 | listicles ("10 things…") |
+| hyperbole | +2.05 | "amazing/shocking" |
+| curiosity_gap | 0.00 | **feature muerta** (`PHRASE_CUES` mínimo → casi nunca dispara) |
+| ellipsis | ≈0 | no informativa (signo inestable entre semillas) |
+| all_caps | −0.76 | empuja a **no**-clickbait (siglas de prensa seria: NASA, NATO…) |
+| question | −3.80 | empuja a **no**-clickbait (el `?` final sale más en noticias reales aquí) |
+
+Los tres positivos = clickbait de manual → **valida** el white-box. Hallazgo clave: `all_caps` y `question` salen **negativos** — el modelo **corrige solo** suposiciones que las reglas tenían *al revés* (las contaban como +clickbait). Ejemplo de **medir > intuir**. Los pesos grandes son **estables entre semillas** (la explicación es fiable, no un artefacto del split). *(Caveat: pesos condicionales y dataset específico de titulares EN — no sobre-generalizar.)*
+
+**Siguiente:** (1) re-medir el baseline de reglas en el **mismo test** (comparación 100 % justa, pendiente); (2) **opción B** — featurización **por cue** (~570 features, desbloquea `common_phrases` como *features*) → palanca para superar el empate sin salir de la familia interpretable.
+
 
 
 "Aplico Rudin donde puedo —incoherencia(A MEDIAS, YA QUE EL MODELO NO) y léxico son intrínsecamente interpretables— y reservo lo post-hoc (LIME/SHAP), con sus límites de fidelidad, solo para la parte que depende de un transformer preentrenado que no puedo abrir de otro modo." !!!IMPORTANTE (NO MODIFICAR, RECORDAR POSTURA DEFINIDA)

--- a/README.md
+++ b/README.md
@@ -617,15 +617,17 @@ Issue #65. Primer modelo **entrenado** del proyecto: una **regresión logística
 - **Featurización (opción A, por categoría):** `featurize(headline)` corre `lexical.detect`, cuenta los `matches` por categoría con `Counter` y emite un vector de 7 enteros en el orden de la nueva constante `lexical.CATEGORIES` (multi-hot / bag-of-words simplificado **por categoría**, no por palabra).
 - **Tubería** (`backend/evaluation/linear_model.py`): `load_dataset` (reusa E4-03) → `featurize` → **split train/test estratificado** (`test_size=0.2`, semilla fija → corrige el **sesgo optimista**) → `LogisticRegression.fit` (minimiza **log-loss**) → `predict` → métricas + pesos.
 
-**Resultado (held-out test, `random_state=24`):**
+**Resultado (comparación justa: ambos sobre el mismo held-out test, `random_state=24`):**
 
-| | Reglas (t=1, todo el dataset) | Lineal (held-out) |
+| | Reglas (t=1) | Lineal |
 |---|---|---|
-| Precision | 0.847 | **0.863** |
-| Recall | **0.850** | 0.842 |
-| F1 | 0.849 | **0.852** |
+| Precision | 0.841 | **0.863** |
+| Recall | **0.845** | 0.842 |
+| F1 | 0.843 | **0.852** |
 
-**Veredicto:** **empate en F1** (~0.850). El lineal lo logra sobre un **test honesto** (las reglas medían sobre **todo** el dataset → optimista) y gana **precisión** a cambio de algo de recall. Con 7 features gruesas, contar reglas y aprender pesos extraen casi lo mismo → el modelo no es el cuello de botella, **la granularidad de las features lo es**.
+> Sobre **todo** el dataset las reglas daban F1=0.849 (optimista); en el test honesto bajan a 0.843 → el *caveat* era real, pequeño (parte sesgo, parte muestreo).
+
+**Veredicto:** el lineal **gana, modesto pero limpio** (F1 0.852 vs 0.843). Toda la ventaja es **precisión** (+0.022); el recall queda empatado. Y la **explicación predice la métrica**: las reglas contaban `all_caps`/`question` como +clickbait → falsos positivos → precisión 0.841; el lineal aprendió que son **negativos** → menos falsos positivos → precisión 0.863. La tabla de pesos (R3.8) anticipó dónde estaría la ganancia. Aun así, con 7 features gruesas el margen es pequeño → **la granularidad de las features es el cuello de botella**, no el modelo.
 
 **Explicabilidad (R3.8) — pesos aprendidos:**
 
@@ -641,7 +643,7 @@ Issue #65. Primer modelo **entrenado** del proyecto: una **regresión logística
 
 Los tres positivos = clickbait de manual → **valida** el white-box. Hallazgo clave: `all_caps` y `question` salen **negativos** — el modelo **corrige solo** suposiciones que las reglas tenían *al revés* (las contaban como +clickbait). Ejemplo de **medir > intuir**. Los pesos grandes son **estables entre semillas** (la explicación es fiable, no un artefacto del split). *(Caveat: pesos condicionales y dataset específico de titulares EN — no sobre-generalizar.)*
 
-**Siguiente:** (1) re-medir el baseline de reglas en el **mismo test** (comparación 100 % justa, pendiente); (2) **opción B** — featurización **por cue** (~570 features, desbloquea `common_phrases` como *features*) → palanca para superar el empate sin salir de la familia interpretable.
+**Siguiente:** **opción B** — featurización **por cue** (~570 features, desbloquea `common_phrases` como *features*) → palanca para ampliar el margen sin salir de la familia interpretable.
 
 
 

--- a/README.md
+++ b/README.md
@@ -614,16 +614,18 @@ Formaliza la **explicabilidad** —eje del TFG— y entrega la primera señal **
 
 Issue #65. Primer modelo **entrenado** del proyecto: una **regresión logística** que *aprende* un peso por señal en vez de contar pistas con un umbral fijo. Sigue siendo **interpretable** (los pesos son la explicación, R3.8) — peldaño 2 alineado con Rudin (interpretable-primero, medir el hueco antes de plantear una caja negra).
 
-- **Featurización (opción A, por categoría):** `featurize(headline)` corre `lexical.detect`, cuenta los `matches` por categoría con `Counter` y emite un vector de 7 enteros en el orden de la nueva constante `lexical.CATEGORIES` (multi-hot / bag-of-words simplificado **por categoría**, no por palabra).
+- **Featurización — dos granularidades:**
+  - **Opción A (por categoría):** `featurize` cuenta los `matches` por categoría → vector de **7** enteros en el orden de `lexical.CATEGORIES`.
+  - **Opción B (por cue):** `featurize_cues` cuenta **cada cue individual** (clave `match["cue"]`) → vector de **~390** en el orden de `lexical.ALL_CUES`; los `PATTERNS` se quedan por categoría (su texto casado varía → híbrido). Es un bag-of-words restringido al vocabulario de pistas.
 - **Tubería** (`backend/evaluation/linear_model.py`): `load_dataset` (reusa E4-03) → `featurize` → **split train/test estratificado** (`test_size=0.2`, semilla fija → corrige el **sesgo optimista**) → `LogisticRegression.fit` (minimiza **log-loss**) → `predict` → métricas + pesos.
 
-**Resultado (comparación justa: ambos sobre el mismo held-out test, `random_state=24`):**
+**Resultado (todos sobre el mismo held-out test, `random_state=24`):**
 
-| | Reglas (t=1) | Lineal |
-|---|---|---|
-| Precision | 0.841 | **0.863** |
-| Recall | **0.845** | 0.842 |
-| F1 | 0.843 | **0.852** |
+| | Reglas (t=1) | Lineal A (categoría) | Lineal B (por cue) |
+|---|---|---|---|
+| Precision | 0.841 | 0.863 | **0.927** |
+| Recall | **0.845** | 0.842 | 0.811 |
+| F1 | 0.843 | 0.852 | **0.865** |
 
 > Sobre **todo** el dataset las reglas daban F1=0.849 (optimista); en el test honesto bajan a 0.843 → el *caveat* era real, pequeño (parte sesgo, parte muestreo).
 
@@ -643,7 +645,14 @@ Issue #65. Primer modelo **entrenado** del proyecto: una **regresión logística
 
 Los tres positivos = clickbait de manual → **valida** el white-box. Hallazgo clave: `all_caps` y `question` salen **negativos** — el modelo **corrige solo** suposiciones que las reglas tenían *al revés* (las contaban como +clickbait). Ejemplo de **medir > intuir**. Los pesos grandes son **estables entre semillas** (la explicación es fiable, no un artefacto del split). *(Caveat: pesos condicionales y dataset específico de titulares EN — no sobre-generalizar.)*
 
-**Siguiente:** **opción B** — featurización **por cue** (~570 features, desbloquea `common_phrases` como *features*) → palanca para ampliar el margen sin salir de la familia interpretable.
+**Opción B — features por cue (F1 0.865):** una feature por **palabra/frase** (~390) en vez de por categoría. La granularidad **revela heterogeneidad dentro de las categorías hechas a mano**:
+
+- **TOP (clickbait):** `you` (+5.9, el nº1 → dirigirse al lector), `we`, `what`, `this`, `everyone`, `guys` (sujetos vagos) + `adorable`, `hilarious`, `funniest`, `amazing`, `literally` (hipérbole afectiva).
+- **BOTTOM (no-clickbait):** `question` (−4.5, estable con A) + `extraordinary`, `legendary`, `striking`, `memorable`, `grand` — **todas de la categoría `hyperbole`**, pero léxico **formal de prensa seria**.
+
+Ese contraste explica el salto de precisión (0.863 → **0.927**): A daba `hyperbole = +2.0` (el **promedio**); B distingue `adorable` (clickbait) de `extraordinary` (serio) y **deja de dispararse** con los formales. La categoría a mano era **heterogénea** y el modelo lo destapa — hallazgo lingüístico, no solo métrico. *(Caveat: algunos pesos del bottom — `ethnic`, `psychological`, `charged` — son artefacto temático del corpus, no "no-clickbait" universal.)*
+
+**Siguiente (opcional):** **B2** — añadir `common_phrases` como features (arrastra el acoplamiento de `detect()`, que es a la vez la tool de reglas → decisión pendiente); o el peldaño neural (E5-05). El modelo lineal interpretable ya **bate al baseline con explicación legible** (R3.8).
 
 
 

--- a/backend/evaluation/linear_model.py
+++ b/backend/evaluation/linear_model.py
@@ -67,4 +67,17 @@ if __name__ == "__main__":
         )
     )
 
-    # pista: sorted(zip(lexical.CATEGORIES, model.coef_[0]), key=..., reverse=True)
+    # Lineal vs Reglas:
+    rule_pred = []
+    for x in X_test:
+        if sum(x) >= lexical.THRESHOLD:
+            rule_pred.append(1)
+        else:
+            rule_pred.append(0)
+
+    print(
+        "reglas",
+        precision_recall_fscore_support(
+            y_test, rule_pred, average="binary", zero_division=0
+        ),
+    )

--- a/backend/evaluation/linear_model.py
+++ b/backend/evaluation/linear_model.py
@@ -1,0 +1,70 @@
+from collections import Counter
+
+from backend.evaluation.eval_lexical import load_dataset
+from backend.integrations.nlp import lexical
+
+
+from sklearn.model_selection import train_test_split
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import precision_recall_fscore_support, classification_report
+
+
+def featurize(headline) -> list[int]:  # -> vector
+    # Similar a Bag of Words, debemos contar cuanto hay de cada categoria léxica.
+    result = lexical.detect(headline)  # "10 AMAZING Things You Won't Believe"
+
+    categories_list = []
+    for match in result.data["matches"]:
+        categories_list.append(match["category"])
+
+    # Matches = {category, cue, span} Usamos categorias
+
+    contador = Counter(categories_list)
+    vector = [contador[cat] for cat in lexical.CATEGORIES]
+    return vector
+    # Devuelve lista de int en orden de CATEGORIES
+
+
+if __name__ == "__main__":
+
+    data = load_dataset()
+
+    # Features: cleaning (MULTI_HOT)
+    # Bag of Words Binario SIMPLIFICADO (por categoria en vez de palabra)
+
+    headlines, labels = zip(*data)
+    X = [featurize(h) for h in headlines]
+    y = labels
+
+    # Split (Separamos train/test para evitar sesgo optimista -> sin generalización)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, stratify=y, random_state=24
+    )
+
+    model = LogisticRegression(
+        max_iter=1000
+    )  # LOGISITIC NO LINEAR PORQUE CLICKBAIT ES BINARIO (CONSTANTE), NO CONTINUO.
+
+    # Era por debajo una combinacion lineal -> sigmoide -> [0,1]
+    # 0.75 = 75% prob
+
+    # Train (Pesos + error) Error sigue formula LOG-LOSS que penaliza fallar al afimrar clickbait
+    model.fit(X_train, y_train)
+
+    # Predict (para x nuevo, aplicamos formula de antes)
+    y_pred = model.predict(X_test)
+    print(
+        precision_recall_fscore_support(
+            y_test, y_pred, average="binary", zero_division=0
+        )
+    )
+
+    print(
+        sorted(
+            zip(lexical.CATEGORIES, model.coef_[0]),
+            key=lambda par: par[1],
+            reverse=True,
+        )
+    )
+
+    # pista: sorted(zip(lexical.CATEGORIES, model.coef_[0]), key=..., reverse=True)

--- a/backend/evaluation/linear_model.py
+++ b/backend/evaluation/linear_model.py
@@ -25,6 +25,28 @@ def featurize(headline) -> list[int]:  # -> vector
     # Devuelve lista de int en orden de CATEGORIES
 
 
+# En vez de modificar la anterior, dejo para que se puedan usar PATTERNS ya que sí es categórica, resto por cues y sumamos. (como una pveriosn avanzada)
+
+
+def featurize_cues(headline) -> list[int]:  # -> vector
+    result = lexical.detect(headline)
+
+    categories_list = []
+    cue_list = []
+    for match in result.data["matches"]:
+        if match["category"] in lexical.PATTERNS:
+            categories_list.append(match["category"])
+        else:
+            cue_list.append(match["cue"])
+
+    contador_category = Counter(categories_list)
+    contador_cue = Counter(cue_list)
+    vector = list(contador_category[cat] for cat in lexical.PATTERNS) + list(
+        contador_cue[cue] for cue in lexical.ALL_CUES
+    )
+    return vector
+
+
 if __name__ == "__main__":
 
     data = load_dataset()
@@ -33,7 +55,7 @@ if __name__ == "__main__":
     # Bag of Words Binario SIMPLIFICADO (por categoria en vez de palabra)
 
     headlines, labels = zip(*data)
-    X = [featurize(h) for h in headlines]
+    X = [featurize_cues(h) for h in headlines]
     y = labels
 
     # Split (Separamos train/test para evitar sesgo optimista -> sin generalización)
@@ -59,13 +81,17 @@ if __name__ == "__main__":
         )
     )
 
-    print(
-        sorted(
-            zip(lexical.CATEGORIES, model.coef_[0]),
-            key=lambda par: par[1],
-            reverse=True,
-        )
+    feature_names = list(lexical.PATTERNS) + lexical.ALL_CUES
+    weight_table = sorted(
+        zip(feature_names, model.coef_[0]),
+        key=lambda par: par[1],
+        reverse=True,
     )
+    print("TABLA DE PESOS")
+    print()
+    print("TOP: ", weight_table[:20])
+    print()
+    print("BOTTOM: ", weight_table[-20:])
 
     # Lineal vs Reglas:
     rule_pred = []

--- a/backend/integrations/nlp/lexical.py
+++ b/backend/integrations/nlp/lexical.py
@@ -35,6 +35,10 @@ PATTERNS = {
     "ellipsis": re.compile(r"\.\.\.|…"),  # ... o …
 }
 
+CATEGORIES = (
+    list(WORD_CUES) + list(PHRASE_CUES) + list(PATTERNS)
+)  # Usado para featurizar en el modelo linear
+
 # Pistas necesarias para considerarse clickbait.
 # Default t=1 (mejor F1≈0.85, P≈R). Modo conservador: t=2 (precisión≈0.97). TODO: Parametrizar
 THRESHOLD = 1

--- a/backend/integrations/nlp/lexical.py
+++ b/backend/integrations/nlp/lexical.py
@@ -41,6 +41,13 @@ CATEGORIES = (
 
 # Pistas necesarias para considerarse clickbait.
 # Default t=1 (mejor F1≈0.85, P≈R). Modo conservador: t=2 (precisión≈0.97). TODO: Parametrizar
+
+# Creamos un orden para reutilizar en linear_model (igual que CATEGORIES).
+# No aplica PATTERNS (no se pueden determinar, son reglas)
+
+# Orden alfabético por defecto.
+# Desempaquetamos de set a string
+ALL_CUES = sorted(set().union(*WORD_CUES.values(), *PHRASE_CUES.values()))
 THRESHOLD = 1
 
 


### PR DESCRIPTION
Closes #65

Primer modelo **entrenado** del proyecto: regresión logística sobre las pistas
léxicas como features. Sigue siendo **interpretable** (los pesos son la
explicación, R3.8) — peldaño 2 alineado con Rudin.

### Qué incluye
- `backend/evaluation/linear_model.py`: `load_dataset` → `featurize` → split
  train/test estratificado → `LogisticRegression.fit` → `predict` → métricas + pesos.
- **Dos granularidades:** A (por categoría, 7 features, `lexical.CATEGORIES`) y
  B (por cue, ~390, `lexical.ALL_CUES`; patterns por categoría → híbrido).
- `lexical.py`: constantes `CATEGORIES` y `ALL_CUES` (orden estable).
- Bump de CI (`checkout@v5`, `setup-python@v6`).

### Resultado (mismo held-out test, random_state=24)
| | Reglas (t=1) | Lineal A | Lineal B |
|---|---|---|---|
| Precision | 0.841 | 0.863 | **0.927** |
| Recall | **0.845** | 0.842 | 0.811 |
| F1 | 0.843 | 0.852 | **0.865** |

El lineal **bate al baseline** (0.865 vs 0.843), todo en precisión.

### Explicabilidad (R3.8)
La granularidad de B **destapa heterogeneidad** dentro de las categorías hechas
a mano: distingue la hipérbole de clickbait (`adorable`, `hilarious`) de la
formal de prensa seria (`extraordinary`, `legendary`) — de ahí el salto de
precisión. Los pesos negativos (`question`, `all_caps`) corrigen suposiciones
que las reglas tenían al revés.

### Notas
- `numpy`/`scikit-learn` siguen en `requirements-dev.txt`, no en `requirements.txt` (CI ligero).
- El modelo es aún un script de investigación; shipearlo como tool contrastable (R3.10) es el follow-up (E5-07).