### PR TITLE
feat(api): app FastAPI con /analyze, CORS y OpenAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 .env
 .claude
 .vscode/settings.json
+
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -29,17 +29,32 @@ Version de Python: 3.12.3
 
 ## Convenciones de desarrollo
 
+### Organización del trabajo: hitos, issues y ramas
+
+Tres niveles, y **solo uno tiene rama**:
+
+| Nivel | Qué es | ¿Rama? | ¿Versión? |
+|---|---|---|---|
+| **Hito** (H1–H6) | Checkpoint con fecha y meta; agrupa issues | no | **sí**, al cerrarlo |
+| **Issue** | Unidad de trabajo | **sí** — 1 rama → 1 PR → squash a `dev` | no |
+
+Un hito **no es trabajo, es un punto de control**: no se ramifica ni se mergea. La unidad de trabajo es —y ha sido siempre— el issue.
+
+**Épicas (histórico).** Hasta la `v0.2.0` el trabajo se agrupaba en épicas (E1–E5): dominio sin fecha, de ahí los labels `epic:*`. En Fase B **los hitos las sustituyen**, porque cada hito ya trae dominio *y* fecha («H2 · API REST · octubre»); mantener los dos ejes duplicaría la misma información. Los labels `epic:*` se conservan como registro de los issues de Fase A.
+
 ### Ramas
 
-Cada rama de trabajo parte de `dev` y sigue el patrón `<tipo>/<descripción-corta>`:
+Cada rama de trabajo parte de `dev` (recién actualizada: tras un squash la rama de origen queda inservible como base) y sigue el patrón `<tipo>/<nº issue>-<descripción-corta>`:
 
 | Prefijo | Uso |
 |---|---|
-| `feature/` | Nueva funcionalidad |
+| `feat/` | Nueva funcionalidad |
 | `fix/` | Corrección de bug |
 | `chore/` | Setup, estructura, mantenimiento |
 | `docs/` | Documentación |
 | `test/` | Tests nuevos o mejoras de cobertura |
+
+Ejemplos: `feat/72-splits-train-dev-test`, `feat/86-app-fastapi`, `fix/lexico-cue-una-letra`. El número se omite cuando el trabajo no tiene issue (típico en `docs/`).
 
 ### Commits — Conventional Commits
 
@@ -66,12 +81,12 @@ Dos ramas permanentes con papeles distintos:
 
 **Releases:** al promocionar `dev → main` se crea un **tag** (`vX.Y.Z`). Una versión es **tageable** solo si cumple los cuatro criterios:
 
-1. **Bloque funcional completo** — épica cerrada o conjunto coherente de issues DEBERÁ (no features a medias).
+1. **Bloque funcional completo** — en Fase B, **hito cerrado**; en Fase A era la épica. Un conjunto coherente de issues DEBERÁ, sin features a medias.
 2. **CI verde** en `dev` (suite completa).
 3. **Verificación E2E** del servidor MCP pasada (tools respondiendo en vivo).
 4. **Documentación al día** (README y requisitos reflejan lo incluido).
 
-**Esquema de versiones** (semver adaptado al TFG): **minor** (`v0.X.0`) = bloque funcional/épica (`v0.1.0` = MVP Fase A, `v0.2.0` = Épica 5 NLP explicable); **patch** (`v0.X.Y`) = hotfix sobre lo shipeado; **major** (`v1.0.0`) = hito TFG (entrega final).
+**Esquema de versiones** (semver adaptado al TFG): **minor** (`v0.X.0`) = bloque funcional — **un hito** en Fase B (`v0.3` = H2, `v0.4` = H3…), una épica en Fase A (`v0.1.0` = MVP, `v0.2.0` = Épica 5 NLP explicable); **patch** (`v0.X.Y`) = hotfix sobre lo shipeado; **major** (`v1.0.0`) = entrega final del TFG.
 
 > **Principio:** las versiones son **cortes en el tiempo**, no contenedores temáticos. Una mejora posterior va a la **siguiente** versión aunque pertenezca por dominio a una épica ya taggeada (la trazabilidad temática la dan los labels de épica en los issues, no los tags). Los tags son inmutables: nunca se "reabre" una versión.
 
@@ -885,6 +900,39 @@ Esto convierte las **tarjetas renderizadas desde el JSON de la herramienta** de 
 De aquí sale también un **requisito nuevo, R6.13**: si la narración llega vacía o ilegible, la interfaz debe mostrar igualmente los resultados estructurados —con un aviso discreto de que no hubo resumen— y no condicionar la visualización del análisis a que esa narración exista. No es una precaución hipotética: el análisis se había completado con éxito y sólo faltaba la prosa; mostrar «la respuesta del asistente» habría dejado una pantalla en blanco y tirado un resultado válido.
 
 **Cierre:** se adopta `04-preciso` como prompt de partida —por el razonamiento de sus reglas y su mejor salida, no como «ganador medido»—, y el bucle de `tool_calling_fase3.py` queda como esqueleto del agente real: acepta el prompt de sistema como parámetro, mantiene el historial, ejecuta herramientas y corta a las seis vueltas.
+
+### Diseño de los endpoints REST: contrato de `POST /analyze` (H1, PR #85)
+
+Cierre del tercer bloque de H1 («diseño de los endpoints REST»). Se fija el contrato **antes** de escribir la app porque en el prototipo lo consumen **tres** sitios distintos —el formulario de análisis, las tarjetas embebidas en el chat y el historial—: se diseña una vez y sirve para los tres.
+
+**Tres principios lo gobiernan** (`backend/api/schemas.py`):
+
+1. **Envoltorio uniforme por señal.** Las señales son una *lista* de objetos con la misma forma, no un objeto con un campo por señal. El frontend itera y pinta tarjetas sin conocerlas de antemano: añadir una sexta señal no obliga a tocar Angular. Es el mismo desacople que el catálogo (R5.8).
+2. **El estado va por señal, no global.** Un único campo `status` cubre dos situaciones que, desde el punto de vista de la respuesta, son la misma —esa señal no tiene resultado, las demás sí—: faltan datos de entrada (`no_aplicable`, la incoherencia necesita el cuerpo) o la ejecución falló (`error`; ~1 de cada 5 llamadas a HF da timeout, medido en la Épica 4). `/analyze` **no** devuelve error global mientras alguna señal funcione: perder tres análisis correctos porque el cuarto falló sería el mismo error que evita R6.13.
+3. **Veredicto por dimensiones, no por mayoría.** Cada señal se etiqueta como *forma* (sensacionalismo en la redacción), *engaño* (el titular promete lo que el cuerpo no cumple) o *tono*. La dimensión se lee de `MODEL_CARDS` (R3.9), no se cablea en el orquestador.
+
+**Por qué la mayoría no vale.** Promediar señales que miden cosas distintas produce un veredicto falso. El caso decisivo es un titular sobrio cuyo cuerpo no corresponde:
+
+| Señal | Veredicto |
+|---|---|
+| Zero-shot | no es clickbait |
+| Léxico | no es clickbait |
+| Lineal | no es clickbait |
+| **Incoherencia** | **sí es clickbait** |
+
+Tres a uno, y **la correcta es la cuarta**: por mayoría saldría «factual». La jerarquía es explícita —el engaño pesa más que la forma— y las discrepancias *dentro* de una dimensión se declaran (`null` → `ambiguo`) en lugar de resolverse por votación.
+
+**El tono se muestra pero no vota.** Una narrativa marcadamente positiva o negativa aleja de la objetividad, pero eso no es hacer clickbait, y cuánto pesa es juicio de quien lee. No necesita ningún caso especial en el código: la señal devuelve `is_clickbait: null` y el mismo filtro que ignora las señales caídas la ignora a ella.
+
+**La orquestación** (`backend/api/analyze.py`) lanza las señales con `asyncio.gather(..., return_exceptions=True)`, que en vez de propagar la primera excepción la **devuelve** dentro de la lista de resultados. Cada excepción se traduce a una señal en estado `error` y la respuesta sigue siendo un 200 con lo que sí se pudo calcular. Las señales se declaran en una tabla (nombre de tool + cómo ejecutarla + cómo leer su veredicto) para que el bucle tenga una sola forma: añadir una señal es añadir una fila y su ficha.
+
+**Un desajuste que destapó el diseño.** La ficha del zero-shot tenía `"signal": "detect_clickbait (zero-shot)"` — un campo pensado para leer, usado como clave de búsqueda. En cuanto `/analyze` busca la dimensión por ese valor, cualquier mejora de la etiqueta rompe la búsqueda **en silencio**: no lanza excepción, simplemente no encuentra la ficha. Renombrado al nombre exacto de la tool (la anotación «zero-shot» ya estaba en `name` y `task`, no se pierde nada) y añadido `test_model_cards_signals_match_registered_tools`, que comprueba que los cinco `signal` resuelven contra tools realmente registradas. El renombrado arregla hoy; el test arregla las próximas veces.
+
+**Dos correcciones de paso:**
+- **Validación**: `headline=" "` pasaba `min_length=1` —un espacio mide un carácter— y llegaba hasta las señales, que fallaban una a una: la respuesta era un 200 con `sin_datos` en vez del 422 que corresponde. Ahora recorta antes de medir.
+- **CI**: el filtro `branches` de GitHub Actions es por rama **destino**. Con el flujo `dev→main` adoptado en la Épica 5, las PR de feature apuntan a `dev` y **no disparaban los tests**; el CI no saltaba hasta promocionar `dev→main`, cuando ya es tarde. Añadido `dev` a `pull_request` y `push`.
+
+**Límites de lo entregado.** No hay app FastAPI todavía, así que `analyze()` **no es alcanzable por HTTP** y no existe prueba extremo a extremo: los 29 tests de la orquestación usan dobles, y el camino nunca se ha ejecutado contra HuggingFace ni contra el modelo de embeddings. Quedan también sin diseñar los contratos de `/tools`, `/history` y `/chat`. La app y su router son H2 (issue #86).
 
 
 

--- a/README.md
+++ b/README.md
@@ -934,6 +934,97 @@ Tres a uno, y **la correcta es la cuarta**: por mayoría saldría «factual». L
 
 **Límites de lo entregado.** No hay app FastAPI todavía, así que `analyze()` **no es alcanzable por HTTP** y no existe prueba extremo a extremo: los 29 tests de la orquestación usan dobles, y el camino nunca se ha ejecutado contra HuggingFace ni contra el modelo de embeddings. Quedan también sin diseñar los contratos de `/tools`, `/history` y `/chat`. La app y su router son H2 (issue #86).
 
+### Arquitectura de despliegue: un servidor MCP, no una federación (H2, #86)
+
+Al escribir la app REST había que decidir la topología, y la respuesta obvia —replicar la arquitectura del entorno profesional del autor: un contenedor por MCP especialista, orquestados desde un punto central— resultó apoyarse en una **premisa que aquí no se cumple**.
+
+En esa arquitectura los especialistas (Azure, AKS, Rundeck) **ya existen y son de otros**: la federación resuelve un problema de propiedad del código y de ritmos de despliegue distintos. Aquí no hay ningún MCP de The Guardian que ensamblar — se escribe en este repo, contra su API REST, y comparte `BaseAPI`, `ToolResult`, `observability` y `settings` con las demás. Partirlas obligaría a duplicar esa base o a publicar un paquete compartido.
+
+**Tres niveles que se confunden con facilidad**, y cuya confusión es justo lo que produjo la redacción original de R1.7:
+
+| Nivel | Qué es | Ejemplo | Cuántos hay |
+|---|---|---|---|
+| API externa | servicio de un tercero, ajeno a MCP | `api.nytimes.com` | varios |
+| MCP_Tool | función propia que la envuelve | `get_nyt_news` | 11 |
+| MCP_Server | proceso que expone tools por el protocolo | `tfg-mcp-server` | **uno** |
+
+NYT y Guardian no son servidores: son *hojas* dentro del único servidor.
+
+**Evaluación contra los criterios que importaban** (desacoplamiento, memoria, latencia y el eje de explicabilidad):
+
+- **Memoria: ya estaba resuelta sin contenedores.** `incoherence.py` importa `sentence_transformers` *dentro* de `_get_model`, y `local.py` importa `transformers` dentro de `_get_pipeline`. Torch no entra en memoria si nadie usa esas señales. Separar `nlp` por RAM sería pagar dos veces por lo que ya da la carga perezosa; el argumento que sobrevive es el **tamaño de imagen**, que es asunto de H4.
+- **Latencia: medida, no supuesta.** Un spike levantó el servidor real con `streamable-http` y lo consumió como cliente MCP: handshake **0,212 s**, `list_tools` (11 tools) **0,036 s**, `call_tool` **0,033 s** y **0,006 s** la segunda en la misma sesión. Barato — pero un `/analyze` distribuido sumaría el handshake y cuatro saltos a los **0,4 s** que hoy cuesta importando el núcleo. El spike confirmó además algo que hasta entonces era razonamiento: `call_tool` devuelve `TextContent` cuyo `.text` es un **JSON string**, así que pasar `/analyze` por MCP significa `dict → json.dumps → TextContent → json.loads → dict`.
+- **Explicabilidad: el criterio decisivo.** La transparencia *de sistema* —qué herramienta se invocó, con qué fuentes— vive hoy en una traza única (`log_tool_invocation`). Repartirla entre contenedores la fragmenta sin aportar nada al eje del trabajo.
+
+**Decisión: tres contenedores** — servidor MCP, API REST y web. R1.6 se cumple (el servidor *puede* exponerse por HTTP y desplegarse aparte), R7 también, y `/analyze` conserva su latencia importando el núcleo. La separación de `nlp` se reconsiderará en H4 **si el tamaño de imagen o el arranque en frío duelen de verdad**, con la medición delante; decidirlo ahora sería pagar un coste sin saber si hace falta.
+
+**Cambios en los requisitos** (`docs/requisitos.md`):
+
+- **R1.8 acotado.** Su redacción («si un MCP_Server declarado no responde») y la intención del autor («si una API declarada no está, el sistema sigue funcionando») parecían contradecirse. No lo hacían: **hablan de listas distintas**. R1.8 se refiere a la lista de servidores MCP —nivel 3, sin sentido hasta que exista el cliente— y queda anotado como tal.
+- **R2.8 nuevo.** La intención del autor se convierte en criterio propio donde le corresponde: degradación ante APIs externas caídas. **Ya está satisfecho** desde la Épica 1 — `_aggregate_status` devuelve `degraded` cuando alguna sonda falla—, pero no estaba escrito.
+- **R1.9 nuevo.** El requisito de extensibilidad que sí sirve a este proyecto: añadir una fuente o una señal no debe obligar a tocar las existentes ni la interfaz. Está alineado con la tesis —añadir una señal es añadir una perspectiva contrastable— y **medio construido ya**: el envoltorio uniforme de `schemas.py` hace que una sexta señal no obligue a tocar Angular, `MODEL_CARDS` declara su naturaleza y `register()` la enchufa. Queda un fleco: `main.py` todavía lista los `register()` a mano.
+
+**R1.7 se mantiene sin cambios.** No porque haga falta hoy, sino porque el coste de dejar la puerta abierta es nulo: cuando llegue el cliente MCP en `/tools`, su configuración será una **lista** de endpoints en vez de una URL —cinco líneas— y el requisito seguirá siendo satisfacible el día que se quiera enchufar un servidor MCP ajeno, sin haber construido hoy una federación que no resuelve ningún problema real.
+
+#### Dónde vive CORS, y dónde no
+
+Decidida la topología, conviene fijar en qué salto aplica cada mecanismo, porque es fuente habitual de confusión:
+
+```
+Navegador ──(1)──→ nginx ──(2)──→ FastAPI ──(3)──→ servidor MCP
+                                          ──(4)──→ APIs externas (NYT, HuggingFace…)
+```
+
+| Salto | ¿CORS? | Autenticación |
+|---|---|---|
+| (1) navegador → nginx | **el único donde existe** | ninguna |
+| (2) nginx → FastAPI | no | ninguna, red interna |
+| (3) FastAPI → servidor MCP | no | *bearer*, si algún día se expone fuera |
+| (4) FastAPI → APIs externas | no | API keys (ya implementadas) |
+
+**CORS es un concepto exclusivamente de navegador**: nace de la política del mismo origen, que solo aplican los navegadores. Los saltos 2-4 son servidor a servidor, así que `HF_TOKEN` o `NYT_API_KEY` viajan sin que CORS pinte nada.
+
+**Topología del frontend: nginx como proxy inverso.** Sirve el build de Angular en `/` y reenvía `/api/*` a uvicorn por la red interna. Para el navegador todo es **el mismo origen**: desaparecen CORS y el *preflight* —que hoy convierte cada `POST /analyze` en dos viajes—, pero se mantienen dos contenedores con trabajos separados. En desarrollo el equivalente es el `proxy.conf.json` de Angular, de modo que desarrollo y producción se comporten igual; ese desajuste es el fallo clásico de servir el front en un origen distinto.
+
+Se descartó que **FastAPI sirviera los estáticos**: no es su trabajo, acopla el despliegue del frontend al de la API, y el *catch-all* que exige el enrutado de cliente de Angular puede tragarse `/docs` y `/openapi.json` si se registra en mal orden.
+
+**`CORSMiddleware` se mantiene igualmente**, aunque la topología lo vuelva inerte en producción: R4.7 lo exige, cuesta seis líneas y es la salida si en algún momento se desarrolla sin proxy.
+
+_(Nota sobre `mcp-proxy`: en el entorno profesional del autor los MCP de terceros solo hablan `stdio`, y se exponen por HTTP envolviéndolos con [mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) tras un nginx con bearer. Aquí no hace falta —el SDK de Python habla `streamable-http` de forma nativa, medido arriba— pero **sería la herramienta correcta** el día que se enchufe un servidor MCP ajeno que solo soporte `stdio`.)_
+
+### App REST: primer análisis por HTTP (H2, #86)
+
+Con el contrato y la orquestación ya cerrados en H1, esta parte es delgada a propósito: `backend/api/app.py` monta la aplicación, expone `POST /analyze` y `GET /health`, y delega. Se arranca aparte del servidor MCP:
+
+```bash
+uvicorn backend.api.app:app --reload
+```
+
+**`check_health()` sale de `register()`** en `core/health.py`. Antes vivía dentro de la tool MCP; ahora es una función de módulo que consumen **las dos fachadas**, porque dos sondeos independientes acabarían respondiendo cosas distintas sobre el mismo sistema.
+
+**`configure_logging()` va en el `lifespan`, no a nivel de módulo.** `structlog.configure()` muta estado global del proceso, y a nivel de módulo eso ocurriría **al importar** — que en pytest es durante la colección, antes de que exista ninguna fixture. El repo ya tiene una fixture `autouse` (`_reset_structlog`) puesta tras sufrir justo ese problema, pero **no protegería de un efecto en el import**. El `lifespan` solo corre cuando la app sirve de verdad: `TestClient(app)` no lo dispara, `with TestClient(app)` sí.
+
+**Lo que aporta esta parte no es el código, es la primera ejecución real.** Hasta aquí los 29 tests de la orquestación usaban dobles: el camino nunca se había recorrido contra HuggingFace ni contra el modelo de embeddings.
+
+| Escenario | Latencia |
+|---|---|
+| En caliente | **0,4–0,7 s** (pico observado de 3,8 s) |
+| Arranque de proceso en frío | ~20 s |
+| Primerísima ejecución | ~60 s (descarga de `all-MiniLM-L6-v2`) |
+
+Los 20 s **no son una limitación, son una consecuencia**: `IncoherenceDetector` carga el modelo de forma perezosa, en la primera petición, en vez de al arrancar. Precalentarlo en el `lifespan` los trasladaría del primer usuario a uvicorn — decisión de H4, con el `healthcheck` del contenedor delante, porque un arranque de 20 s cambia el `start_period`.
+
+**Y el sistema discrimina:**
+
+| Titular (con cuerpo coherente) | Veredicto | Señales |
+|---|---|---|
+| *Federal Reserve Holds Interest Rates Steady in March Meeting* | `factual` | las cuatro de acuerdo; lineal p=0.163, similitud 0.579 |
+| *17 Things Nobody Tells You About Moving Abroad* | **`ambiguo`** | zero-shot lo lee como *factual news*; léxico y lineal lo marcan (p=1.000) |
+
+El segundo caso merece atención: **es el escenario de discrepancia que se había trazado sobre el papel al diseñar el contrato, apareciendo por sí solo en la primera prueba real**. Un listicle dispara las pistas de superficie y la lectura semántica no lo acompaña. El sistema lo declara `ambiguo` en vez de resolverlo por mayoría — que es exactamente lo que el principio 3 pretendía.
+
+**Límites.** Sigue sin haber `/tools`, `/history` ni `/chat`. Los 12 tests nuevos cubren la capa HTTP (validación, delegación, CORS, OpenAPI) y **no repiten la orquestación**, que ya cubre `test_analyze.py`. Y `analyze.py` mantiene un efecto de importación conocido —`_api = get_nlp_backend()` a nivel de módulo— que congela el backend NLP al importar, igual que hace `tool.py`.
+
 
 
 "Aplico Rudin donde puedo —incoherencia(A MEDIAS, YA QUE EL MODELO NO) y léxico son intrínsecamente interpretables— y reservo lo post-hoc (LIME/SHAP), con sus límites de fidelidad, solo para la parte que depende de un transformer preentrenado que no puedo abrir de otro modo." !!!IMPORTANTE (NO MODIFICAR, RECORDAR POSTURA DEFINIDA)

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -1,0 +1,108 @@
+"""Aplicación REST.
+
+**Segundo punto de entrada del backend**, independiente del servidor MCP de
+``backend/main.py``: aquel arranca con ``mcp.run(transport="stdio")`` y sirve a
+un cliente MCP; éste arranca con uvicorn y sirve al frontend.
+
+    uvicorn backend.api.app:app --reload
+
+Los dos son **fachadas sobre el mismo núcleo**, no una encima de la otra. Por
+eso ``/analyze`` llama a la orquestación importándola, y ``/health`` reutiliza
+el mismo ``check_health`` que la tool MCP, en vez de dar un rodeo por el
+protocolo: pasar por MCP significaría serializar a JSON *string* y volver a
+parsear, para acabar en la misma función.
+
+Se descartaron dos alternativas: montar la API dentro de ``main.py`` compartiendo
+el objeto ``mcp`` en memoria
+y hacer que la API sea cliente MCP por HTTP desde ya (obliga a cambiar el
+transporte a ``streamable-http`` antes de necesitarlo). Esa decisión se afronta
+al llegar a ``/tools``, que sí necesita la capa MCP: enumerar las herramientas
+conectadas en runtime no se puede hacer importando módulos.
+"""
+
+from contextlib import asynccontextmanager
+
+import structlog
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from backend.api.analyze import analyze
+from backend.api.schemas import AnalyzeRequest, AnalyzeResponse
+from backend.config.settings import settings
+from backend.core.health import check_health
+from backend.core.logging import configure_logging
+
+log = structlog.get_logger()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Configura el logging al arrancar, no al importar.
+
+    Importar el módulo no debe tener efectos secundarios: los tests lo importan
+    para construir el cliente y no deberían heredar la configuración global de
+    structlog.
+    """
+    configure_logging()
+    log.info(
+        "api.start",
+        service="clickbait-api",
+        nlp_backend=settings.nlp_backend,
+        cors_origins=settings.cors_origins,
+    )
+    yield
+
+
+app = FastAPI(
+    title="ClickBait Analysis API",
+    description=(
+        "API REST del TFG *Agente inteligente basado en MCP para la detección y "
+        "análisis de clickbait en medios digitales*.\n\n"
+        "El sistema **no emite un veredicto único de caja negra**: contrasta "
+        "varias señales de distinta naturaleza (interpretable, híbrida y opaca) "
+        "y las agrupa por lo que miden —forma, engaño y tono—, declarando las "
+        "discrepancias en vez de promediarlas."
+    ),
+    version="0.3.0-dev",
+    lifespan=lifespan,
+)
+
+# `allow_credentials` concede permiso para que viajen cookies, autenticación
+# HTTP y certificados de cliente en peticiones de otro origen (por defecto el
+# navegador NO los manda). Queda en False porque aquí no hay ninguna de esas
+# cosas: sería conceder un permiso que nadie usa.
+#
+# Ojo con el malentendido habitual: NO hace falta para tokens `Authorization:
+# Bearer`, que son una cabecera corriente cubierta por `allow_headers`. Así que
+# probablemente no haya que activarlo ni cuando llegue la autenticación.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origins,
+    allow_credentials=False,
+    allow_methods=["GET", "POST"],
+    allow_headers=["*"],
+)
+
+
+@app.post("/analyze", response_model=AnalyzeResponse, tags=["análisis"])
+async def post_analyze(request: AnalyzeRequest) -> AnalyzeResponse:
+    """Analiza un titular contrastando todas las señales disponibles.
+
+    Devuelve **200 aunque alguna señal falle**: cada una lleva su propio
+    `status`, y perder tres análisis correctos porque el cuarto dio timeout
+    sería un error. Si el cuerpo de la noticia no se
+    envía, la señal de incoherencia queda en `no_aplicable` y la dimensión de
+    engaño no se puede evaluar.
+    """
+    return await analyze(request)
+
+
+@app.get("/health", tags=["operación"])
+async def get_health() -> dict:
+    """Estado de las integraciones externas.
+
+    Sondea cada API con una petición ligera y agrega: `ok` si todas responden,
+    `degraded` si alguna falla, `down` si ninguna. Es el mismo sondeo que expone
+    la tool MCP `health_check`.
+    """
+    return await check_health()

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -20,5 +20,10 @@ class Settings(BaseSettings):
         "remote"  # Añadimos dos opciones de backend NLP, así mantenemos remoto sin cambiar mucho.
     )
 
+    # Orígenes permitidos por CORS. Configurable porque el frontend vive
+    # en localhost:4200 en desarrollo pero no en despliegue. Desde el
+    # entorno se pasa como JSON: CORS_ORIGINS='["https://ejemplo.org"]'
+    cors_origins: list[str] = ["http://localhost:4200"]
+
 
 settings = Settings()  # type: ignore #Activa la validación al importar

--- a/backend/core/health.py
+++ b/backend/core/health.py
@@ -46,6 +46,22 @@ def _aggregate_status(integrations: dict) -> Literal["ok", "degraded", "down"]:
     return "degraded"
 
 
+async def check_health() -> dict:
+    """Sondea todas las integraciones y agrega su estado.
+
+    Vive fuera de ``register`` porque lo consumen DOS fachadas: la tool MCP de
+    abajo y ``GET /health`` de la API REST. Duplicar el sondeo llevaría a
+    que las dos respondieran cosas distintas.
+    """
+    results = await asyncio.gather(*(_probe(**cfg) for cfg in PROBES.values()))
+    integrations = dict(zip(PROBES, results))
+    return {
+        "status": _aggregate_status(integrations),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "integrations": integrations,
+    }
+
+
 def register(mcp: FastMCP):
     @mcp.tool()
     @log_tool_invocation
@@ -55,10 +71,4 @@ def register(mcp: FastMCP):
         Returns:
             dict: Diccionario con estado, timestamp e integraciones
         """
-        results = await asyncio.gather(*(_probe(**cfg) for cfg in PROBES.values()))
-        integrations = dict(zip(PROBES, results))
-        return {
-            "status": _aggregate_status(integrations),
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "integrations": integrations,
-        }
+        return await check_health()

--- a/docs/requisitos.md
+++ b/docs/requisitos.md
@@ -35,7 +35,8 @@ Este documento define los requisitos para un Trabajo de Fin de Grado (TFG) que i
 5. SI falla la ejecución de una herramienta, ENTONCES EL MCP_Server DEBERÁ devolver una respuesta de error estructurada con detalles.
 6. EL MCP_Server DEBERÁ poder exponerse mediante **transporte HTTP** (`streamable-http`) además de `stdio`, para permitir su despliegue como contenedor independiente. _(Precondición del desacople: `stdio` exige que el cliente lance el servidor como subproceso, lo que no cruza contenedores.)_
 7. EL sistema DEBERÁ admitir la conexión a **varios MCP_Server especialistas** declarados por configuración; añadir o retirar uno NO DEBERÁ requerir cambios de código.
-8. SI un MCP_Server declarado no responde, ENTONCES el sistema DEBERÁ seguir operando con los restantes y reflejar su estado degradado.
+8. SI un MCP_Server declarado no responde, ENTONCES el sistema DEBERÁ seguir operando con los restantes y reflejar su estado degradado. _(Alcance: **servidores MCP**, no las APIs externas que consumen sus tools — eso es R2.8. Ver memoria de cambios.)_
+9. Añadir una nueva MCP_Tool —una fuente de datos o una señal de análisis— NO DEBERÁ requerir modificar las herramientas existentes ni la interfaz web. _(Mitad de servidor: registro por módulo. Mitad de interfaz: el envoltorio uniforme de señales, R5.8. Ver memoria de cambios.)_
 
 ### Requisito 2: Herramientas de integración de API públicas
 
@@ -50,6 +51,7 @@ Este documento define los requisitos para un Trabajo de Fin de Grado (TFG) que i
 5. CUANDO se reciban respuestas de la API, EL API_Consumer DEBERÁ validar la estructura de la respuesta antes de procesarla.
 6. CUANDO se realice una llamada a la API, EL API_Consumer DEBERÁ rastrear el número de llamadas a la API utilizadas y registrarlo como **observabilidad interna** (logs). _(No se devuelve en la salida de la tool para no ensuciar la respuesta — ver memoria de cambios.)_
 7. DONDE una API tenga límites de uso, EL API_Consumer DEBERÁ rastrear la cuota restante y registrarla como **observabilidad interna** (logs). _(Ver memoria de cambios.)_
+8. SI una API externa declarada no responde, ENTONCES el sistema DEBERÁ seguir operando con las restantes y reflejar su estado degradado. _(Distinto de R1.8, que habla de servidores MCP. Ya satisfecho por el health check desde la Épica 1. Ver memoria de cambios.)_
 
 ### Requisito 3: Herramientas de análisis de texto con NLP
 

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,10 @@ fastmcp
 httpx
 pydantic-settings
 
+
+fastapi
+uvicorn
+
 pytest
 pytest-asyncio
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,9 @@ aiofile==3.9.0
 aiolimiter==1.2.1
     # via -r requirements.in
 annotated-doc==0.0.4
-    # via typer
+    # via
+    #   fastapi
+    #   typer
 annotated-types==0.7.0
     # via pydantic
 anyio==4.12.1
@@ -60,6 +62,8 @@ email-validator==2.3.0
     # via pydantic
 exceptiongroup==1.3.1
     # via fastmcp
+fastapi==0.141.1
+    # via -r requirements.in
 fastmcp==3.1.0
     # via -r requirements.in
 filelock==3.29.4
@@ -154,6 +158,7 @@ pycparser==3.0
     # via cffi
 pydantic[email]==2.12.5
     # via
+    #   fastapi
     #   fastmcp
     #   mcp
     #   openapi-pydantic
@@ -224,6 +229,7 @@ sse-starlette==3.3.2
     # via mcp
 starlette==0.52.1
     # via
+    #   fastapi
     #   mcp
     #   sse-starlette
 structlog==25.5.0
@@ -244,6 +250,7 @@ typing-extensions==4.15.0
     # via
     #   anyio
     #   exceptiongroup
+    #   fastapi
     #   huggingface-hub
     #   mcp
     #   opentelemetry-api
@@ -256,6 +263,7 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via
+    #   fastapi
     #   mcp
     #   pydantic
     #   pydantic-settings
@@ -263,6 +271,7 @@ uncalled-for==0.2.0
     # via fastmcp
 uvicorn==0.41.0
     # via
+    #   -r requirements.in
     #   fastmcp
     #   mcp
 watchfiles==1.1.1

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -1,0 +1,156 @@
+"""Tests de la capa HTTP (R4).
+
+Aquí NO se prueba la orquestación —eso es `test_analyze.py`— sino lo que añade
+FastAPI encima: validación de entrada, delegación, CORS y OpenAPI. Por eso se
+sustituyen `analyze` y `check_health` en el namespace de `app`: las rutas los
+resuelven como globales del módulo en cada llamada.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api import app as app_mod
+from backend.api.app import app
+from backend.api.schemas import (
+    AnalyzeResponse,
+    Dimension,
+    DimensionVerdict,
+    OverallVerdict,
+    SignalResult,
+    SignalStatus,
+    SignalType,
+)
+from backend.config.settings import settings
+
+client = TestClient(app)
+
+
+def _respuesta(headline="Un titular", content=None):
+    return AnalyzeResponse(
+        headline=headline,
+        content=content,
+        signals=[
+            SignalResult(
+                name="detect_clickbait_lexical",
+                status=SignalStatus.OK,
+                dimension=Dimension.FORMA,
+                type=SignalType.INTERPRETABLE,
+                is_clickbait=True,
+                data={"score": 2, "is_clickbait": True},
+            )
+        ],
+        dimensions=[
+            DimensionVerdict(
+                dimension=Dimension.FORMA,
+                is_clickbait=True,
+                contributing=["detect_clickbait_lexical"],
+            )
+        ],
+        verdict=OverallVerdict.CLICKBAIT_DE_FORMA,
+    )
+
+
+@pytest.fixture
+def analisis(monkeypatch):
+    """Sustituye la orquestación y captura con qué se la llamó."""
+    recibido = {}
+
+    async def falso_analyze(request):
+        recibido["request"] = request
+        return _respuesta(request.headline, request.content)
+
+    monkeypatch.setattr(app_mod, "analyze", falso_analyze)
+    return recibido
+
+
+# ----- POST /analyze -----
+
+
+def test_analyze_devuelve_la_respuesta_completa(analisis):
+    response = client.post("/analyze", json={"headline": "Un titular"})
+
+    assert response.status_code == 200
+    cuerpo = response.json()
+    assert cuerpo["verdict"] == "clickbait_de_forma"
+    assert cuerpo["signals"][0]["name"] == "detect_clickbait_lexical"
+    # El JSON crudo de la herramienta viaja sin aplanar: alimenta las tarjetas
+    # de explicabilidad.
+    assert cuerpo["signals"][0]["data"] == {"score": 2, "is_clickbait": True}
+
+
+def test_analyze_pasa_el_cuerpo_a_la_orquestacion(analisis):
+    client.post("/analyze", json={"headline": "Un titular", "content": "El cuerpo"})
+    assert analisis["request"].content == "El cuerpo"
+
+
+def test_sin_content_la_peticion_es_valida(analisis):
+    # El cuerpo es opcional: sin él sólo se pierde la dimensión de engaño.
+    assert client.post("/analyze", json={"headline": "Un titular"}).status_code == 200
+    assert analisis["request"].content is None
+
+
+@pytest.mark.parametrize("blanco", [" ", "", "\t\n"])
+def test_titular_en_blanco_es_422(blanco, analisis):
+    # 422 y no un 200 con `sin_datos`: la petición es inválida, no es que el
+    # análisis no haya dado resultado.
+    assert client.post("/analyze", json={"headline": blanco}).status_code == 422
+
+
+def test_falta_el_titular_es_422(analisis):
+    assert client.post("/analyze", json={}).status_code == 422
+
+
+def test_el_titular_llega_normalizado(analisis):
+    client.post("/analyze", json={"headline": "  Un titular  "})
+    assert analisis["request"].headline == "Un titular"
+
+
+# ----- GET /health -----
+
+
+def test_health_expone_el_estado_agregado(monkeypatch):
+    async def falso_check():
+        return {
+            "status": "degraded",
+            "timestamp": "2026-08-04T00:00:00+00:00",
+            "integrations": {"nyt": {"reachable": False, "error": "boom"}},
+        }
+
+    monkeypatch.setattr(app_mod, "check_health", falso_check)
+
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "degraded"
+
+
+# ----- CORS (R4.7) y OpenAPI (R4.8) -----
+
+
+def test_cors_permite_el_origen_configurado():
+    origen = settings.cors_origins[0]
+    response = client.options(
+        "/analyze",
+        headers={"Origin": origen, "Access-Control-Request-Method": "POST"},
+    )
+    assert response.headers["access-control-allow-origin"] == origen
+
+
+def test_cors_rechaza_un_origen_no_declarado():
+    response = client.options(
+        "/analyze",
+        headers={
+            "Origin": "http://origen-no-declarado.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_openapi_documenta_las_rutas_y_el_contrato():
+    esquema = client.get("/openapi.json").json()
+
+    assert set(esquema["paths"]) == {"/analyze", "/health"}
+    # Las descripciones de los Field llegan al esquema: son lo que ve quien
+    # consume /docs y lo que hereda el cliente TypeScript generado.
+    propiedades = esquema["components"]["schemas"]["SignalResult"]["properties"]
+    assert "herramienta MCP" in propiedades["name"]["description"]


### PR DESCRIPTION
## #86 · App FastAPI: `/analyze` y `/health`

Closes #86

Segundo entry point del backend, independiente del servidor MCP. Con el contrato
y la orquestación ya cerrados en #85, el código es delgado a propósito —monta la
app y delega—; lo que aporta esta PR es **la primera ejecución real**.

### Qué incluye
- `backend/api/app.py`: `POST /analyze` y `GET /health`, CORS con orígenes por
  setting, OpenAPI en `/docs`. Se arranca con `uvicorn backend.api.app:app`.
- `backend/core/health.py`: `check_health()` sale de `register()`. Lo consumen la
  tool MCP y el endpoint REST; dos sondeos independientes acabarían respondiendo
  cosas distintas sobre el mismo sistema.
- `requirements.in`: `fastapi` no era dependencia del proyecto —`starlette` y
  `uvicorn` entraban por arrastre del SDK de MCP—, así que R4.1 no era ni
  instalable. `uvicorn` pasa a declararse explícito: se invoca a mano.
- 12 tests de la capa HTTP. No repiten la orquestación, que ya cubre
  `test_analyze.py`. Total **98 passed**.

### El hallazgo
Hasta aquí los 29 tests de la orquestación usaban dobles: el camino nunca se
había recorrido contra HuggingFace ni contra el modelo de embeddings.

| Titular (con cuerpo coherente) | Veredicto |
|---|---|
| *Federal Reserve Holds Interest Rates Steady* | `factual` — las cuatro de acuerdo |
| *17 Things Nobody Tells You About Moving Abroad* | **`ambiguo`** |

El segundo **es el caso de discrepancia que se trazó sobre el papel al diseñar el
contrato, apareciendo por sí solo en la primera prueba real**: el listicle dispara
las pistas de superficie (léxico y lineal, p=1.000) y el zero-shot lo lee como
*factual news*. El sistema lo declara en vez de resolverlo por mayoría.

Latencias: **0,4–0,7 s en caliente**, ~20 s de arranque en frío, ~60 s la primera
vez. Los 20 s no son una limitación sino consecuencia de que el modelo de
embeddings carga perezosamente; precalentarlo en el `lifespan` es decisión de H4,
con el `healthcheck` del contenedor delante.

### Decisión de arquitectura y cambios de requisitos
Al montar la app había que decidir la topología, y replicar la del entorno
profesional del autor —un contenedor por MCP especialista— se apoyaba en una
premisa que aquí no se cumple: allí los especialistas ya existen y son de
terceros; aquí se escriben en este repo y comparten `BaseAPI`/`ToolResult`.

**Tres contenedores** (MCP, API, web). Lo sostienen mediciones, no intuición: un
spike levantó el servidor real con `streamable-http` —handshake 0,212 s,
`list_tools` 0,036 s— y confirmó que `call_tool` devuelve un JSON *string*, así
que pasar `/analyze` por MCP sería `dict → dumps → TextContent → loads → dict`. Y
la memoria, que era el argumento fuerte para separar `nlp`, **ya estaba resuelta
por la carga perezosa**.

- **R1.8 acotado**: su letra («si un MCP_Server declarado no responde») y la
  intención del autor («si una API declarada no está») no se contradecían —
  hablan de listas distintas.
- **R2.8 nuevo**: esa intención puesta donde le corresponde. Ya satisfecho.
- **R1.9 nuevo**: añadir una fuente o señal no debe obligar a tocar las
  existentes ni la interfaz. Medio cumplido por el envoltorio uniforme.
- **R1.7 sin cambios**: no hace falta hoy, pero dejar la puerta abierta es gratis.

### Notas
Incluye también la sección de H1 en el README —el contrato de `/analyze`— que
quedó pendiente al mergear #85.

Sin cubrir: `/tools`, `/history` y `/chat`. Y `analyze.py` mantiene un efecto de
importación que congela el backend NLP al importar; documentado y medido en un
issue aparte.
