### PR TITLE
feat(api): contrato REST y orquestación de POST /analyze

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
+# El filtro `branches` es por rama DESTINO. Con el flujo dev->main, las PRs de
+# feature apuntan a dev: si aquí solo figurara main, se mergearían sin pasar los
+# tests y el CI no saltaría hasta promocionar dev->main, cuando ya es tarde.
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   test:

--- a/backend/api/analyze.py
+++ b/backend/api/analyze.py
@@ -1,0 +1,309 @@
+"""Orquestación de ``POST /analyze``.
+
+Lanza las señales de clickbait a la vez, envuelve cada una en el formato
+uniforme de ``schemas`` y agrega el resultado. Tres invariantes lo gobiernan:
+
+1. **Una señal vota si —y solo si— su ``is_clickbait`` no es None.** Ahí caen
+   sin caso especial tanto las que fallaron como el tono, que por naturaleza no
+   emite veredicto de clickbait.
+2. **Una dimensión aparece si alguna de sus señales votó.** Si las que votaron
+   discrepan, no se promedia ni se resuelve por mayoría: se declara ``None``.
+3. **El veredicto global sale de las dimensiones con jerarquía** —el engaño pesa
+   más que la forma—, nunca de contar señales.
+
+Por qué no vale la mayoría: un titular sobrio cuyo cuerpo no cumple lo prometido
+tiene tres señales diciendo «no» y una diciendo «sí», y la correcta es la cuarta.
+
+El aislamiento de fallos es el punto delicado: una señal caída no puede tumbar
+las otras cuatro (~1 de cada 5 llamadas a HuggingFace da timeout, medido en la
+Épica 4). Por eso se usa ``asyncio.gather(..., return_exceptions=True)``, que en
+vez de propagar la primera excepción la DEVUELVE dentro de la lista de
+resultados, en la posición que le toca. Cada excepción se traduce entonces a una
+señal en estado ``error`` y la respuesta sigue siendo un 200 con lo que sí se
+pudo calcular.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from backend.api.schemas import (
+    AnalyzeRequest,
+    AnalyzeResponse,
+    Dimension,
+    DimensionVerdict,
+    OverallVerdict,
+    SignalResult,
+    SignalStatus,
+    SignalType,
+)
+from backend.core.models import ToolResult
+from backend.integrations.nlp import lexical, linear
+from backend.integrations.nlp.factory import get_nlp_backend
+from backend.integrations.nlp.incoherence import IncoherenceDetector
+from backend.integrations.nlp.model_cards import MODEL_CARDS
+
+# Instancias únicas: LocalNLPClient cachea los pipelines por instancia y el
+# detector carga el modelo de forma perezosa, así que crearlos por petición
+# tiraría la caché y recargaría el modelo cada vez. Como contrapartida, el
+# backend queda fijado al importar: cambiarlo exige reiniciar, igual que en la
+# tool MCP (que lo fija en register()).
+_api = get_nlp_backend()
+_detector = IncoherenceDetector()
+
+# Índice de fichas por nombre de tool. Es lo que permite no cablear aquí la
+# dimensión ni el tipo de cada señal: se leen de MODEL_CARDS (R3.9). Un desajuste
+# entre esta clave y el nombre real de la tool lo detecta antes de llegar aquí
+# test_model_cards_signals_match_registered_tools.
+_CARDS = {card["signal"]: card for card in MODEL_CARDS}
+
+# TODO(deuda): estos ids están duplicados en integrations/nlp/tool.py. Unificar
+# leyéndolos de MODEL_CARDS["name"] exige antes normalizar ese campo, que hoy
+# mezcla ids de HuggingFace con descripciones en prosa.
+_ZERO_SHOT_MODEL = "facebook/bart-large-mnli"
+_ZERO_SHOT_LABELS = ["clickbait", "factual news"]
+_SENTIMENT_MODEL = "cardiffnlp/twitter-roberta-base-sentiment-latest"
+
+
+@dataclass(frozen=True)
+class _Signal:
+    """Cómo se ejecuta una señal y cómo se lee su veredicto.
+
+    Declararlas en una tabla en vez de con cinco bloques casi idénticos deja el
+    bucle de ejecución con una sola forma. Añadir una sexta señal es añadir una
+    entrada a ``_SIGNALS`` y su ficha en MODEL_CARDS.
+
+    ``@dataclass`` lee las anotaciones de campo y genera ``__init__``,
+    ``__repr__`` y ``__eq__``, que es lo que ahorra escribir el constructor a
+    mano. ``frozen=True`` añade inmutabilidad: asignar a un campo después de
+    construir la instancia lanza ``FrozenInstanceError`` (y como efecto
+    secundario genera ``__hash__``, así que son hashables).
+
+    Se congela porque ``_SIGNALS`` es una tabla de constantes, leída al importar
+    y compartida por todas las peticiones: sin ``frozen`` nada impediría que un
+    handler hiciera ``spec.needs_content = True`` y mutara el comportamiento
+    global. Ojo, la inmutabilidad es SUPERFICIAL —impide reasignar el campo, no
+    mutar un objeto mutable guardado dentro—, pero aquí todos son str, bool o
+    funciones, así que es efectiva del todo.
+
+    TODO(futuro): si hace falta activar/desactivar señales por configuración,
+    esta tabla es el punto de extensión — pasaría de constante a construirse
+    desde settings.
+    """
+
+    name: str  # nombre EXACTO de la tool MCP; es la clave en _CARDS
+    run: Callable[[str, str | None], Awaitable[ToolResult]]
+    verdict: Callable[[dict[str, Any]], bool | None]
+    needs_content: bool = False
+
+
+# El extractor `verdict` existe porque cada tool expresa su conclusión a su
+# manera (label / is_clickbait / incoherent), y ese paso interpretativo —"una
+# similitud por debajo del umbral la leemos como clickbait"— se prefiere visible
+# aquí antes que uniformando el retorno de las tools, que es contrato público
+# leído por el LLM (validado en el spike #82).
+_SIGNALS: tuple[_Signal, ...] = (
+    _Signal(
+        name="detect_clickbait",
+        run=lambda h, c: _api.zero_shot(h, _ZERO_SHOT_MODEL, _ZERO_SHOT_LABELS),
+        verdict=lambda d: d["label"] == "clickbait",
+    ),
+    _Signal(
+        name="detect_clickbait_lexical",
+        # Síncrona y de milisegundos: va a un hilo solo para que el bucle trate a
+        # todas igual. El coste del hilo es despreciable frente a la uniformidad.
+        run=lambda h, c: asyncio.to_thread(lexical.detect, h),
+        verdict=lambda d: d["is_clickbait"],
+    ),
+    _Signal(
+        name="detect_clickbait_linear",
+        run=lambda h, c: asyncio.to_thread(linear.predict, h),
+        verdict=lambda d: d["is_clickbait"],
+    ),
+    _Signal(
+        name="detect_clickbait_incoherence",
+        run=lambda h, c: _detector.detect(h, c),
+        verdict=lambda d: d["incoherent"],
+        needs_content=True,
+    ),
+    _Signal(
+        name="analyze_sentiment",
+        run=lambda h, c: _api.classify(h, _SENTIMENT_MODEL),
+        # El tono se muestra como una señal más pero NO vota: alejarse de la
+        # objetividad no es hacer clickbait, y cuánto pesa eso lo juzga quien
+        # lee. Devolver None aquí es toda la implementación de esa decisión.
+        verdict=lambda d: None,
+    ),
+)
+
+
+async def analyze(request: AnalyzeRequest) -> AnalyzeResponse:
+    """Analiza un titular con todas las señales aplicables.
+
+    Sin lógica propia a propósito: cada invariante vive en su helper y se puede
+    probar por separado.
+    """
+    signals = await _run_signals(request.headline, request.content)
+    dimensions = _aggregate(signals)
+    return AnalyzeResponse(
+        headline=request.headline,
+        content=request.content,
+        signals=signals,
+        dimensions=dimensions,
+        verdict=_overall(dimensions),
+    )
+
+
+async def _run_signals(headline: str, content: str | None) -> list[SignalResult]:
+    """Ejecuta en paralelo las señales aplicables y envuelve cada resultado."""
+    by_name: dict[str, SignalResult] = {}
+    pending: list[_Signal] = []
+
+    for spec in _SIGNALS:
+        if spec.needs_content and not (content and content.strip()):
+            by_name[spec.name] = _build(
+                spec,
+                SignalStatus.NO_APLICABLE,
+                detail="Requiere el cuerpo o teaser de la noticia.",
+            )
+        else:
+            pending.append(spec)
+
+    outcomes = await asyncio.gather(
+        *(_run_one(spec, headline, content) for spec in pending),
+        return_exceptions=True,
+    )
+
+    # gather conserva el ORDEN DE ENTRADA, no el de finalización: aunque el
+    # zero-shot tarde 3 s y el léxico 2 ms, cada resultado vuelve en la posición
+    # de su spec. Por eso el zip es correcto.
+    for spec, outcome in zip(pending, outcomes):
+        if isinstance(outcome, BaseException):
+            # BaseException y no Exception: asyncio.CancelledError hereda de la
+            # primera desde Python 3.8 y gather también la deposita en la lista.
+            by_name[spec.name] = _build(
+                spec,
+                SignalStatus.ERROR,
+                # TODO(deuda): el texto de la excepción es útil para depurar
+                # pero expone interioridad. Sanear antes de salir de desarrollo.
+                detail=f"{type(outcome).__name__}: {outcome}",
+            )
+        else:
+            by_name[spec.name] = outcome
+
+    # Se emiten en el orden de _SIGNALS para que la interfaz pinte las tarjetas
+    # siempre igual, con independencia de cuál acabó antes o cuál se saltó.
+    return [by_name[spec.name] for spec in _SIGNALS]
+
+
+async def _run_one(spec: _Signal, headline: str, content: str | None) -> SignalResult:
+    """Ejecuta UNA señal.
+
+    Sin ``try/except``, y es deliberado: hay dos formas de fallar y cada una se
+    trata donde le toca. El fallo PREVISTO (timeout de HuggingFace, titular
+    vacío) llega como ``ToolResult.fail`` con su mensaje legible y se mapea
+    aquí. El IMPREVISTO —la corrutina revienta, o ``spec.verdict`` da KeyError
+    porque una tool cambió de formato— sube al ``gather``, que lo aísla.
+    """
+    outcome = await spec.run(headline, content)
+    if not outcome.has_content():
+        return _build(
+            spec,
+            SignalStatus.ERROR,
+            detail=outcome.error or "La señal no devolvió resultado.",
+        )
+    return _build(
+        spec,
+        SignalStatus.OK,
+        is_clickbait=spec.verdict(outcome.data),
+        data=outcome.data,
+    )
+
+
+def _build(
+    spec: _Signal,
+    status: SignalStatus,
+    *,
+    is_clickbait: bool | None = None,
+    data: dict[str, Any] | None = None,
+    detail: str | None = None,
+) -> SignalResult:
+    """Envuelve el resultado de una señal leyendo dimensión y tipo de su ficha.
+
+    Único sitio donde se construye un SignalResult, así que la traducción ficha
+    → respuesta está en un solo punto. El acceso a ``_CARDS`` puede dar KeyError
+    si se añade una señal sin ficha: es intencionado, y el test de alineación lo
+    detecta antes.
+    """
+    card = _CARDS[spec.name]
+    return SignalResult(
+        name=spec.name,
+        status=status,
+        dimension=Dimension(card["dimension"]),
+        type=SignalType(card["type"]),
+        is_clickbait=is_clickbait,
+        data=data,
+        detail=detail,
+    )
+
+
+def _aggregate(signals: list[SignalResult]) -> list[DimensionVerdict]:
+    """Agrupa por dimensión las señales que votaron (invariantes 1 y 2)."""
+    votes: dict[Dimension, list[SignalResult]] = {}
+    for signal in signals:
+        # `is None` y no `if not signal.is_clickbait`: False es un veredicto
+        # VÁLIDO —"esta señal dice que no es clickbait"— y con la comprobación
+        # por falsedad se perderían todos los votos negativos, dejando cualquier
+        # titular factual en sin_datos. Este único filtro cubre a la vez las
+        # señales que fallaron y las que no votan por naturaleza (el tono).
+        if signal.is_clickbait is None:
+            continue
+        votes.setdefault(signal.dimension, []).append(signal)
+
+    verdicts = []
+    for dimension, voters in votes.items():
+        # Conjunto de booleanos: solo puede ser {True}, {False} o {True, False}.
+        # Un elemento significa acuerdo; dos, discrepancia.
+        distinct = {v.is_clickbait for v in voters}
+        verdicts.append(
+            DimensionVerdict(
+                dimension=dimension,
+                # next(iter(...)) porque un set no es indexable. Discrepancia →
+                # None: dos señales de forma en desacuerdo es información, no
+                # ruido que haya que resolver por mayoría.
+                is_clickbait=next(iter(distinct)) if len(distinct) == 1 else None,
+                contributing=[v.name for v in voters],
+            )
+        )
+    return verdicts
+
+
+def _overall(dimensions: list[DimensionVerdict]) -> OverallVerdict:
+    """Deriva la etiqueta única con jerarquía explícita (invariante 3).
+
+    Cadena de ``if`` y no ``match``: aquí no hay un sujeto sobre el que
+    despachar —cada rama evalúa una condición distinta sobre objetos
+    distintos—, y sobre todo el ORDEN ES la jerarquía. Un ``switch`` comunica
+    «alternativas paralelas, el orden da igual», justo lo contrario.
+    """
+    # Primero: con la lista vacía, el any() de abajo daría False y caería en
+    # FACTUAL, declarando factual un titular que nadie pudo analizar.
+    if not dimensions:
+        return OverallVerdict.SIN_DATOS
+
+    by_dimension = {d.dimension: d for d in dimensions}
+    engano = by_dimension.get(Dimension.ENGANO)
+    forma = by_dimension.get(Dimension.FORMA)
+
+    # El engaño manda: un titular que promete lo que el cuerpo no cumple es
+    # clickbait aunque esté redactado con sobriedad.
+    if engano is not None and engano.is_clickbait:
+        return OverallVerdict.ENGANOSO
+    if forma is not None and forma.is_clickbait:
+        return OverallVerdict.CLICKBAIT_DE_FORMA
+    # Una detección positiva pesa más que una discrepancia: solo si nadie ha
+    # detectado nada importa que alguna dimensión quedara sin resolver. La
+    # discrepancia no se pierde, sigue visible en dimensions[].
+    if any(d.is_clickbait is None for d in dimensions):
+        return OverallVerdict.AMBIGUO
+    return OverallVerdict.FACTUAL

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -33,9 +33,16 @@ Tres principios lo gobiernan:
 """
 
 from enum import Enum
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StringConstraints
+
+# Recorta antes de medir. Con un simple `min_length=1`, un titular de un solo
+# espacio pasa la validación —mide 1 carácter— y llega hasta las señales, que
+# fallan una a una: la respuesta sería un 200 con veredicto `sin_datos` en vez
+# del 422 que corresponde a una petición inválida. Pydantic aplica
+# `strip_whitespace` antes que `min_length`, así que el blanco se rechaza aquí.
+NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
 class SignalStatus(str, Enum):
@@ -139,7 +146,7 @@ class OverallVerdict(str, Enum):
 
 
 class AnalyzeRequest(BaseModel):
-    headline: str = Field(min_length=1, description="Titular a analizar (en inglés).")
+    headline: NonBlankStr = Field(description="Titular a analizar (en inglés).")
     content: str | None = Field(
         default=None,
         description=(

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -1,0 +1,164 @@
+"""Contrato de la API REST (R4).
+
+Estos modelos definen la respuesta de ``POST /analyze``, el endpoint que orquesta
+las señales de clickbait. Es el contrato más importante del sistema porque lo
+consumen **tres** sitios: el formulario de análisis, las tarjetas embebidas en el
+chat y el historial. Se diseña una vez y sirve para los tres.
+
+Tres principios lo gobiernan:
+
+1. **Envoltorio uniforme por señal.** Las señales son una LISTA de objetos con la
+   misma forma, no un objeto con un campo por señal. Así el frontend itera y
+   pinta tarjetas sin conocerlas de antemano: añadir una quinta señal no obliga a
+   tocar Angular. Es el mismo desacople que en el catálogo.
+
+2. **El estado va por señal, no global.** Un único campo ``status`` cubre dos
+   situaciones que, desde el punto de vista de la respuesta, son la misma —esa
+   señal no tiene resultado, pero las demás sí—: que falten datos de entrada
+   (``no_aplicable``: la incoherencia necesita el cuerpo) y que la ejecución
+   falle (``error``: ~1 de cada 5 llamadas a HuggingFace da timeout, medido en la
+   Épica 4). ``/analyze`` NO devuelve error global mientras alguna señal
+   funcione: perder tres análisis correctos porque el cuarto falló sería el mismo
+   error que evita R6.13.
+
+3. **Veredicto por dimensiones, no por mayoría.** Las señales miden cosas
+   distintas (forma vs engaño), así que promediarlas produce un veredicto
+   engañoso: tres señales de forma de acuerdo no significan que el titular mienta.
+   La dimensión de cada señal se lee de ``MODEL_CARDS`` (R3.9), no se cablea aquí.
+
+   El tono se presenta como una señal más, pero no vota: alejarse de la
+   objetividad no es lo mismo que hacer clickbait, y cuánto pesa eso es juicio
+   de quien lee. No hace falta ningún caso especial para conseguirlo —
+   simplemente no emite veredicto, igual que una señal que ha fallado.
+"""
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SignalStatus(str, Enum):
+    """Por qué una señal tiene o no resultado."""
+
+    OK = "ok"
+    NO_APLICABLE = "no_aplicable"  # faltan datos de entrada (p. ej. el cuerpo)
+    ERROR = "error"  # la ejecución falló (timeout, proveedor caído...)
+
+
+class Dimension(str, Enum):
+    """Qué mide una señal. Determina cómo se agrupan los veredictos."""
+
+    FORMA = "forma"  # sensacionalismo en la redacción
+    ENGANO = "engano"  # el titular promete algo que el cuerpo no cumple
+    TONO = "tono"  # carga emocional; contexto que se muestra, no veredicto
+
+
+class SignalType(str, Enum):
+    """Naturaleza del modelo. Se muestra como badge en la interfaz."""
+
+    INTERPRETABLE = "interpretable"
+    HIBRIDO = "híbrido"
+    OPACO = "opaco"
+
+
+class SignalResult(BaseModel):
+    """Resultado de UNA señal, con el mismo envoltorio sea cual sea (principio 1)."""
+
+    name: str = Field(description="Nombre de la herramienta MCP que la produjo.")
+    status: SignalStatus
+    dimension: Dimension
+    type: SignalType = Field(
+        description="Naturaleza del modelo, para el badge de la UI."
+    )
+
+    is_clickbait: bool | None = Field(
+        default=None,
+        description=(
+            "Veredicto de esta señal, o None si no aporta ninguno: porque no "
+            "pudo ejecutarse, o porque por naturaleza no lo emite (el tono). El "
+            "agregado ignora los None en ambos casos; ``status`` distingue cuál "
+            "de los dos ha sido."
+        ),
+    )
+    data: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "JSON CRUDO devuelto por la herramienta, sin aplanar. Es lo que "
+            "alimenta las tarjetas de explicabilidad (spans, top_cues, "
+            "similitud...). No se transforma aquí para no perder información "
+            "que la interfaz pueda necesitar."
+        ),
+    )
+    detail: str | None = Field(
+        default=None,
+        description=(
+            "Motivo legible cuando no hay resultado: «requiere el cuerpo de la "
+            "noticia», «el proveedor no respondió». Permite pintar la tarjeta en "
+            "gris explicando por qué, en vez de omitirla sin más."
+        ),
+    )
+
+
+class DimensionVerdict(BaseModel):
+    """Veredicto agregado de las señales que miden lo mismo (principio 3).
+
+    Solo aparecen las dimensiones en las que alguna señal llegó a emitir
+    veredicto. Si ninguna lo hizo —fallaron, faltaba el cuerpo, o la dimensión
+    no vota— la dimensión no se incluye, en vez de añadir un objeto vacío que la
+    interfaz tendría que aprender a ignorar. El motivo no se pierde: está en la
+    tarjeta de cada señal, que es donde el usuario lo lee.
+    """
+
+    dimension: Dimension
+    is_clickbait: bool | None = Field(
+        default=None,
+        description=(
+            "None si las señales de esta dimensión se contradicen: no se "
+            "promedian ni se resuelven por mayoría, se declara la discrepancia."
+        ),
+    )
+    contributing: list[str] = Field(
+        default_factory=list,
+        description="Señales que han contribuido a este veredicto.",
+    )
+
+
+class OverallVerdict(str, Enum):
+    """Etiqueta única, para listados compactos como el historial.
+
+    Se deriva de las dimensiones con una jerarquía explícita —el engaño pesa más
+    que la forma— en lugar de por mayoría de señales.
+    """
+
+    ENGANOSO = "enganoso"  # hay engaño: el cuerpo no corresponde al titular
+    CLICKBAIT_DE_FORMA = "clickbait_de_forma"  # sensacionalista, pero sin engañar
+    FACTUAL = "factual"
+    AMBIGUO = "ambiguo"  # las señales de una misma dimensión se contradicen
+    SIN_DATOS = "sin_datos"  # ninguna señal llegó a emitir veredicto
+
+
+class AnalyzeRequest(BaseModel):
+    headline: str = Field(min_length=1, description="Titular a analizar (en inglés).")
+    content: str | None = Field(
+        default=None,
+        description=(
+            "Cuerpo o teaser. Opcional: sin él, la señal de incoherencia queda "
+            "en 'no_aplicable' y no se puede evaluar la dimensión de engaño."
+        ),
+    )
+
+
+class AnalyzeResponse(BaseModel):
+    headline: str
+    content: str | None = None
+
+    signals: list[SignalResult]
+    dimensions: list[DimensionVerdict]
+    verdict: OverallVerdict
+
+    @property
+    def has_any_result(self) -> bool:
+        """¿Alguna señal llegó a ejecutarse? Si no, la respuesta es informativa
+        (dice por qué falló cada una) pero no hay análisis que mostrar."""
+        return any(s.status == SignalStatus.OK for s in self.signals)

--- a/backend/integrations/nlp/model_cards.py
+++ b/backend/integrations/nlp/model_cards.py
@@ -7,14 +7,33 @@ marca qué señales son white-box (``interpretable``) frente a caja negra
 
 La otra mitad de R3.9 (intercambiar modelos por configuración) la cubre la
 factoría ``get_nlp_backend`` vía el setting ``nlp_backend`` (remote/local).
+
+El campo ``signal`` es la **clave de máquina**: debe coincidir EXACTAMENTE con el
+nombre de la tool MCP que produce esa señal, porque ``/analyze`` lo usa para
+buscar la ficha de cada resultado. No es una etiqueta legible —para eso están
+``name`` y ``task``— y meterle anotaciones («detect_clickbait (zero-shot)»)
+rompe la búsqueda en silencio: no lanza excepción, simplemente no encuentra la
+ficha. ``test_model_cards_signals_match_registered_tools`` lo vigila.
+
+El campo ``dimension`` indica QUÉ mide cada señal, no cómo de transparente es:
+
+- ``forma``  — sensacionalismo en la redacción del titular (estilo).
+- ``engano`` — que el titular prometa algo que el cuerpo no cumple.
+- ``tono``   — carga emocional del texto; no es una señal de clickbait.
+
+Es lo que permite a ``/analyze`` agrupar los veredictos por dimensión en vez de
+promediar señales que miden cosas distintas: tres señales de *forma* de acuerdo
+no significan que el titular engañe. Sin este campo, el backend tendría que
+cablear qué señal es cuál — justo lo que se evita.
 """
 
 MODEL_CARDS = [
     {
-        "signal": "detect_clickbait (zero-shot)",
+        "signal": "detect_clickbait",
         "name": "facebook/bart-large-mnli",
         "task": "Clasifica el titular como clickbait vs factual por inferencia natural (NLI, zero-shot).",
         "type": "opaco",
+        "dimension": "forma",
         "limitations": [
             "Modelo genérico de NLI, no entrenado específicamente en clickbait.",
             "Caja negra: sin explicación intrínseca (post-hoc opcional, R3.11).",
@@ -28,6 +47,7 @@ MODEL_CARDS = [
         "name": "cardiffnlp/twitter-roberta-base-sentiment-latest",
         "task": "Análisis de sentimiento en 3 clases (positivo / neutral / negativo).",
         "type": "opaco",
+        "dimension": "tono",
         "limitations": [
             "Entrenado en tuits, no en titulares de noticias.",
             "Caja negra.",
@@ -37,6 +57,7 @@ MODEL_CARDS = [
     },
     {
         "signal": "detect_clickbait_incoherence",
+        "dimension": "engano",
         "name": "sentence-transformers/all-MiniLM-L6-v2",
         "task": "Similitud coseno titular↔contenido; una similitud baja indica posible clickbait por incoherencia.",
         "type": "híbrido",
@@ -50,6 +71,7 @@ MODEL_CARDS = [
     },
     {
         "signal": "detect_clickbait_lexical",
+        "dimension": "forma",
         "name": "Léxico por reglas (listas de cues de Chakraborty et al. 2016)",
         "task": "Detecta pistas léxicas/estructurales de clickbait y devuelve qué cues dispararon y dónde.",
         "type": "interpretable",
@@ -64,6 +86,7 @@ MODEL_CARDS = [
     },
     {
         "signal": "detect_clickbait_linear",
+        "dimension": "forma",
         "name": "Regresión logística sobre features léxicas (entrenada en Chakraborty)",
         "task": "Clickbait ponderado: aprende el peso de cada pista y devuelve los cues que más contribuyeron al veredicto.",
         "type": "interpretable",

--- a/tests/api/test_analyze.py
+++ b/tests/api/test_analyze.py
@@ -1,0 +1,382 @@
+"""Tests de la orquestación de /analyze.
+
+Ninguno toca la red ni carga modelos: se sustituyen las cuatro fuentes reales
+(`_api`, `_detector`, `lexical.detect`, `linear.predict`) por dobles
+controlables. Las lambdas de `_SIGNALS` resuelven `_api` y `_detector` como
+globales del módulo EN CADA LLAMADA, así que monkeypatchear el módulo basta.
+"""
+
+import asyncio
+import time
+
+import pytest
+from pydantic import ValidationError
+
+from backend.api import analyze as analyze_mod
+from backend.api.analyze import _SIGNALS, _aggregate, _build, _overall, _run_signals
+from backend.api.schemas import (
+    AnalyzeRequest,
+    Dimension,
+    DimensionVerdict,
+    OverallVerdict,
+    SignalStatus,
+)
+from backend.core.models import ToolResult
+from backend.integrations.nlp import lexical, linear
+
+_SPECS = {spec.name: spec for spec in _SIGNALS}
+
+
+# ----- Dobles -----
+
+
+class _FakeAPI:
+    """Backend NLP sin red. `delay` sirve para medir la concurrencia."""
+
+    def __init__(self, label="clickbait", sentiment="neutral", delay=0.0):
+        self.label, self.sentiment, self.delay = label, sentiment, delay
+
+    async def zero_shot(self, text, model, labels):
+        await asyncio.sleep(self.delay)
+        return ToolResult.ok({"label": self.label, "score": 0.91})
+
+    async def classify(self, text, model):
+        await asyncio.sleep(self.delay)
+        return ToolResult.ok({"label": self.sentiment, "score": 0.84})
+
+
+async def _revienta(*args, **kwargs):
+    raise TimeoutError("el proveedor no respondió")
+
+
+async def _falla(*args, **kwargs):
+    return ToolResult.fail("el proveedor no respondió")
+
+
+class _FakeDetector:
+    def __init__(self, similarity=0.61, delay=0.0):
+        self.similarity, self.delay = similarity, delay
+
+    async def detect(self, headline, content):
+        await asyncio.sleep(self.delay)
+        return ToolResult.ok(
+            {
+                "similarity": self.similarity,
+                "incoherent": self.similarity < 0.3,
+                "headline": headline,
+                "content": content,
+            }
+        )
+
+
+@pytest.fixture
+def señales(monkeypatch):
+    """Instala los dobles. Devuelve una función para configurarlos por test."""
+
+    def instalar(
+        *,
+        label="clickbait",
+        sentiment="neutral",
+        similarity=0.61,
+        lexico=True,
+        lineal=True,
+        delay=0.0,
+    ):
+        monkeypatch.setattr(analyze_mod, "_api", _FakeAPI(label, sentiment, delay))
+        monkeypatch.setattr(analyze_mod, "_detector", _FakeDetector(similarity, delay))
+
+        def fake_lexical(headline):
+            time.sleep(delay)
+            return ToolResult.ok(
+                {
+                    "score": 2 if lexico else 0,
+                    "is_clickbait": lexico,
+                    "matches": [],
+                    "headline": headline,
+                }
+            )
+
+        def fake_linear(headline):
+            time.sleep(delay)
+            return ToolResult.ok(
+                {
+                    "is_clickbait": lineal,
+                    "probability": 0.88 if lineal else 0.12,
+                    "top_cues": [],
+                    "headline": headline,
+                }
+            )
+
+        monkeypatch.setattr(lexical, "detect", fake_lexical)
+        monkeypatch.setattr(linear, "predict", fake_linear)
+
+    return instalar
+
+
+def _signal(name, is_clickbait, status=SignalStatus.OK):
+    return _build(_SPECS[name], status, is_clickbait=is_clickbait)
+
+
+def _por_dimension(verdicts):
+    return {v.dimension: v for v in verdicts}
+
+
+# ----- Validación de entrada -----
+
+
+@pytest.mark.parametrize("blanco", [" ", "", "\t\n", "   "])
+def test_headline_en_blanco_se_rechaza(blanco):
+    # Un titular de solo espacios medía 1 carácter y pasaba `min_length=1`,
+    # produciendo un 200 con `sin_datos` en lugar de un 422.
+    with pytest.raises(ValidationError):
+        AnalyzeRequest(headline=blanco)
+
+
+def test_headline_se_normaliza():
+    assert AnalyzeRequest(headline="  Breaking News  ").headline == "Breaking News"
+
+
+# ----- _aggregate: invariantes 1 y 2 -----
+
+
+def test_señales_de_acuerdo_dan_veredicto_de_dimension(señales):
+    verdicts = _por_dimension(
+        _aggregate(
+            [
+                _signal("detect_clickbait", True),
+                _signal("detect_clickbait_lexical", True),
+                _signal("detect_clickbait_linear", True),
+            ]
+        )
+    )
+    assert verdicts[Dimension.FORMA].is_clickbait is True
+    assert len(verdicts[Dimension.FORMA].contributing) == 3
+
+
+def test_señales_en_discrepancia_no_se_resuelven_por_mayoria():
+    # Dos a uno NO gana: la discrepancia se declara, no se promedia.
+    verdicts = _por_dimension(
+        _aggregate(
+            [
+                _signal("detect_clickbait", False),
+                _signal("detect_clickbait_lexical", True),
+                _signal("detect_clickbait_linear", True),
+            ]
+        )
+    )
+    assert verdicts[Dimension.FORMA].is_clickbait is None
+    assert len(verdicts[Dimension.FORMA].contributing) == 3
+
+
+def test_veredicto_negativo_cuenta_como_voto():
+    # Regresión: con `if not signal.is_clickbait` en vez de `is None`, los votos
+    # False se descartarían y un titular factual saldría sin_datos.
+    verdicts = _por_dimension(_aggregate([_signal("detect_clickbait_lexical", False)]))
+    assert verdicts[Dimension.FORMA].is_clickbait is False
+
+
+def test_el_tono_no_vota_y_no_genera_dimension():
+    verdicts = _aggregate(
+        [
+            _signal("analyze_sentiment", None),
+            _signal("detect_clickbait_lexical", True),
+        ]
+    )
+    assert Dimension.TONO not in _por_dimension(verdicts)
+
+
+def test_señal_fallida_no_genera_dimension():
+    verdicts = _aggregate(
+        [_signal("detect_clickbait_incoherence", None, SignalStatus.ERROR)]
+    )
+    assert verdicts == []
+
+
+# ----- _overall: invariante 3 -----
+
+
+def _dim(dimension, is_clickbait):
+    return DimensionVerdict(dimension=dimension, is_clickbait=is_clickbait)
+
+
+def test_sin_dimensiones_es_sin_datos():
+    # Debe comprobarse ANTES que la ambigüedad: con la lista vacía el any() da
+    # False y caería en FACTUAL, declarando factual lo que nadie pudo analizar.
+    assert _overall([]) == OverallVerdict.SIN_DATOS
+
+
+def test_el_engaño_pesa_mas_que_la_forma():
+    # Tres señales de forma dicen "no" y una de engaño dice "sí": gana la de
+    # engaño. Por mayoría saldría "factual", que es justo el error a evitar.
+    verdict = _overall([_dim(Dimension.FORMA, False), _dim(Dimension.ENGANO, True)])
+    assert verdict == OverallVerdict.ENGANOSO
+
+
+def test_forma_sin_engaño_es_clickbait_de_forma():
+    verdict = _overall([_dim(Dimension.FORMA, True), _dim(Dimension.ENGANO, False)])
+    assert verdict == OverallVerdict.CLICKBAIT_DE_FORMA
+
+
+def test_todo_negativo_es_factual():
+    verdict = _overall([_dim(Dimension.FORMA, False), _dim(Dimension.ENGANO, False)])
+    assert verdict == OverallVerdict.FACTUAL
+
+
+def test_dimension_sin_resolver_es_ambiguo():
+    verdict = _overall([_dim(Dimension.FORMA, None), _dim(Dimension.ENGANO, False)])
+    assert verdict == OverallVerdict.AMBIGUO
+
+
+def test_una_deteccion_positiva_pesa_mas_que_una_discrepancia():
+    # Decisión consciente: la ambigüedad de forma no oculta el engaño detectado.
+    # Sigue visible en dimensions[], solo no manda en la etiqueta única.
+    verdict = _overall([_dim(Dimension.FORMA, None), _dim(Dimension.ENGANO, True)])
+    assert verdict == OverallVerdict.ENGANOSO
+
+
+# ----- _run_signals: aplicabilidad, aislamiento, orden -----
+
+
+@pytest.mark.asyncio
+async def test_sin_cuerpo_la_incoherencia_queda_no_aplicable(señales):
+    señales()
+    signals = {s.name: s for s in await _run_signals("Un titular", None)}
+
+    incoherencia = signals["detect_clickbait_incoherence"]
+    assert incoherencia.status == SignalStatus.NO_APLICABLE
+    assert incoherencia.is_clickbait is None
+    assert incoherencia.detail  # explica por qué, para pintarla en gris
+    # Las demás sí corren.
+    assert signals["detect_clickbait_lexical"].status == SignalStatus.OK
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cuerpo", [None, "", "   "])
+async def test_cuerpo_en_blanco_equivale_a_no_tenerlo(señales, cuerpo):
+    señales()
+    signals = {s.name: s for s in await _run_signals("Un titular", cuerpo)}
+    assert signals["detect_clickbait_incoherence"].status == SignalStatus.NO_APLICABLE
+
+
+@pytest.mark.asyncio
+async def test_una_señal_que_revienta_no_tumba_a_las_demas(señales, monkeypatch):
+    señales()
+    monkeypatch.setattr(analyze_mod._api, "zero_shot", _revienta)
+
+    signals = {s.name: s for s in await _run_signals("Un titular", "Un cuerpo")}
+
+    caida = signals["detect_clickbait"]
+    assert caida.status == SignalStatus.ERROR
+    assert caida.is_clickbait is None
+    assert "TimeoutError" in caida.detail  # tipo + mensaje, para depurar
+    # Las otras cuatro sobreviven: ese es el punto de return_exceptions=True.
+    otras = [s for n, s in signals.items() if n != "detect_clickbait"]
+    assert all(s.status == SignalStatus.OK for s in otras)
+
+
+@pytest.mark.asyncio
+async def test_tool_result_fail_se_traduce_a_error_con_su_mensaje(señales, monkeypatch):
+    señales()
+    monkeypatch.setattr(
+        lexical, "detect", lambda h: ToolResult.fail("El titular está vacío")
+    )
+
+    signals = {s.name: s for s in await _run_signals("Un titular", "Un cuerpo")}
+    assert signals["detect_clickbait_lexical"].status == SignalStatus.ERROR
+    assert signals["detect_clickbait_lexical"].detail == "El titular está vacío"
+
+
+@pytest.mark.asyncio
+async def test_un_formato_inesperado_se_aisla_como_error(señales, monkeypatch):
+    # Si una tool cambia de formato, el KeyError del extractor sube al gather y
+    # degrada esa señal sola, en vez de devolver un 500.
+    señales()
+    monkeypatch.setattr(lexical, "detect", lambda h: ToolResult.ok({"otra_clave": 1}))
+
+    signals = {s.name: s for s in await _run_signals("Un titular", "Un cuerpo")}
+    assert signals["detect_clickbait_lexical"].status == SignalStatus.ERROR
+    assert "KeyError" in signals["detect_clickbait_lexical"].detail
+
+
+@pytest.mark.asyncio
+async def test_el_orden_de_las_señales_es_estable(señales):
+    señales()
+    con_cuerpo = [s.name for s in await _run_signals("Un titular", "Un cuerpo")]
+    sin_cuerpo = [s.name for s in await _run_signals("Un titular", None)]
+
+    # Aunque una se salte, la interfaz recibe siempre las tarjetas en el mismo
+    # orden: el de _SIGNALS, no el de finalización.
+    assert con_cuerpo == sin_cuerpo == [spec.name for spec in _SIGNALS]
+
+
+@pytest.mark.asyncio
+async def test_las_señales_corren_en_paralelo(señales):
+    # La razón de ser del gather: el coste es el de la más lenta, no la suma.
+    señales(delay=0.1)
+
+    inicio = time.perf_counter()
+    await _run_signals("Un titular", "Un cuerpo")
+    transcurrido = time.perf_counter() - inicio
+
+    assert transcurrido < 0.3  # secuencial serían ~0.5 s
+
+
+@pytest.mark.asyncio
+async def test_la_dimension_y_el_tipo_salen_de_la_ficha(señales):
+    señales()
+    signals = {s.name: s for s in await _run_signals("Un titular", "Un cuerpo")}
+
+    assert signals["detect_clickbait_incoherence"].dimension == Dimension.ENGANO
+    assert signals["analyze_sentiment"].dimension == Dimension.TONO
+    assert signals["detect_clickbait_lexical"].dimension == Dimension.FORMA
+
+
+# ----- analyze: extremo a extremo (con dobles) -----
+
+
+@pytest.mark.asyncio
+async def test_clickbait_de_forma_con_cuerpo_coherente(señales):
+    señales(label="clickbait", lexico=True, lineal=True, similarity=0.61)
+
+    response = await analyze_mod.analyze(
+        AnalyzeRequest(headline="You Won't Believe What Happened Next", content="...")
+    )
+
+    assert response.verdict == OverallVerdict.CLICKBAIT_DE_FORMA
+    assert response.has_any_result
+    assert len(response.signals) == len(_SIGNALS)
+    # El tono aparece como tarjeta pero no como dimensión.
+    assert "analyze_sentiment" in {s.name for s in response.signals}
+    assert Dimension.TONO not in {d.dimension for d in response.dimensions}
+
+
+@pytest.mark.asyncio
+async def test_forma_sobria_pero_engañosa(señales):
+    # Tres señales dicen "no es clickbait" y solo la incoherencia dice que sí.
+    señales(label="factual news", lexico=False, lineal=False, similarity=0.22)
+
+    response = await analyze_mod.analyze(
+        AnalyzeRequest(headline="Report Details Q3 Financial Results", content="...")
+    )
+
+    assert response.verdict == OverallVerdict.ENGANOSO
+    dimensiones = _por_dimension(response.dimensions)
+    assert dimensiones[Dimension.FORMA].is_clickbait is False
+    assert dimensiones[Dimension.ENGANO].is_clickbait is True
+
+
+@pytest.mark.asyncio
+async def test_si_todas_las_señales_fallan_no_hay_veredicto(señales, monkeypatch):
+    señales()
+    for modulo, atributo in ((lexical, "detect"), (linear, "predict")):
+        monkeypatch.setattr(modulo, atributo, lambda h: ToolResult.fail("caído"))
+    for metodo in ("zero_shot", "classify"):
+        monkeypatch.setattr(analyze_mod._api, metodo, _falla)
+
+    response = await analyze_mod.analyze(AnalyzeRequest(headline="Un titular"))
+
+    assert response.verdict == OverallVerdict.SIN_DATOS
+    assert not response.has_any_result
+    assert response.dimensions == []
+    # Aun así la respuesta es informativa: cada tarjeta dice qué le pasó.
+    assert all(s.detail for s in response.signals)

--- a/tests/integrations/test_nlp.py
+++ b/tests/integrations/test_nlp.py
@@ -5,7 +5,10 @@ import pytest
 import respx  # Usamos en vez de htttp, ya que no hacemos llamadas de verdad, mockeamos
 from httpx import Response, TimeoutException
 
+from mcp.server.fastmcp import FastMCP
+
 from backend.integrations.nlp import lexical, linear, model_cards
+from backend.integrations.nlp import tool as nlp_tool
 from backend.integrations.nlp.client import HFClient
 from backend.integrations.nlp.incoherence import IncoherenceDetector
 from backend.integrations.nlp.local import LocalNLPClient
@@ -460,12 +463,22 @@ def test_linear_detector_no_headline():
 
 
 def test_model_cards_wellformed():
-    required = {"signal", "name", "task", "type", "limitations", "backend"}
+    required = {
+        "signal",
+        "name",
+        "task",
+        "type",
+        "dimension",
+        "limitations",
+        "backend",
+    }
     valid_types = {"interpretable", "híbrido", "opaco"}
+    valid_dimensions = {"forma", "engano", "tono"}
     assert isinstance(model_cards.MODEL_CARDS, list) and model_cards.MODEL_CARDS
     for card in model_cards.MODEL_CARDS:
         assert required <= card.keys()
         assert card["type"] in valid_types
+        assert card["dimension"] in valid_dimensions
         assert isinstance(card["limitations"], list) and card["limitations"]
 
 
@@ -474,3 +487,14 @@ def test_model_cards_serializable_and_cover_signals():
     dumped = json.dumps(model_cards.MODEL_CARDS)
     for name in ["facebook/bart-large-mnli", "all-MiniLM-L6-v2"]:
         assert name in dumped
+
+
+@pytest.mark.asyncio
+async def test_model_cards_signals_match_registered_tools():
+    # El campo ``signal`` es la clave con la que /analyze busca la ficha de cada resultado, así que tiene que ser el nombre EXACTO de la tool MCP.
+    mcp = FastMCP("test")
+    nlp_tool.register(mcp)
+    registered = {tool.name for tool in await mcp.list_tools()}
+
+    carded = {card["signal"] for card in model_cards.MODEL_CARDS}
+    assert carded <= registered, f"fichas sin tool: {carded - registered}"


### PR DESCRIPTION
## Contrato REST y orquestación de `POST /analyze`

Primer entregable de H2. Define el contrato del endpoint y la lógica que lo
produce; la app FastAPI va aparte.

### Qué incluye
- `backend/api/schemas.py`: contrato de `POST /analyze`. Envoltorio uniforme por
  señal (la UI itera, añadir una quinta no obliga a tocar Angular), `status` por
  señal en vez de global, y veredicto agregado **por dimensiones**.
- `backend/api/analyze.py`: orquestación. Las señales se lanzan con
  `asyncio.gather(..., return_exceptions=True)`, así que una caída degrada su
  propia tarjeta y la respuesta sigue siendo 200 con lo que sí se calculó.
- `backend/integrations/nlp/model_cards.py`: campo `dimension` en las cinco
  fichas, y el `signal` del zero-shot renombrado a `detect_clickbait`.

### Dos decisiones que conviene mirar
- **El tono se muestra pero no vota.** Alejarse de la objetividad no es hacer
  clickbait, y cuánto pesa eso lo juzga quien lee. No necesita ningún caso
  especial: devuelve `is_clickbait: null` y el mismo filtro que ignora las
  señales caídas lo ignora a él.
- **La discrepancia se declara, no se resuelve.** Dos señales de la misma
  dimensión en desacuerdo dan `null`, no mayoría. Promediar produciría un
  veredicto falso: un titular sobrio cuyo cuerpo no cumple lo prometido tiene
  tres señales diciendo "no" y una diciendo "sí", y la correcta es la cuarta.

### Por qué el `signal` de la ficha tenía que cambiar
Era `"detect_clickbait (zero-shot)"`: un campo pensado para leer, usado como
clave de búsqueda. En cuanto `/analyze` busca por él, cualquier mejora de la
etiqueta rompe la búsqueda **en silencio** — no lanza, simplemente no encuentra
la ficha. `test_model_cards_signals_match_registered_tools` vigila que los cinco
`signal` resuelvan contra tools registradas.

### Además
- **Fix de validación**: `headline=" "` pasaba `min_length=1` (mide 1 carácter) y
  acababa en un 200 con `sin_datos` en vez de un 422. Ahora recorta antes de medir.
- **Fix de CI**: el filtro `branches` es por rama destino, así que con el flujo
  dev→main las PRs de feature no disparaban tests. Añadido `dev`.

### Notas
`95 passed` (29 nuevos en `tests/api/test_analyze.py`, sin red ni modelos).

Sin cubrir todavía: la app FastAPI y el router, así que `analyze()` aún no es
alcanzable por HTTP y no hay prueba extremo a extremo con señales reales.
Anotados en el código como `TODO(deuda)` los ids de modelo duplicados con
`tool.py` y el texto de excepción expuesto en la respuesta.
