### PR TITLE
docs: validación del agente conversacional y tolerancia a narración vacía (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,6 +824,68 @@ El diseño del prototipo destapó que los requisitos describían una interfaz de
 - **R6 ampliado** — dos vías de entrada; estado de los servidores conectados; renderizado del resultado estructurado y la traza.
 - **Glosario** — `Agent_Orchestrator`, `LLM_Backend`.
 
+### Spike: validación del *tool calling* con un modelo local (#82)
+
+Todo el diseño del asistente descansaba sobre un supuesto sin verificar: **que un modelo pequeño servido en local decide bien qué herramienta invocar**. Antes de construir nada encima se comprueba, porque el resultado determina la arquitectura: si el modelo no elige bien, el chat pasa a **modo guiado** (R13.8) y el backend decide las herramientas. Scripts reproducibles en [`spikes/`](spikes/).
+
+Modelo: `qwen3.5:2b` (2.3B, Q8_0) con Ollama. Se prueban las **descripciones reales** de los docstrings y el catálogo completo, incluidas las **cuatro herramientas de clickbait con nombres casi idénticos**.
+
+**Diseño de la medición:** las consultas se separan por tipo, porque promediarlas daría una cifra sin sentido — en las *genéricas* («¿es clickbait?») vale cualquier detector, mientras que en las *específicas* solo una es correcta. Son estas últimas las que revelan si el modelo confunde herramientas parecidas.
+
+| Categoría | Acierto |
+|---|---|
+| Genérica (cualquier detector vale) | 4/4 |
+| **Específica (solo una correcta)** | **8/8** |
+| Otro dominio (noticias, modelos) | 3/3 |
+| Sin herramienta (no debe llamar) | 5/5 |
+| **Global** | **20/20 (100 %)** · parámetros válidos 15/15 |
+
+**Lectura:** el modelo discrimina entre las homónimas por el matiz de la petición — «qué pistas léxicas **y dónde**» → `detect_clickbait_lexical`; «dame la **probabilidad**» → `detect_clickbait_linear`. Esa distinción solo puede venir de las descripciones, lo que confirma la premisa de **R13.2**: los *docstrings* son la interfaz con el modelo, y añadir una herramienta no obliga a tocar el agente.
+
+**Modo de fallo detectado (Fase 1):** ante una consulta que debía invocar la herramienta, el modelo **redactó él mismo el análisis** en lugar de llamarla. No admitió no poder: fingió el resultado. Es la justificación empírica de **R13.4** — el veredicto debe proceder de las tools, nunca del modelo.
+
+**La latencia fue el criterio conflictivo, y reveló un problema de infraestructura.** La primera tanda dio **71,7 s de media**: Ollama nunca llegaba a usar la GPU, por dos causas encadenadas —el directorio `cuda_v12` con permisos `700` de root, y por debajo librerías CUDA corruptas (`ldd` → SIGBUS)—, probablemente por una instalación que agotó el espacio en disco. El modelo se cargaba con `offloaded 0/N layers to GPU` **independientemente de su tamaño**: reducirlo de 4B a 2B no cambiaba nada. Reinstalando Ollama se recuperó la GPU (`library=CUDA compute=7.5`, reparto parcial de 17/26 capas por los 3,2 GiB disponibles).
+
+| | CPU | **GPU** |
+|---|---|---|
+| Acierto global | 20/20 | **20/20** |
+| Parámetros válidos | 15/15 | **15/15** |
+| Latencia media | 71,7 s | **20,6 s** |
+
+**El acierto es idéntico en ambas tandas** — buen control experimental: la calidad de la decisión depende del modelo, no del hardware, que solo mueve la latencia; y el resultado se reproduce en dos ejecuciones independientes.
+
+La media, además, engañaba. Excluyendo la primera consulta —150,6 s de **carga en frío**, coste único al montar 2,7 GB de pesos—, la **mediana es de 8,8 s**. Los picos de 30-50 s corresponden a respuestas donde el modelo redacta párrafos explicativos, no a la selección de herramienta: **decidir qué tool llamar cuesta ~8-9 s**. El bucle completo del agente (decidir → ejecutar → narrar) rondará los 20-25 s, aceptable con streaming y un indicador de progreso.
+
+**Decisión:** se adopta el ***tool calling* real** (R13.1) — se cumplen los tres criterios: acierto (100 % ≫ 80 % exigido), parámetros válidos (100 %) y latencia. El **modo guiado** (R13.8) pasa de plan B probable a **degradación reservada para entornos sin GPU**: en CPU pura el mismo modelo tardaba 71,7 s de media y el chat resultaba inviable. La distinción importa porque el despliegue podría acabar siendo en CPU.
+
+**Limitaciones:** 20 consultas, un modelo, y redactadas en un registro limpio — los usuarios reales escriben peor. Es una señal sólida, no una medida definitiva.
+
+#### El bucle completo: encadena bien, pero envuelve mal los datos
+
+Las fases anteriores sólo medían la *selección*. Ejecutando las herramientas de verdad y devolviendo el resultado al modelo (`role="tool"`), el bucle **encadena correctamente**: ante «busca una noticia del NYT y dime si su titular es clickbait» llama a `get_nyt_news`, **toma el titular del resultado** y se lo pasa a los detectores.
+
+El hallazgo relevante es otro: **transcribe bien las cifras, fabrica lo que las rodea.** Los valores se reproducen con exactitud (0.9375 → «93 %»; spans `[0,4]` y `[29,32]` correctos), pero alrededor aparecen invenciones: una escala *«2/3 niveles»* que no existe, explicaciones de qué significa cada cue que ninguna herramienta ha dado, o *«una empresa llamada Researcher's Lab»* cuando el texto decía *«researchers at a small lab»*.
+
+#### ¿Puede corregirlo el prompt? (cuatro variantes)
+
+Como el prompt es configuración versionada (R13.5), comparar variantes es el experimento natural. Se probaron cuatro —cada una escrita **contra los fallos observados en la anterior**— más la ausencia de prompt como control ([`spikes/prompts/`](spikes/prompts/)).
+
+**Lo que quedó establecido:** un prompt elimina las fabricaciones obvias (sin él, siempre tablas, emojis y escalas inventadas, ~1000 caracteres por respuesta), y **las reglas dirigidas funcionan** — cada norma escrita contra un fallo concreto lo corrigió: la escala inventada, la traducción de las categorías, la fusión de posiciones, la auto-atribución («he detectado» → «el detector léxico señala»). La mejor salida obtenida es exacta punto por punto, con cada cue en su propia posición.
+
+**Lo que NO se puede afirmar: cuál prompt es mejor.** La varianza entre ejecuciones domina — una variante fue la mejor en una tanda y peor que el control en la siguiente, con el mismo prompt y las mismas consultas. Con dos consultas por variante y sin repeticiones, **no hay ranking defendible**; harían falta ~5 repeticiones por par (prompt, consulta). Los hallazgos *cualitativos* sí son fiables, porque son errores verificables contra la salida de las herramientas.
+
+**Modo de fallo nuevo:** en dos ejecuciones el modelo invocó las tres herramientas correctamente y **no generó texto final** (respuesta vacía). Ambas fueron la consulta encadenada más larga. Ningún prompt lo previene.
+
+#### Consecuencia de diseño
+
+Ningún prompt alcanza fidelidad total, y el mejor sólo **desplaza el error hacia formas más sutiles**: de inventar una escala (obvio, el usuario sospecha) a fundir dos posiciones en un rango (discreto, suena preciso y es falso). Un error sutil es *más* peligroso que uno llamativo.
+
+Esto convierte las **tarjetas renderizadas desde el JSON de la herramienta** de buena práctica en **necesidad demostrada**, por tres vías independientes: el modelo *inventa* contexto alrededor de datos correctos; a veces *no responde* —y la tarjeta sigue mostrando el análisis aunque falle la narración—; y un detector automático de alucinaciones **siempre va por detrás** (el escrito aquí buscaba escalas «/3» y «/5» y no vio un «2/1» posterior, y no puede detectar un dato correcto mal atribuido, porque el número sí está en la salida). **R13.3 y R13.4 quedan demostrados, no supuestos.**
+
+De aquí sale también un **requisito nuevo, R6.13**: si la narración llega vacía o ilegible, la interfaz debe mostrar igualmente los resultados estructurados —con un aviso discreto de que no hubo resumen— y no condicionar la visualización del análisis a que esa narración exista. No es una precaución hipotética: el análisis se había completado con éxito y sólo faltaba la prosa; mostrar «la respuesta del asistente» habría dejado una pantalla en blanco y tirado un resultado válido.
+
+**Cierre:** se adopta `04-preciso` como prompt de partida —por el razonamiento de sus reglas y su mejor salida, no como «ganador medido»—, y el bucle de `tool_calling_fase3.py` queda como esqueleto del agente real: acepta el prompt de sistema como parámetro, mantiene el historial, ejecuta herramientas y corta a las seis vueltas.
+
 
 
 "Aplico Rudin donde puedo —incoherencia(A MEDIAS, YA QUE EL MODELO NO) y léxico son intrínsecamente interpretables— y reservo lo post-hoc (LIME/SHAP), con sus límites de fidelidad, solo para la parte que depende de un transformer preentrenado que no puedo abrir de otro modo." !!!IMPORTANTE (NO MODIFICAR, RECORDAR POSTURA DEFINIDA)

--- a/docs/requisitos.md
+++ b/docs/requisitos.md
@@ -117,6 +117,7 @@ Este documento define los requisitos para un Trabajo de Fin de Grado (TFG) que i
 10. LA Web_Interface DEBERÁ ofrecer **dos vías de entrada**: un formulario de análisis directo (determinista) y un **asistente conversacional** (ver Requisito 13).
 11. LA Web_Interface DEBERÁ mostrar el estado de los **MCP_Server conectados** (nombre, transporte, estado y herramientas que aporta), generado dinámicamente a partir del descubrimiento; los filtros por servidor DEBERÁN derivarse de esa misma lista.
 12. CUANDO el Agent_Orchestrator invoque herramientas, LA Web_Interface DEBERÁ renderizar el **resultado estructurado de cada herramienta** —no solo la narración del modelo— junto a la **traza** de herramientas invocadas.
+13. SI la narración del modelo llega **vacía o ilegible**, ENTONCES LA Web_Interface DEBERÁ mostrar igualmente los **resultados estructurados** de las herramientas invocadas, indicando de forma discreta que el asistente no generó un resumen. LA Web_Interface NO DEBERÁ condicionar la visualización del análisis a la existencia de esa narración. _(Modo de fallo observado en el spike #82: el agente invoca correctamente las herramientas y devuelve una respuesta de cero caracteres; el análisis existe y no debe perderse.)_
 
 ### Requisito 7: Entorno de implementación de Docker
 

--- a/spikes/prompts/01-breve.md
+++ b/spikes/prompts/01-breve.md
@@ -1,0 +1,4 @@
+Eres el asistente de un sistema de análisis de clickbait. Dispones de herramientas
+para analizar titulares y buscar noticias.
+
+Responde de forma BREVE: máximo tres frases. No uses tablas, listas ni emojis.

--- a/spikes/prompts/02-completo.md
+++ b/spikes/prompts/02-completo.md
@@ -1,0 +1,37 @@
+Eres el asistente de un sistema de detección de clickbait. Tu papel es invocar las
+herramientas adecuadas y **narrar** lo que devuelven. No eres tú quien juzga.
+
+## Reglas de veracidad (las más importantes)
+
+- El veredicto y las cifras proceden SIEMPRE de las herramientas. No los estimes
+  ni los calcules por tu cuenta.
+- No añadas datos que no estén en la salida de una herramienta: ni escalas
+  («2 sobre 3»), ni interpretaciones de lo que significa cada pista, ni detalles
+  del artículo que no aparezcan en el texto recibido.
+- Si no has llamado a ninguna herramienta, di que no tienes el análisis. Nunca
+  redactes tú el análisis.
+- Si un dato no está, dilo. Es preferible a rellenarlo.
+
+## Sobre las señales
+
+Cada herramienta mide algo distinto y de naturaleza distinta:
+
+- **Léxico** (interpretable): pistas de superficie del titular. Detecta clickbait
+  de FORMA, no de engaño.
+- **Modelo lineal** (interpretable): probabilidad ponderada sobre esas mismas
+  pistas. También mide forma.
+- **Incoherencia** (híbrida): compara titular y cuerpo. Es la única que detecta
+  ENGAÑO, es decir, que el titular prometa algo que el texto no cumple.
+- **Zero-shot** (opaca): lectura semántica; no ofrece explicación de por qué.
+
+Cuando varias señales discrepen, dilo explícitamente en lugar de promediarlas: un
+titular puede ser clickbait de forma sin engañar.
+
+## Límites que debes advertir
+
+- Las herramientas están entrenadas con titulares de noticias **en inglés**. Si el
+  titular está en otro idioma, avísalo antes de analizarlo.
+
+## Estilo
+
+Breve: máximo tres frases. Sin tablas, sin listas, sin emojis.

--- a/spikes/prompts/03-estricto.md
+++ b/spikes/prompts/03-estricto.md
@@ -1,0 +1,53 @@
+Eres el asistente de un sistema de detección de clickbait. Tu papel es invocar las
+herramientas adecuadas y NARRAR lo que devuelven. No eres tú quien juzga.
+
+## Reglas de veracidad
+
+- El veredicto y las cifras proceden SIEMPRE de las herramientas. No los estimes
+  ni los calcules por tu cuenta.
+- Reproduce las cifras tal como vienen. No inventes escalas ni denominadores: si
+  una herramienta devuelve `score: 2`, escribe «2», nunca «2/3», «2/1» ni
+  «2 sobre 5».
+- Usa los nombres de categoría TAL COMO los devuelve la herramienta
+  (`forward_reference`, `hyperbole`, `leading_number`, `question`...). No los
+  traduzcas por términos de tu cosecha ni los sustituyas por sinónimos.
+- NO expliques qué significa una pista, por qué funciona ni qué efecto tiene en
+  el lector. Limítate a nombrarla y a decir dónde aparece.
+- No atribuyas un dato a la herramienta equivocada: cada cifra pertenece a la que
+  la devolvió.
+- Del artículo, menciona sólo lo que aparezca literalmente en el texto recibido.
+  No completes autores, empresas, instituciones ni fechas.
+- Si no has llamado a ninguna herramienta, di que no tienes el análisis. Nunca
+  redactes tú el análisis.
+- Si un dato no está, dilo. Es preferible a rellenarlo.
+
+## Cómo referirte a ti mismo
+
+Habla de las herramientas en tercera persona: «el detector léxico señala...»,
+«el modelo lineal da una probabilidad de...». Nunca «he detectado» ni «mi
+análisis»: el análisis no es tuyo.
+
+## Sobre las señales
+
+Cada herramienta mide algo distinto y de naturaleza distinta:
+
+- **Léxico** (interpretable): pistas de superficie del titular. Detecta clickbait
+  de FORMA, no de engaño.
+- **Modelo lineal** (interpretable): probabilidad ponderada sobre esas mismas
+  pistas. También mide forma.
+- **Incoherencia** (híbrida): compara titular y cuerpo. Es la única que detecta
+  ENGAÑO, es decir, que el titular prometa algo que el texto no cumple.
+- **Zero-shot** (opaca): lectura semántica; no ofrece explicación de por qué.
+
+Cuando varias señales discrepen, dilo explícitamente en lugar de promediarlas: un
+titular puede ser clickbait de forma sin engañar.
+
+## Límites que debes advertir
+
+Las herramientas están entrenadas con titulares de noticias en inglés. Si el
+titular está en otro idioma, avísalo antes de analizarlo.
+
+## Formato
+
+Texto corrido, máximo tres frases. Sin negritas ni asteriscos, sin encabezados,
+sin listas, sin tablas, sin emojis.

--- a/spikes/prompts/04-preciso.md
+++ b/spikes/prompts/04-preciso.md
@@ -1,0 +1,69 @@
+Eres el asistente de un sistema de detección de clickbait. Tu papel es invocar las
+herramientas adecuadas y NARRAR lo que devuelven. No eres tú quien juzga.
+
+## Reglas de veracidad
+
+- El veredicto y las cifras proceden SIEMPRE de las herramientas. No los estimes
+  ni los calcules por tu cuenta.
+- Reproduce las cifras tal como vienen. No inventes escalas ni denominadores: si
+  una herramienta devuelve `score: 2`, escribe «2», nunca «2/3», «2/1» ni
+  «2 sobre 5».
+- NO expliques qué significa una pista, por qué funciona ni qué efecto tiene en
+  el lector. Limítate a nombrarla y a decir dónde aparece.
+- No atribuyas un dato a la herramienta equivocada: cada cifra pertenece a la que
+  la devolvió.
+- Del artículo, menciona sólo lo que aparezca literalmente en el texto recibido.
+  No completes autores, empresas, instituciones ni fechas.
+- Si no has llamado a ninguna herramienta, di que no tienes el análisis. Nunca
+  redactes tú el análisis.
+
+## Precisión por encima de brevedad
+
+Es la regla que manda sobre las de formato:
+
+- **Cada pista lleva su propia posición.** Nunca agrupes varias pistas bajo un
+  mismo rango: si «this» está en [0,4] y «you» en [29,32], no digas que ambas
+  «aparecen entre 0-4».
+- **Si no cabe todo, menciona menos pistas — nunca comprimas varias en una.**
+  Es preferible citar una sola pista con su posición exacta que citar tres con
+  los datos fundidos.
+- **Si no puedes dar un dato con exactitud, omítelo.** Un dato ausente es
+  aceptable; uno aproximado o fusionado, no.
+
+## Nombres de las categorías
+
+Escribe los nombres de categoría exactamente como los devuelve la herramienta y
+en su forma original: `forward_reference`, `hyperbole`, `leading_number`,
+`question`, `all_caps`, `ellipsis`. No los traduzcas ni busques equivalentes en
+castellano. Si prefieres no usarlos, describe la pista sin nombrar la categoría.
+
+## Cómo referirte a ti mismo
+
+Habla de las herramientas en tercera persona: «el detector léxico señala...»,
+«el modelo lineal da una probabilidad de...». Nunca «he detectado» ni «mi
+análisis»: el análisis no es tuyo.
+
+## Sobre las señales
+
+Cada herramienta mide algo distinto y de naturaleza distinta:
+
+- Léxico (interpretable): pistas de superficie del titular. Detecta clickbait de
+  FORMA, no de engaño.
+- Modelo lineal (interpretable): probabilidad ponderada sobre esas mismas pistas.
+  También mide forma.
+- Incoherencia (híbrida): compara titular y cuerpo. Es la única que detecta
+  ENGAÑO, es decir, que el titular prometa algo que el texto no cumple.
+- Zero-shot (opaca): lectura semántica; no ofrece explicación de por qué.
+
+Cuando varias señales discrepen, dilo explícitamente en lugar de promediarlas: un
+titular puede ser clickbait de forma sin engañar.
+
+## Límites que debes advertir
+
+Las herramientas están entrenadas con titulares de noticias en inglés. Si el
+titular está en otro idioma, avísalo antes de analizarlo.
+
+## Formato
+
+Texto corrido, máximo cuatro frases. Sin negritas ni asteriscos, sin
+encabezados, sin listas, sin tablas, sin emojis.

--- a/spikes/tool_calling_fase1.py
+++ b/spikes/tool_calling_fase1.py
@@ -1,0 +1,146 @@
+"""Spike #82 - Fase 1: ¿el modelo local hace tool calling?
+
+Prueba MÍNIMA: una sola herramienta y un esquema simple. Es el filtro de entrada:
+si el modelo no llama bien a UNA tool, no tiene sentido medir las fases 2 y 3.
+
+Se comprueban dos cosas opuestas, porque fallar en cualquiera invalida al modelo:
+  1. Que LLAME a la herramienta cuando hace falta.
+  2. Que NO la llame cuando la pregunta no la necesita (los modelos pequeños
+     tienden a invocar tools por inercia en cuanto se les ofrece una).
+
+Requisitos: `ollama serve` en marcha y el modelo descargado.
+Ejecutar:   python spikes/tool_calling_fase1.py [modelo]
+
+El modelo se pasa por argumento porque comparar tamaños ES el objetivo: en una
+GPU de 4 GB, un modelo que no quepa se ejecuta 100% en CPU y la latencia lo hace
+inservible (comprobado con qwen3.5:4b -> 5.4 GiB -> 0/33 capas en GPU).
+"""
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+OLLAMA_URL = "http://localhost:11434/api/chat"
+MODEL = sys.argv[1] if len(sys.argv) > 1 else "qwen3.5:2b"
+
+# La caché KV crece con el contexto y compite con los pesos por la VRAM. En una
+# GPU de 4 GB es la palanca más barata para que el modelo quepa: con num_ctx=4096
+# hacen falta ~3.8 GiB (no cabe -> 100% CPU -> ~64 s por respuesta).
+NUM_CTX = int(sys.argv[2]) if len(sys.argv) > 2 else 2048
+
+# Esquema de la herramienta en el formato que espera Ollama (estilo OpenAI).
+# OJO: en el sistema real esto NO se escribe a mano — FastMCP lo genera a partir
+# del docstring + los type hints, y el agente lo recibe por MCP (tools/list).
+# Aquí se replica el texto real de `detect_clickbait_lexical` para que el spike
+# mida el comportamiento del modelo con NUESTRAS descripciones, no con un ejemplo
+# de juguete.
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "detect_clickbait_lexical",
+            "description": (
+                "Detecta clickbait por pistas léxicas y estructurales del titular "
+                "(hipérbole, referencias vagas, número inicial, interrogación, "
+                "mayúsculas, elipsis) y devuelve qué pistas dispararon y dónde. "
+                "Pensada para titulares en inglés."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "headline": {
+                        "type": "string",
+                        "description": "Titular a evaluar (en inglés).",
+                    }
+                },
+                "required": ["headline"],
+            },
+        },
+    }
+]
+
+# (consulta, ¿debería llamar a la tool?)
+PRUEBAS = [
+    ("¿Es clickbait este titular? '10 Amazing Things You Won't Believe'", True),
+    ("Analiza: 'Spain wins the 2026 World Cup'", True),
+    ("¿Qué es el clickbait? Explícamelo en dos frases.", False),
+    ("Hola, ¿qué tal?", False),
+]
+
+
+def chat(messages, tools=None, timeout=300):
+    """Una llamada a /api/chat. Devuelve (respuesta, segundos).
+
+    stream=False para recibir la respuesta completa de una vez; en el backend
+    real interesará streaming, pero aquí sólo se mide comportamiento.
+    """
+    payload = {
+        "model": MODEL,
+        "messages": messages,
+        "stream": False,
+        "options": {"num_ctx": NUM_CTX},
+    }
+    if tools:
+        payload["tools"] = tools
+
+    request = urllib.request.Request(
+        OLLAMA_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    inicio = time.perf_counter()
+    with urllib.request.urlopen(request, timeout=timeout) as respuesta:
+        datos = json.loads(respuesta.read())
+    return datos, time.perf_counter() - inicio
+
+
+def _resumen_llamadas(mensaje):
+    """Extrae las tool_calls de la respuesta -> lista de (nombre, argumentos)."""
+    llamadas = []
+    for llamada in mensaje.get("tool_calls") or []:
+        funcion = llamada.get("function", {})
+        llamadas.append((funcion.get("name"), funcion.get("arguments")))
+    return llamadas
+
+
+if __name__ == "__main__":
+    print(f"Modelo: {MODEL} | num_ctx: {NUM_CTX}\n")
+
+    aciertos = 0
+    latencias = []
+
+    for consulta, espera_llamada in PRUEBAS:
+        try:
+            datos, segundos = chat([{"role": "user", "content": consulta}], TOOLS)
+        except urllib.error.URLError as error:
+            print(f"ERROR de conexión con Ollama: {error}")
+            print("¿Está corriendo `ollama serve`?")
+            raise SystemExit(1)
+
+        mensaje = datos.get("message", {})
+        llamadas = _resumen_llamadas(mensaje)
+        latencias.append(segundos)
+
+        llamo = bool(llamadas)
+        correcto = llamo == espera_llamada
+        aciertos += correcto
+
+        print(f"[{'OK ' if correcto else 'MAL'}] {consulta}")
+        print(f"      esperado: {'llamar' if espera_llamada else 'NO llamar':10s}"
+              f" | obtenido: {'llamó' if llamo else 'no llamó':10s} | {segundos:5.1f}s")
+        for nombre, argumentos in llamadas:
+            print(f"      -> {nombre}({argumentos})")
+        if not llamo:
+            texto = (mensaje.get("content") or "").strip().replace("\n", " ")
+            print(f"      texto: {texto[:110]}...")
+        print()
+
+    total = len(PRUEBAS)
+    print(f"Aciertos de decisión: {aciertos}/{total}")
+    print(f"Latencia media: {sum(latencias)/len(latencias):.1f}s "
+          f"(min {min(latencias):.1f}s, max {max(latencias):.1f}s)")
+    print()
+    print("Criterio de la Fase 1: si no llama cuando debe, o llama siempre,")
+    print("el modelo no sirve para tool calling -> plan B (modo guiado, R13.8).")

--- a/spikes/tool_calling_fase2.py
+++ b/spikes/tool_calling_fase2.py
@@ -1,0 +1,268 @@
+"""Spike #82 - Fase 2: ¿elige BIEN la herramienta entre varias parecidas?
+
+La Fase 1 probó que el mecanismo funciona con una sola tool. Aquí está el dato
+que decide el issue: con el catálogo real -donde hay cuatro herramientas de
+clickbait con nombres casi idénticos- ¿acierta el modelo?
+
+DISEÑO: no todas las consultas tienen una única respuesta correcta.
+  - GENÉRICA  ("¿es clickbait?")        -> cualquier tool de clickbait vale.
+  - ESPECÍFICA ("¿qué pistas léxicas?") -> solo vale una; aquí se ve la confusión.
+  - OTRO_DOMINIO                        -> comprueba que no se queda en clickbait.
+  - SIN_TOOL                            -> comprueba que no invoca por inercia.
+Mezclar genéricas y específicas en una sola cifra daría un número sin sentido,
+así que se reportan por separado.
+
+Las descripciones de las tools son las REALES (docstrings de tool.py), porque lo
+que se mide es si el modelo sabe distinguirlas con los textos que tendrá en
+producción. En el sistema final las genera FastMCP y llegan por MCP tools/list.
+
+Ejecutar: python spikes/tool_calling_fase2.py [modelo] [num_ctx]
+"""
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import Counter
+
+import os
+
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "127.0.0.1:11434")
+OLLAMA_URL = f"http://{OLLAMA_HOST}/api/chat"
+MODEL = sys.argv[1] if len(sys.argv) > 1 else "qwen3.5:2b"
+NUM_CTX = int(sys.argv[2]) if len(sys.argv) > 2 else 2048
+
+
+def _tool(nombre, descripcion, propiedades, obligatorios):
+    return {
+        "type": "function",
+        "function": {
+            "name": nombre,
+            "description": descripcion,
+            "parameters": {
+                "type": "object",
+                "properties": propiedades,
+                "required": obligatorios,
+            },
+        },
+    }
+
+
+_HEADLINE = {"headline": {"type": "string", "description": "Titular a evaluar (en inglés)."}}
+
+TOOLS = [
+    _tool(
+        "detect_clickbait",
+        "Detecta si un titular de noticia es clickbait o informativo (factual) usando "
+        "clasificación zero-shot. Devuelve la etiqueta ganadora y su confianza.",
+        _HEADLINE, ["headline"],
+    ),
+    _tool(
+        "detect_clickbait_lexical",
+        "Detecta clickbait por pistas léxicas y estructurales del titular: hipérbole, "
+        "referencias vagas (this/these), número inicial (listicle), interrogación, "
+        "mayúsculas, elipsis. Devuelve QUÉ pistas dispararon y DÓNDE.",
+        _HEADLINE, ["headline"],
+    ),
+    _tool(
+        "detect_clickbait_linear",
+        "Detecta clickbait con un modelo lineal entrenado (regresión logística sobre "
+        "pistas léxicas). Devuelve la PROBABILIDAD de clickbait y los cues que más "
+        "contribuyeron al veredicto con su peso.",
+        _HEADLINE, ["headline"],
+    ),
+    _tool(
+        "detect_clickbait_incoherence",
+        "Detecta clickbait midiendo la INCOHERENCIA entre el titular y el cuerpo de la "
+        "noticia mediante similitud semántica. Requiere ambos textos: una similitud baja "
+        "indica que el titular no se corresponde con lo que cuenta la noticia.",
+        {
+            "headline": _HEADLINE["headline"],
+            "content": {"type": "string", "description": "Cuerpo o teaser con el que contrastar."},
+        },
+        ["headline", "content"],
+    ),
+    _tool(
+        "analyze_sentiment",
+        "Analiza el sentimiento de un texto y lo clasifica como positive, neutral o "
+        "negative, con su confianza.",
+        {"text": {"type": "string", "description": "Texto a analizar (en inglés)."}},
+        ["text"],
+    ),
+    _tool(
+        "get_nyt_news",
+        "Busca noticias del New York Times sobre un tema, de los últimos días.",
+        {
+            "topic": {"type": "string", "description": "Tema a buscar."},
+            "days": {"type": "integer", "description": "Días hacia atrás (por defecto 7)."},
+        },
+        [],
+    ),
+    _tool(
+        "get_guardian_news",
+        "Busca noticias de The Guardian sobre un tema, de los últimos días.",
+        {
+            "topic": {"type": "string", "description": "Tema a buscar."},
+            "days": {"type": "integer", "description": "Días hacia atrás (por defecto 7)."},
+        },
+        [],
+    ),
+    _tool(
+        "describe_models",
+        "Divulga los modelos que emplea el sistema: nombre, tarea, tipo (interpretable, "
+        "híbrido u opaco) y limitaciones conocidas. No recibe argumentos.",
+        {}, [],
+    ),
+]
+
+CLICKBAIT_CUALQUIERA = {
+    "detect_clickbait", "detect_clickbait_lexical", "detect_clickbait_linear",
+}
+
+# (categoría, consulta, herramientas aceptables)  -- conjunto vacío = no debe llamar
+PRUEBAS = [
+    ("GENERICA", "¿Es clickbait este titular? '10 Amazing Things You Won't Believe'", CLICKBAIT_CUALQUIERA),
+    ("GENERICA", "Analiza si esto es clickbait: 'Scientists Discover New Species'", CLICKBAIT_CUALQUIERA),
+    ("GENERICA", "'You Won't Believe What Happened Next' — ¿es un titular engañoso?", CLICKBAIT_CUALQUIERA),
+    ("GENERICA", "Evalúa este titular: 'Top 5 Secrets Finally Revealed'", CLICKBAIT_CUALQUIERA),
+
+    ("ESPECIFICA", "¿Qué pistas léxicas dispara el titular 'Amazing Things You Need'?", {"detect_clickbait_lexical"}),
+    ("ESPECIFICA", "Muéstrame qué cues concretos aparecen en '10 Best Tips Ever' y dónde", {"detect_clickbait_lexical"}),
+    ("ESPECIFICA", "Dame la probabilidad de clickbait de 'This Simple Trick Will Shock You'", {"detect_clickbait_linear"}),
+    ("ESPECIFICA", "Usa el modelo entrenado para puntuar 'Doctors Hate This One Trick'", {"detect_clickbait_linear"}),
+    ("ESPECIFICA", "¿El titular 'Cure Found' concuerda con el cuerpo 'Researchers report early-stage results in mice'?", {"detect_clickbait_incoherence"}),
+    ("ESPECIFICA", "Compara titular y contenido: titular 'Miracle Diet Works', cuerpo 'A small study shows modest effects'", {"detect_clickbait_incoherence"}),
+    ("ESPECIFICA", "¿Qué sentimiento transmite 'This is the worst day ever'?", {"analyze_sentiment"}),
+    ("ESPECIFICA", "Analiza el tono emocional de 'A wonderful celebration took place'", {"analyze_sentiment"}),
+
+    ("OTRO_DOMINIO", "Dame noticias del New York Times sobre inteligencia artificial", {"get_nyt_news"}),
+    ("OTRO_DOMINIO", "¿Qué ha publicado The Guardian sobre cambio climático?", {"get_guardian_news"}),
+    ("OTRO_DOMINIO", "¿Qué modelos usas y qué limitaciones tienen?", {"describe_models"}),
+
+    ("SIN_TOOL", "¿Qué es el clickbait? Explícamelo en dos frases.", set()),
+    ("SIN_TOOL", "Hola, ¿qué tal?", set()),
+    ("SIN_TOOL", "Explícame cómo funciona una regresión logística", set()),
+    ("SIN_TOOL", "¿Por qué es difícil detectar clickbait en español?", set()),
+    ("SIN_TOOL", "Gracias, hasta luego", set()),
+]
+
+# Parámetros obligatorios por herramienta, para validar los argumentos.
+OBLIGATORIOS = {
+    t["function"]["name"]: set(t["function"]["parameters"]["required"]) for t in TOOLS
+}
+
+
+def chat(messages, tools=None, timeout=600):
+    payload = {
+        "model": MODEL,
+        "messages": messages,
+        "stream": False,
+        "options": {"num_ctx": NUM_CTX},
+    }
+    if tools:
+        payload["tools"] = tools
+    request = urllib.request.Request(
+        OLLAMA_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    inicio = time.perf_counter()
+    with urllib.request.urlopen(request, timeout=timeout) as respuesta:
+        datos = json.loads(respuesta.read())
+    return datos, time.perf_counter() - inicio
+
+
+def parametros_validos(nombre, argumentos):
+    """¿Respeta el esquema? Requiere que estén los obligatorios y no vengan vacíos."""
+    if nombre not in OBLIGATORIOS:
+        return False, "herramienta inexistente"
+    if not isinstance(argumentos, dict):
+        return False, "argumentos no son un objeto"
+    faltan = OBLIGATORIOS[nombre] - set(argumentos)
+    if faltan:
+        return False, f"faltan {sorted(faltan)}"
+    vacios = [k for k in OBLIGATORIOS[nombre] if not str(argumentos.get(k, "")).strip()]
+    if vacios:
+        return False, f"vacíos {vacios}"
+    return True, ""
+
+
+if __name__ == "__main__":
+    print(f"Modelo: {MODEL} | num_ctx: {NUM_CTX} | host: {OLLAMA_HOST} | "
+          f"{len(TOOLS)} herramientas | {len(PRUEBAS)} consultas\n")
+
+    por_categoria = Counter()
+    aciertos_categoria = Counter()
+    latencias = []
+    params_ok = params_total = 0
+    confusiones = Counter()
+
+    for categoria, consulta, aceptables in PRUEBAS:
+        try:
+            datos, segundos = chat([{"role": "user", "content": consulta}], TOOLS)
+        except urllib.error.URLError as error:
+            print(f"ERROR de conexión: {error} — ¿está `ollama serve` en marcha?")
+            raise SystemExit(1)
+
+        mensaje = datos.get("message", {})
+        llamadas = [
+            (c.get("function", {}).get("name"), c.get("function", {}).get("arguments"))
+            for c in (mensaje.get("tool_calls") or [])
+        ]
+        latencias.append(segundos)
+        por_categoria[categoria] += 1
+
+        elegidas = {n for n, _ in llamadas}
+        if aceptables:
+            correcto = bool(elegidas & aceptables)
+        else:
+            correcto = not elegidas
+        aciertos_categoria[categoria] += correcto
+
+        if not correcto and elegidas:
+            for elegida in elegidas:
+                confusiones[f"{sorted(aceptables)[0] if aceptables else 'ninguna'} -> {elegida}"] += 1
+
+        for nombre, argumentos in llamadas:
+            params_total += 1
+            ok, _ = parametros_validos(nombre, argumentos)
+            params_ok += ok
+
+        marca = "OK " if correcto else "MAL"
+        print(f"[{marca}] ({categoria}) {consulta[:72]}")
+        if llamadas:
+            for nombre, argumentos in llamadas:
+                ok, motivo = parametros_validos(nombre, argumentos)
+                aviso = "" if ok else f"   <-- PARÁMETROS: {motivo}"
+                print(f"        -> {nombre}({json.dumps(argumentos, ensure_ascii=False)[:80]}){aviso}")
+        else:
+            print("        -> (sin llamada)")
+        if not correcto:
+            esperado = ", ".join(sorted(aceptables)) if aceptables else "NINGUNA"
+            print(f"        esperado: {esperado}")
+        print(f"        {segundos:.1f}s")
+
+    print("\n" + "=" * 70)
+    print("RESULTADOS")
+    print("=" * 70)
+    for categoria in ("GENERICA", "ESPECIFICA", "OTRO_DOMINIO", "SIN_TOOL"):
+        total = por_categoria[categoria]
+        if total:
+            aciertos = aciertos_categoria[categoria]
+            print(f"  {categoria:14s} {aciertos:2d}/{total:2d}  ({aciertos/total:5.0%})")
+    total_global = sum(por_categoria.values())
+    aciertos_global = sum(aciertos_categoria.values())
+    print(f"  {'GLOBAL':14s} {aciertos_global:2d}/{total_global:2d}  ({aciertos_global/total_global:5.0%})")
+    print()
+    if params_total:
+        print(f"  Parámetros válidos: {params_ok}/{params_total} ({params_ok/params_total:.0%})")
+    print(f"  Latencia: media {sum(latencias)/len(latencias):.1f}s | "
+          f"min {min(latencias):.1f}s | max {max(latencias):.1f}s")
+    if confusiones:
+        print("\n  Confusiones más frecuentes (esperada -> elegida):")
+        for par, veces in confusiones.most_common(5):
+            print(f"    {veces}x  {par}")
+    print()
+    print("  Criterio #82: acierto >= 80% y parámetros válidos casi siempre")
+    print("  -> tool calling real. Por debajo -> modo guiado (R13.8).")

--- a/spikes/tool_calling_fase3.py
+++ b/spikes/tool_calling_fase3.py
@@ -1,0 +1,197 @@
+"""Spike #82 - Fase 3: el bucle completo del agente (encadenamiento).
+
+Las fases 1 y 2 sólo medían SI el modelo elige bien la herramienta. Nunca se
+ejecutó una tool ni se le devolvió el resultado. Aquí se prueba el bucle entero,
+que es lo que hará el chat en producción:
+
+    consulta -> el modelo pide una tool -> SE EJECUTA de verdad
+             -> se le devuelve el resultado (role="tool")
+             -> el modelo lo usa y responde, o pide otra tool
+
+Lo que se quiere ver:
+  - ¿Encadena? (usar la salida de una tool como entrada de la siguiente)
+  - ¿USA los datos devueltos, o los ignora / se los inventa?  <- clave para R13.4
+  - ¿Cuántas vueltas y cuánto tiempo cuesta una respuesta completa?
+
+Las herramientas locales (léxico, lineal) se ejecutan REALES. La de noticias se
+simula con un artículo fijo: así el experimento es determinista y no depende de
+claves de API ni de la disponibilidad del NYT.
+
+Ejecutar: OLLAMA_HOST=127.0.0.1:11435 python spikes/tool_calling_fase3.py [modelo]
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+# El spike vive fuera de los paquetes del proyecto; se añade la raíz al path
+# para poder ejecutar las herramientas reales sin convertir spikes/ en paquete.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from backend.integrations.nlp import lexical, linear  # noqa: E402
+
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "127.0.0.1:11434")
+OLLAMA_URL = f"http://{OLLAMA_HOST}/api/chat"
+MODEL = sys.argv[1] if len(sys.argv) > 1 else "qwen3.5:2b"
+NUM_CTX = int(sys.argv[2]) if len(sys.argv) > 2 else 4096  # el bucle acumula contexto
+MAX_VUELTAS = 6  # cortafuegos: un agente que no converge no debe girar sin fin
+
+# Artículo fijo que devuelve la tool de noticias simulada. El titular es
+# deliberadamente sensacionalista para que el análisis posterior tenga sustancia.
+ARTICULO = {
+    "title": "This One AI Trick Will Completely Change Your Job Forever",
+    "content": (
+        "Researchers at a small lab published a preprint describing modest "
+        "productivity gains when using an AI assistant for routine coding tasks. "
+        "The study covered 40 participants over two weeks."
+    ),
+    "url": "https://www.nytimes.com/example",
+    "date": "2026-08-01",
+}
+
+
+def _tool(nombre, descripcion, propiedades, obligatorios):
+    return {
+        "type": "function",
+        "function": {
+            "name": nombre,
+            "description": descripcion,
+            "parameters": {
+                "type": "object",
+                "properties": propiedades,
+                "required": obligatorios,
+            },
+        },
+    }
+
+
+_HEADLINE = {"headline": {"type": "string", "description": "Titular a evaluar (en inglés)."}}
+
+TOOLS = [
+    _tool(
+        "get_nyt_news",
+        "Busca noticias del New York Times sobre un tema. Devuelve el titular, el "
+        "contenido y la fecha de cada artículo.",
+        {"topic": {"type": "string", "description": "Tema a buscar."}},
+        ["topic"],
+    ),
+    _tool(
+        "detect_clickbait_lexical",
+        "Detecta clickbait por pistas léxicas y estructurales del titular: hipérbole, "
+        "referencias vagas, número inicial, interrogación, mayúsculas, elipsis. "
+        "Devuelve QUÉ pistas dispararon y DÓNDE.",
+        _HEADLINE, ["headline"],
+    ),
+    _tool(
+        "detect_clickbait_linear",
+        "Detecta clickbait con un modelo lineal entrenado. Devuelve la PROBABILIDAD "
+        "de clickbait y los cues que más contribuyeron, con su peso.",
+        _HEADLINE, ["headline"],
+    ),
+]
+
+
+def ejecutar(nombre, argumentos):
+    """Ejecuta la herramienta de verdad y devuelve su salida (dict)."""
+    argumentos = argumentos or {}
+    if nombre == "get_nyt_news":
+        return {"articles": [ARTICULO]}
+    if nombre == "detect_clickbait_lexical":
+        resultado = lexical.detect(argumentos.get("headline", ""))
+    elif nombre == "detect_clickbait_linear":
+        resultado = linear.predict(argumentos.get("headline", ""))
+    else:
+        return {"error": f"herramienta desconocida: {nombre}"}
+    return resultado.data if resultado.success else {"error": resultado.error}
+
+
+def chat(messages, tools, timeout=600):
+    payload = {
+        "model": MODEL,
+        "messages": messages,
+        "stream": False,
+        "options": {"num_ctx": NUM_CTX},
+        "tools": tools,
+    }
+    request = urllib.request.Request(
+        OLLAMA_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    inicio = time.perf_counter()
+    with urllib.request.urlopen(request, timeout=timeout) as respuesta:
+        return json.loads(respuesta.read()), time.perf_counter() - inicio
+
+
+def bucle_agente(consulta, sistema=None):
+    """El bucle de tool calling. Este es, en esencia, el agente real.
+
+    `sistema` es el prompt de sistema (R13.5): se pasa como primer mensaje y por
+    eso puede cambiarse por configuración sin tocar el bucle.
+    """
+    mensajes = []
+    if sistema:
+        mensajes.append({"role": "system", "content": sistema})
+    mensajes.append({"role": "user", "content": consulta})
+    traza = []
+    total = 0.0
+
+    for vuelta in range(MAX_VUELTAS):
+        datos, segundos = chat(mensajes, TOOLS)
+        total += segundos
+        mensaje = datos.get("message", {})
+        mensajes.append(mensaje)
+
+        llamadas = mensaje.get("tool_calls") or []
+        if not llamadas:
+            return mensaje.get("content", ""), traza, total, vuelta + 1
+
+        for llamada in llamadas:
+            funcion = llamada.get("function", {})
+            nombre = funcion.get("name")
+            argumentos = funcion.get("arguments") or {}
+            salida = ejecutar(nombre, argumentos)
+            traza.append((nombre, argumentos, salida))
+            # Se devuelve el resultado al modelo como un mensaje de rol "tool".
+            mensajes.append({
+                "role": "tool",
+                "tool_name": nombre,
+                "content": json.dumps(salida, ensure_ascii=False)[:1500],
+            })
+
+    return "(no convergió)", traza, total, MAX_VUELTAS
+
+
+CONSULTAS = [
+    # Encadenamiento real: la salida de una tool alimenta a la siguiente.
+    "Busca una noticia del New York Times sobre inteligencia artificial y dime si su titular es clickbait.",
+    # Dos herramientas distintas sobre el mismo titular.
+    "Del titular 'This Simple Trick Will Shock You': dime qué pistas léxicas tiene y también su probabilidad según el modelo entrenado.",
+]
+
+
+if __name__ == "__main__":
+    print(f"Modelo: {MODEL} | num_ctx: {NUM_CTX} | host: {OLLAMA_HOST}\n")
+
+    for consulta in CONSULTAS:
+        print("=" * 78)
+        print(f"CONSULTA: {consulta}")
+        print("=" * 78)
+
+        respuesta, traza, segundos, vueltas = bucle_agente(consulta)
+
+        print(f"\nTRAZA ({len(traza)} llamadas, {vueltas} vueltas al modelo, {segundos:.1f}s):")
+        for i, (nombre, argumentos, salida) in enumerate(traza, 1):
+            print(f"  {i}. {nombre}({json.dumps(argumentos, ensure_ascii=False)[:90]})")
+            print(f"     -> {json.dumps(salida, ensure_ascii=False)[:150]}")
+
+        print(f"\nRESPUESTA FINAL:\n{respuesta[:900]}\n")
+
+    print("=" * 78)
+    print("A revisar a mano (no se puede automatizar):")
+    print("  - ¿Encadenó? (titular obtenido de la noticia -> pasado al detector)")
+    print("  - ¿La respuesta USA los números de las tools, o se los inventa?")
+    print("    Inventarlos confirmaría por qué el veredicto no puede salir del LLM (R13.4).")

--- a/spikes/tool_calling_fase4_prompts.py
+++ b/spikes/tool_calling_fase4_prompts.py
@@ -1,0 +1,146 @@
+"""Spike #82 - Fase 4: ¿cuánto cambia el comportamiento según el prompt de sistema?
+
+La Fase 3 destapó dos problemas con el prompt por defecto (ninguno):
+  1. Latencia alta (70-104 s por respuesta), porque el modelo redacta tablas
+     largas con emojis en cada vuelta.
+  2. Fabricación: transcribe bien los NÚMEROS de las herramientas, pero se
+     inventa lo que los rodea (una escala «2 sobre 3» inexistente, explicaciones
+     de los cues que ninguna tool ha dado, un nombre de empresa).
+
+Como el prompt es configuración versionada (R13.5), comparar variantes ES el
+experimento correcto. Se mide si el prompt puede suprimir ambos problemas.
+
+Variantes en spikes/prompts/. La ausencia de prompt es el grupo de control.
+
+Ejecutar: OLLAMA_HOST=127.0.0.1:11435 python spikes/tool_calling_fase4_prompts.py
+"""
+
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from spikes.tool_calling_fase3 import CONSULTAS, bucle_agente  # noqa: E402
+
+PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+
+
+def cargar_prompts():
+    """(nombre, contenido) por variante. None = control sin prompt."""
+    variantes = [("sin-prompt", None)]
+    for ruta in sorted(PROMPTS_DIR.glob("*.md")):
+        variantes.append((ruta.stem, ruta.read_text(encoding="utf-8")))
+    return variantes
+
+
+# Marcas automáticas. AVISO: la primera versión sólo buscaba escalas «/3» y «/5»
+# -las vistas en la Fase 3- y por eso NO detectó un «score 2/1» que apareció
+# después. Es la limitación del método: se construye con los fallos ya conocidos,
+# y las invenciones nuevas adoptan formas nuevas. Sirve de cribado, no de prueba;
+# la revisión manual sigue siendo obligatoria.
+PATRONES_FABRICACION = [
+    (r"\b\d+\s*/\s*\d+\b|\b\d+\s+sobre\s+\d+\b", "escala inventada (X/Y)"),
+    (r"[\U0001F300-\U0001FAFF☀-➿]", "emojis"),
+    (r"^\s*\|", "tablas"),
+    (r"\*\*|__", "negritas"),
+    (r"^\s*#{1,6}\s", "encabezados"),
+    (r"^\s*[-*+]\s", "listas"),
+    (r"\b(he|hemos)\s+(detectado|analizado|encontrado)\b|\bmi\s+análisis\b", "se atribuye el análisis"),
+]
+
+
+def cifras_sin_respaldo(texto, traza):
+    """Números de la respuesta que NO aparecen en la salida de ninguna herramienta.
+
+    Comprobación de fidelidad numérica: si el modelo menciona una probabilidad o
+    una posición, debe venir de una tool. Tolera los conteos derivados (p. ej.
+    «2 pistas» cuando hay dos matches) admitiendo números pequeños.
+    NO detecta datos correctos mal atribuidos -como dar el span de una pista a
+    otra-, que siguen requiriendo lectura manual.
+    """
+    salidas = " ".join(json.dumps(s, ensure_ascii=False) for _, _, s in traza)
+    numeros_tool = set(re.findall(r"\d+", salidas))
+    huerfanos = []
+    for numero in re.findall(r"\d+(?:[.,]\d+)?", texto):
+        entero = numero.replace(",", ".").split(".")[0]
+        decimales = numero.replace(",", ".").replace(".", "")
+        if entero in numeros_tool or decimales[:6] in salidas.replace(".", ""):
+            continue
+        if len(entero) <= 1:  # conteos y ordinales derivados
+            continue
+        huerfanos.append(numero)
+    return huerfanos
+
+
+def revisar(texto, traza=()):
+    """Marcas automáticas de estilo/fabricación. Complementa la revisión manual."""
+    hallazgos = []
+    for patron, etiqueta in PATRONES_FABRICACION:
+        if re.search(patron, texto, flags=re.MULTILINE):
+            hallazgos.append(etiqueta)
+    huerfanos = cifras_sin_respaldo(texto, traza)
+    if huerfanos:
+        hallazgos.append(f"cifras sin respaldo: {', '.join(huerfanos[:4])}")
+    return hallazgos
+
+
+if __name__ == "__main__":
+    variantes = cargar_prompts()
+    print(f"Variantes: {', '.join(n for n, _ in variantes)}")
+    print(f"Consultas: {len(CONSULTAS)}\n")
+
+    resumen = []
+
+    for nombre, sistema in variantes:
+        print("#" * 78)
+        print(f"# PROMPT: {nombre}")
+        print("#" * 78)
+
+        for i, consulta in enumerate(CONSULTAS, 1):
+            inicio = time.perf_counter()
+            respuesta, traza, segundos, vueltas = bucle_agente(consulta, sistema)
+            del inicio
+
+            hallazgos = revisar(respuesta, traza)
+            resumen.append({
+                "prompt": nombre,
+                "consulta": i,
+                "segundos": segundos,
+                "vueltas": vueltas,
+                "llamadas": len(traza),
+                "caracteres": len(respuesta),
+                "marcas": hallazgos,
+            })
+
+            print(f"\n--- consulta {i} --- {segundos:.1f}s | {vueltas} vueltas | "
+                  f"{len(traza)} tools | {len(respuesta)} chars")
+            print("    tools:", " -> ".join(n for n, _, _ in traza) or "(ninguna)")
+            if hallazgos:
+                print("    MARCAS:", ", ".join(hallazgos))
+            print(f"    respuesta: {respuesta[:400]}")
+        print()
+
+    print("=" * 78)
+    print("RESUMEN")
+    print("=" * 78)
+    print(f"{'prompt':14s} {'seg':>7s} {'vueltas':>8s} {'tools':>6s} {'chars':>7s}  marcas")
+    for fila in resumen:
+        print(f"{fila['prompt']:14s} {fila['segundos']:7.1f} {fila['vueltas']:8d} "
+              f"{fila['llamadas']:6d} {fila['caracteres']:7d}  {', '.join(fila['marcas']) or '-'}")
+
+    print()
+    print("Por variante (media de las consultas):")
+    for nombre, _ in variantes:
+        filas = [f for f in resumen if f["prompt"] == nombre]
+        media_s = sum(f["segundos"] for f in filas) / len(filas)
+        media_c = sum(f["caracteres"] for f in filas) / len(filas)
+        con_marcas = sum(1 for f in filas if f["marcas"])
+        print(f"  {nombre:14s} {media_s:6.1f}s | {media_c:6.0f} chars | "
+              f"{con_marcas}/{len(filas)} respuestas con marcas")
+
+    print()
+    print("A revisar a mano: ¿siguen apareciendo interpretaciones inventadas de los")
+    print("cues, o datos del artículo que no estaban en la salida de la herramienta?")


### PR DESCRIPTION
## Spike #82 — validación del *tool calling* con un modelo local

Documenta el spike que valida el supuesto sobre el que descansa todo R13: que un
modelo pequeño servido en local decide bien qué herramienta invocar. Se hizo
**antes** de construir el agente, porque el resultado determinaba la arquitectura.

El issue #82 ya está cerrado; aquí se incorpora el material al repositorio.

### Qué incluye

- `spikes/tool_calling_fase1.py` — una herramienta: ¿emite `tool_calls` válidas?
- `spikes/tool_calling_fase2.py` — 8 herramientas reales y 20 consultas
  clasificadas (genérica / específica / otro dominio / sin herramienta).
- `spikes/tool_calling_fase3.py` — **bucle completo del agente**: ejecuta las
  herramientas de verdad y devuelve el resultado al modelo. Es el esqueleto del
  agente real (acepta prompt de sistema, mantiene historial, corta a 6 vueltas).
- `spikes/tool_calling_fase4_prompts.py` + `spikes/prompts/` — comparativa de
  cuatro prompts de sistema, cada uno escrito contra los fallos del anterior.
- README: sección del spike dentro de Fase B.
- `docs/requisitos.md`: **nuevo R6.13**.

### Resultados

**Selección de herramienta: 20/20 (100 %)**, incluidas 8/8 en las consultas
específicas — distingue `detect_clickbait_lexical` de `_linear` por el matiz de la
petición («qué pistas y dónde» vs «dame la probabilidad»). Esa discriminación sólo
puede venir de las descripciones, lo que confirma **R13.2**: los docstrings son la
interfaz con el modelo, y añadir una herramienta no obliga a tocar el agente.
Parámetros válidos 15/15. El bucle **encadena** correctamente (noticia → titular
extraído del resultado → detectores).

**Latencia:** ~9 s por decisión con GPU; 20-40 s por respuesta completa con un
prompt que exija brevedad. En CPU pura eran 71,7 s de media, con el chat
inviable — de ahí que el modo guiado (R13.8) se mantenga como degradación para
entornos sin GPU.

### Hallazgos que afectan al diseño

**«Transcribe bien, envuelve mal».** El modelo reproduce las cifras con exactitud
(0.9375 → «93 %»; spans `[0,4]` y `[29,32]` correctos) pero fabrica el contexto:
una escala «2/3 niveles» inexistente, explicaciones inventadas de qué significa
cada cue, un nombre de empresa que no estaba en el texto.

Se probaron cuatro prompts contra esos fallos: cada regla dirigida corrigió el
suyo, pero **ninguno alcanza fidelidad total** — el mejor sólo desplaza el error
hacia formas más sutiles (fundir dos posiciones en un mismo rango: suena preciso
y es falso), que son *más* peligrosas que las obvias porque no levantan sospecha.

**Modo de fallo nuevo:** en dos ejecuciones el agente invocó las tres herramientas
correctamente y devolvió **cero caracteres** de narración. El análisis existía
completo; sólo faltaba la prosa. De ahí el **R6.13 (nuevo)**: la interfaz debe
mostrar igualmente los resultados estructurados, con un aviso discreto, y no
condicionar la visualización del análisis a que la narración exista.

Con esto **R13.3 y R13.4 quedan demostrados, no supuestos**: la explicabilidad no
puede depender de la capa generativa, ni cuando inventa ni cuando calla.

### Limitación metodológica

**No se afirma qué prompt es mejor.** La varianza entre ejecuciones domina: una
variante fue la mejor en una tanda y peor que el control en la siguiente, con el
mismo prompt y las mismas consultas. Con dos consultas por variante y sin
repeticiones no hay ranking defendible; harían falta unas cinco repeticiones por
par (prompt, consulta). Se adopta `04-preciso` como prompt de partida por el
razonamiento de sus reglas, no como ganador medido.
