### PR TITLE
feat(integrations): tool describe_models (model cards, R3.9) + tests y README (E5-08)

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,17 @@ Issue #66. Convierte el modelo lineal de E5-06 (script de investigación) en una
 
 **Nota de diseño:** entrenar (sklearn, en `evaluation/`, deps pesadas) y servir (pesos JSON + Python puro, en `integrations/nlp/`) quedan **separados** → CI y runtime siguen ligeros. Tests deterministas (sin mocks, el JSON está versionado).
 
+### E5-08 · Divulgación de modelos (model cards) — R3.9
+
+Issue #71. Cierra la mitad pendiente de **R3.9** (DEBERÁ): *divulgar los modelos que emplea el sistema* (la otra mitad —intercambiarlos por configuración— ya la cubría la factoría `nlp_backend`).
+
+- **Fuente única** `backend/integrations/nlp/model_cards.py`: `MODEL_CARDS`, una ficha por señal con `name`, `task`, **`type`** (interpretable / híbrido / opaco), `limitations` y `backend`.
+- **Tool `describe_models()`** (sin argumentos) → devuelve las fichas en JSON: **divulgación consultable en runtime** por la interfaz MCP, forward-compatible con un futuro frontend.
+- El campo **`type`** enlaza R3.9 con **R3.8**: marca de un vistazo qué señal es **white-box** (léxico, lineal) frente a **caja negra** (zero-shot, sentimiento) o **híbrida** (incoherencia: decisión transparente, feature opaca).
+- Limitaciones **honestas**: el zero-shot es genérico y opaco; el sentimiento está entrenado en tuits; la incoherencia tiene el umbral sin calibrar; el léxico solo capta clickbait de *forma*, no de engaño.
+
+Es transparencia **de sistema** (qué modelos, con qué límites), no solo de modelo. Tests deterministas (estructura + serialización). Con esto, **el alcance obligatorio (DEBERÁ) de la Épica 5 queda completo**.
+
 
 
 "Aplico Rudin donde puedo —incoherencia(A MEDIAS, YA QUE EL MODELO NO) y léxico son intrínsecamente interpretables— y reservo lo post-hoc (LIME/SHAP), con sus límites de fidelidad, solo para la parte que depende de un transformer preentrenado que no puedo abrir de otro modo." !!!IMPORTANTE (NO MODIFICAR, RECORDAR POSTURA DEFINIDA)

--- a/backend/integrations/nlp/model_cards.py
+++ b/backend/integrations/nlp/model_cards.py
@@ -1,0 +1,76 @@
+"""Fichas de modelos (R3.9): divulgación de los modelos/señales del sistema.
+
+Fuente única, consultable en runtime vía la tool ``describe_models`` y
+forward-compatible con un futuro frontend. El campo ``type`` enlaza con R3.8:
+marca qué señales son white-box (``interpretable``) frente a caja negra
+(``opaco``), pasando por las ``híbrido`` (decisión transparente, feature opaca).
+
+La otra mitad de R3.9 (intercambiar modelos por configuración) la cubre la
+factoría ``get_nlp_backend`` vía el setting ``nlp_backend`` (remote/local).
+"""
+
+MODEL_CARDS = [
+    {
+        "signal": "detect_clickbait (zero-shot)",
+        "name": "facebook/bart-large-mnli",
+        "task": "Clasifica el titular como clickbait vs factual por inferencia natural (NLI, zero-shot).",
+        "type": "opaco",
+        "limitations": [
+            "Modelo genérico de NLI, no entrenado específicamente en clickbait.",
+            "Caja negra: sin explicación intrínseca (post-hoc opcional, R3.11).",
+            "Solo inglés.",
+            "En backend remoto (HF): sujeto a timeouts/caídas del proveedor.",
+        ],
+        "backend": "remote | local",
+    },
+    {
+        "signal": "analyze_sentiment",
+        "name": "cardiffnlp/twitter-roberta-base-sentiment-latest",
+        "task": "Análisis de sentimiento en 3 clases (positivo / neutral / negativo).",
+        "type": "opaco",
+        "limitations": [
+            "Entrenado en tuits, no en titulares de noticias.",
+            "Caja negra.",
+            "Solo inglés.",
+        ],
+        "backend": "remote | local",
+    },
+    {
+        "signal": "detect_clickbait_incoherence",
+        "name": "sentence-transformers/all-MiniLM-L6-v2",
+        "task": "Similitud coseno titular↔contenido; una similitud baja indica posible clickbait por incoherencia.",
+        "type": "híbrido",
+        "limitations": [
+            "Decisión transparente (umbral sobre la similitud) pero feature opaca (embeddings).",
+            "Umbral (0.3) sin calibrar.",
+            "Necesita el cuerpo/teaser, no solo el titular.",
+            "Solo inglés.",
+        ],
+        "backend": "local",
+    },
+    {
+        "signal": "detect_clickbait_lexical",
+        "name": "Léxico por reglas (listas de cues de Chakraborty et al. 2016)",
+        "task": "Detecta pistas léxicas/estructurales de clickbait y devuelve qué cues dispararon y dónde.",
+        "type": "interpretable",
+        "limitations": [
+            "Capta clickbait de forma/estilo, no de engaño semántico.",
+            "THRESHOLD=1 agresivo (un solo cue ya lo marca).",
+            "Superficial: no entiende el significado.",
+            "Solo inglés.",
+        ],
+        "backend": "local",
+    },
+    {
+        "signal": "detect_clickbait_linear",
+        "name": "Regresión logística sobre features léxicas (entrenada en Chakraborty)",
+        "task": "Clickbait ponderado: aprende el peso de cada pista y devuelve los cues que más contribuyeron al veredicto.",
+        "type": "interpretable",
+        "limitations": [
+            "Entrenado en titulares de noticias en inglés (Chakraborty); los pesos por-cue pueden no generalizar a otros dominios.",
+            "No capta engaño semántico (usa las mismas pistas de superficie que el léxico).",
+            "Solo inglés.",
+        ],
+        "backend": "local",
+    },
+]

--- a/backend/integrations/nlp/tool.py
+++ b/backend/integrations/nlp/tool.py
@@ -6,7 +6,7 @@ import json
 
 from mcp.server.fastmcp import FastMCP
 from backend.core.observability import log_tool_invocation
-from backend.integrations.nlp import lexical, linear
+from backend.integrations.nlp import lexical, linear, model_cards
 from backend.integrations.nlp.factory import get_nlp_backend
 from backend.integrations.nlp.incoherence import IncoherenceDetector
 
@@ -138,3 +138,19 @@ def register(mcp: FastMCP):
         if not response.has_content():
             return response.error or "Error al predecir clickbait en el titular"
         return json.dumps(response.data)
+
+    @mcp.tool()
+    @log_tool_invocation
+    async def describe_models() -> str:
+        """Divulga los modelos/señales que emplea el sistema (transparencia, R3.9).
+
+        Devuelve, por cada señal, su nombre, tarea, tipo (interpretable /
+        híbrido / opaco) y limitaciones conocidas. Sin argumentos. Útil para la
+        transparencia de sistema y para decidir qué señal usar según su
+        naturaleza (white-box vs caja negra) y sus límites.
+
+        Returns:
+            JSON con la lista de fichas de modelo (name, task, type,
+            limitations, backend).
+        """
+        return json.dumps(model_cards.MODEL_CARDS)

--- a/tests/integrations/test_nlp.py
+++ b/tests/integrations/test_nlp.py
@@ -5,7 +5,7 @@ import pytest
 import respx  # Usamos en vez de htttp, ya que no hacemos llamadas de verdad, mockeamos
 from httpx import Response, TimeoutException
 
-from backend.integrations.nlp import lexical, linear
+from backend.integrations.nlp import lexical, linear, model_cards
 from backend.integrations.nlp.client import HFClient
 from backend.integrations.nlp.incoherence import IncoherenceDetector
 from backend.integrations.nlp.local import LocalNLPClient
@@ -139,6 +139,8 @@ async def test_classify_local(monkeypatch):
     # lambda se usa porque get pipeline tambien devuelve un callable (pipe)
 
     # Basicamente modifica _get_pipeline para que devuelva un callable (fake_pipe)
+
+    # Proxy
 
     result = await client.classify("great movie", model)
     assert result.success
@@ -452,3 +454,23 @@ def test_linear_detector_no_headline():
     result1 = linear.predict(" ")
     result2 = linear.predict("")
     assert not result1.success and not result2.success
+
+
+# --Model cards (R3.9, divulgación de modelos)
+
+
+def test_model_cards_wellformed():
+    required = {"signal", "name", "task", "type", "limitations", "backend"}
+    valid_types = {"interpretable", "híbrido", "opaco"}
+    assert isinstance(model_cards.MODEL_CARDS, list) and model_cards.MODEL_CARDS
+    for card in model_cards.MODEL_CARDS:
+        assert required <= card.keys()
+        assert card["type"] in valid_types
+        assert isinstance(card["limitations"], list) and card["limitations"]
+
+
+def test_model_cards_serializable_and_cover_signals():
+    # La tool describe_models hace json.dumps → debe serializar sin error.
+    dumped = json.dumps(model_cards.MODEL_CARDS)
+    for name in ["facebook/bart-large-mnli", "all-MiniLM-L6-v2"]:
+        assert name in dumped


### PR DESCRIPTION
Close #71

Divulgación de modelos consultable en runtime (R3.9): model_cards.py como fuente única (name/task/type/limitations/backend por señal) y tool MCP describe_models que la sirve. El campo type (interpretable/híbrido/opaco) enlaza con R3.8. La otra mitad de R3.9 (intercambiar por config) ya la cubría la factoría nlp_backend. Tests deterministas (56 passed). Cierra el alcance obligatorio (DEBERÁ) de la Épica 5.