### PR TITLE
Fix #69 · Falsos positivos del léxico por cues de una letra

### DIFF
--- a/backend/integrations/nlp/lexical.py
+++ b/backend/integrations/nlp/lexical.py
@@ -62,7 +62,9 @@ def detect(headline: str) -> ToolResult:
     # Palabras + '. Usar finditter para recibir posiciones
 
     # Words
-    for m in re.finditer(r"[\w']+", lowered):  # Cada palabra
+
+    # Fix: eliminado "i" de cues (En siglas pilla como clickbait)
+    for m in re.finditer(r"[\w']{2,}", lowered):  # Cada palabra (de 2 letras o más)
         token = m.group()  # Token (string)
         for category, words in WORD_CUES.items():
             # Ej: Hyperbole, amazing

--- a/tests/integrations/test_nlp.py
+++ b/tests/integrations/test_nlp.py
@@ -410,6 +410,18 @@ def test_lexical_detector_no_headline():
     assert not (result1.success) and (not result2.success)
 
 
+def test_lexical_acronym_no_false_positive():
+
+    # Test de Bug de acrónimos con puntos
+    result = lexical.detect(
+        "Chinese A.I. Models Close the Gap With Anthropic and OpenAI"
+    )
+    assert result.success
+    cues = {m["cue"] for m in result.data["matches"]}
+    assert "i" not in cues
+    assert result.data["is_clickbait"] is False
+
+
 # --Lineal Determinista!!! (Si cambia seed, cambia test)
 
 


### PR DESCRIPTION
## Fix #69 · Falsos positivos del léxico por cues de una letra

Closes #69

El tokenizer léxico (`[\w']+`) partía acrónimos como "A.I." en `a`/`i`, y el cue
de una letra `i` disparaba clickbait con `THRESHOLD=1` en cualquier titular con
acrónimo o "I" suelto. Descubierto en la prueba E2E del MVP (3 titulares reales
de NYT sobre A.I. falso-positiveados).

### Fix
`[\w']{2,}` — tokens de ≥2 caracteres. Solo afecta a `WORD_CUES`; el único cue de
1 letra era `i`.

### Sin reentrenar
No toca las listas → `ALL_CUES` no cambia → el JSON del lineal sigue alineado; la
feature `i` queda siempre a 0. Corrige léxico **y** lineal a la vez.

### Verificación
- Los 3 titulares de A.I. → ya no clickbait por `i` (léxico y lineal).
- Clickbait real → sigue detectado. Test de regresión añadido. `54 passed`.