### PR TITLE
chore(ci): adoptar ruff como linter y formateador

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,12 @@ jobs:
         run: pip install -r requirements.txt
       - name: Corriendo tests...
         run: pytest -m "not integration"
+      # Después de los tests a propósito: si el estilo falla, el informe de tests
+      # ya se ha generado. Ruff se instala aparte y pineado —no desde
+      # requirements.txt— para no meter tooling de desarrollo en las
+      # dependencias de ejecución. Reglas y exclusiones, en ruff.toml.
+      - name: Comprobando estilo...
+        run: |
+          pip install ruff==0.16.1
+          ruff check .
+          ruff format --check .

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ Cada rama de trabajo parte de `dev` (recién actualizada: tras un squash la rama
 
 Ejemplos: `feat/72-splits-train-dev-test`, `feat/86-app-fastapi`, `fix/lexico-cue-una-letra`. El número se omite cuando el trabajo no tiene issue (típico en `docs/`).
 
+### Estilo
+
+`ruff` hace de linter y formateador; las reglas activas y las exclusiones están en [`ruff.toml`](ruff.toml), y el CI lo comprueba en cada PR.
+
+```bash
+ruff check . --fix     # corrige lo automatizable
+ruff format .          # reformatea
+```
+
 ### Commits — Conventional Commits
 
 Formato: `tipo(scope): descripción`
@@ -1024,6 +1033,25 @@ Los 20 s **no son una limitación, son una consecuencia**: `IncoherenceDetector`
 El segundo caso merece atención: **es el escenario de discrepancia que se había trazado sobre el papel al diseñar el contrato, apareciendo por sí solo en la primera prueba real**. Un listicle dispara las pistas de superficie y la lectura semántica no lo acompaña. El sistema lo declara `ambiguo` en vez de resolverlo por mayoría — que es exactamente lo que el principio 3 pretendía.
 
 **Límites.** Sigue sin haber `/tools`, `/history` ni `/chat`. Los 12 tests nuevos cubren la capa HTTP (validación, delegación, CORS, OpenAPI) y **no repiten la orquestación**, que ya cubre `test_analyze.py`. Y `analyze.py` mantiene un efecto de importación conocido —`_api = get_nlp_backend()` a nivel de módulo— que congela el backend NLP al importar, igual que hace `tool.py`.
+
+### Análisis estático: adopción de ruff
+
+El proyecto no había tenido nunca linter. Se adopta [`ruff`](https://docs.astral.sh/ruff/) —linter y formateador en un binario, sustituto de la pila flake8 + isort + pyupgrade + black— y el CI lo comprueba en cada PR.
+
+**El conjunto de reglas se declara explícitamente** en `ruff.toml` en vez de heredar el de por defecto. La razón no es purismo: ruff amplía sus defaults entre versiones, y confiando en ellos **una actualización de la herramienta rompería el CI sin que cambiara una línea de código**. Por lo mismo, la versión va pineada.
+
+Tres reglas se desactivan a conciencia:
+
+- **`BLE001`** (capturar `Exception`) — chocaría con la arquitectura, no con un descuido. Capturar excepciones amplias en las fronteras de integración es lo que sostiene el aislamiento de fallos de todo el sistema: `ToolResult.fail`, `gather(return_exceptions=True)`, R6.13. Una señal caída no puede tumbar a las demás, y para eso hay que capturar lo que sea que lance el proveedor.
+- **`E501`** (línea larga) — el formateador ya mantiene el *código* dentro del ancho; lo que no puede partir son literales y prosa. Sus 62 avisos caían casi todos en payloads simulados de los tests (hasta 196 caracteres).
+- **`RUF001-003`** (caracteres Unicode ambiguos) — existen para detectar homoglifos (cirílico disfrazado de latino). Aquí sólo saltaban por comillas tipográficas en texto español legítimo.
+
+**Dos hallazgos reales**, que es lo que justifica el ejercicio:
+
+- **`DTZ011` — zona horaria implícita.** Los clientes de Guardian y NYT calculaban la ventana de «noticias de los últimos N días» con `date.today()`, que usa la zona de la máquina. En Docker el contenedor va en UTC y el equipo de desarrollo no, así que **la misma consulta habría devuelto rangos distintos según dónde se ejecutara**, con un día de desfase cerca de medianoche. Corregido a `datetime.now(timezone.utc).date()`. Es exactamente el tipo de fallo que H4 habría destapado en el peor momento.
+- **`B905` — `zip()` sin `strict`.** Ocho sitios. `zip` **trunca en silencio** al iterable más corto, y el más delicado es `linear.py`, que empareja pesos, nombres de features y vector de entrada: si esos tres dejaran de cuadrar, cada peso se atribuiría al cue equivocado y **la explicación sería falsa** sin que nada avisara. En un trabajo cuyo eje es la explicabilidad, eso es el peor fallo posible. Los ocho pasan a `strict=True` —ruff sólo propone `strict=False`, que hace explícito el truncado pero no lo arregla—, convirtiendo un resultado silenciosamente incorrecto en un error ruidoso. Verificado sobre datos reales: las invariantes se cumplían, ahora quedan vigiladas.
+
+Balance: 43 avisos iniciales, 26 corregidos automáticamente, 12 con criterio y 5 desactivados por regla. 26 ficheros tocados, 98 tests en verde.
 
 
 

--- a/backend/api/analyze.py
+++ b/backend/api/analyze.py
@@ -24,8 +24,9 @@ pudo calcular.
 """
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable
+from typing import Any
 
 from backend.api.schemas import (
     AnalyzeRequest,
@@ -177,7 +178,7 @@ async def _run_signals(headline: str, content: str | None) -> list[SignalResult]
     # gather conserva el ORDEN DE ENTRADA, no el de finalización: aunque el
     # zero-shot tarde 3 s y el léxico 2 ms, cada resultado vuelve en la posición
     # de su spec. Por eso el zip es correcto.
-    for spec, outcome in zip(pending, outcomes):
+    for spec, outcome in zip(pending, outcomes, strict=True):
         if isinstance(outcome, BaseException):
             # BaseException y no Exception: asyncio.CancelledError hereda de la
             # primera desde Python 3.8 y gather también la deposita en la lista.

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -22,6 +22,7 @@ conectadas en runtime no se puede hacer importando módulos.
 
 from contextlib import asynccontextmanager
 
+import numpy as np  # Import sin usar para probar check de ruff
 import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -22,7 +22,6 @@ conectadas en runtime no se puede hacer importando módulos.
 
 from contextlib import asynccontextmanager
 
-import numpy as np  # Import sin usar para probar check de ruff
 import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware

--- a/backend/core/base_api.py
+++ b/backend/core/base_api.py
@@ -1,10 +1,10 @@
 import asyncio
 
-from aiolimiter import AsyncLimiter
 import httpx
+import structlog
+from aiolimiter import AsyncLimiter
 
 from backend.core.models import ToolResult
-import structlog
 
 log = structlog.get_logger()
 
@@ -114,7 +114,7 @@ class BaseAPI:
                         f"HTTP error: {e.response.status_code} - {e.response.text}"
                     )
                 except Exception as e:
-                    return ToolResult.fail(f"An error occurred: {str(e)}")
+                    return ToolResult.fail(f"An error occurred: {e!s}")
 
     # Luego reescribirmos en otra clase que herede de Base API y tenemos POLIMORFISMO!
 

--- a/backend/core/health.py
+++ b/backend/core/health.py
@@ -54,7 +54,7 @@ async def check_health() -> dict:
     que las dos respondieran cosas distintas.
     """
     results = await asyncio.gather(*(_probe(**cfg) for cfg in PROBES.values()))
-    integrations = dict(zip(PROBES, results))
+    integrations = dict(zip(PROBES, results, strict=True))
     return {
         "status": _aggregate_status(integrations),
         "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/backend/core/logging.py
+++ b/backend/core/logging.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 
-
 import structlog
 
 from backend.config.settings import settings

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -1,14 +1,14 @@
 from typing import Any
 
-#Usado para validación de campos.
+# Usado para validación de campos.
 from pydantic import BaseModel
+
 
 class ToolResult(BaseModel):
     success: bool
     data: Any | None = None
     error: str | None = None
-    
-    
+
     @classmethod
     def ok(cls, data: Any) -> "ToolResult":
         return cls(success=True, data=data)
@@ -16,6 +16,6 @@ class ToolResult(BaseModel):
     @classmethod
     def fail(cls, error_message: str) -> "ToolResult":
         return cls(success=False, error=error_message)
-    
+
     def has_content(self) -> bool:
         return self.success and self.data is not None

--- a/backend/evaluation/eval_external.py
+++ b/backend/evaluation/eval_external.py
@@ -39,19 +39,21 @@ if __name__ == "__main__":
     data = load_external()
     y_true = [label for _, label, _ in data]
     pos = sum(y_true)
-    print(f"Webis-17 (externo): {len(data)} muestras, {pos} clickbait ({pos/len(data):.1%})")
+    print(
+        f"Webis-17 (externo): {len(data)} muestras, {pos} clickbait ({pos / len(data):.1%})"
+    )
 
     y_rules = [
         1 if lexical.detect(h).data["score"] >= lexical.THRESHOLD else 0
         for h, _, _ in data
     ]
-    y_linear = [
-        1 if linear.predict(h).data["is_clickbait"] else 0 for h, _, _ in data
-    ]
+    y_linear = [1 if linear.predict(h).data["is_clickbait"] else 0 for h, _, _ in data]
 
     for name, y_pred in (("reglas", y_rules), ("lineal", y_linear)):
         p, r, f1, _ = precision_recall_fscore_support(
             y_true, y_pred, average="binary", zero_division=0
         )
         tn, fp, fn, tp = confusion_matrix(y_true, y_pred, labels=[0, 1]).ravel()
-        print(f"{name}: P={p:.3f}  R={r:.3f}  F1={f1:.3f}   (tp={tp} fp={fp} fn={fn} tn={tn})")
+        print(
+            f"{name}: P={p:.3f}  R={r:.3f}  F1={f1:.3f}   (tp={tp} fp={fp} fn={fn} tn={tn})"
+        )

--- a/backend/evaluation/eval_lexical.py
+++ b/backend/evaluation/eval_lexical.py
@@ -1,11 +1,11 @@
 import gzip  # Descompresión en memoria (wow)
 from pathlib import Path
 
-import numpy as np
 from sklearn.metrics import (
     confusion_matrix,
     precision_recall_fscore_support,
 )  # Import conjunto
+
 from backend.integrations.nlp import lexical
 
 DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data"  # Carpeta data

--- a/backend/evaluation/linear_model.py
+++ b/backend/evaluation/linear_model.py
@@ -1,13 +1,11 @@
+import json
 from collections import Counter
-
-from backend.evaluation.splits import load_split
-from backend.integrations.nlp import lexical
-
 
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import precision_recall_fscore_support
-import json
 
+from backend.evaluation.splits import load_split
+from backend.integrations.nlp import lexical
 from backend.integrations.nlp.linear import JSON_FILE, featurize_cues
 
 
@@ -31,12 +29,11 @@ def featurize(headline) -> list[int]:  # -> vector
 
 
 if __name__ == "__main__":
-
     # Splits FÍSICOS (issue #72): mismos ficheros para todos los modelos.
     # El split ya no se hace aquí: se carga (python -m backend.evaluation.splits para crearlos).
     # test NO se carga: congelado hasta el número final del issue.
-    train_h, y_train = zip(*load_split("train"))
-    dev_h, y_dev = zip(*load_split("dev"))
+    train_h, y_train = zip(*load_split("train"), strict=True)
+    dev_h, y_dev = zip(*load_split("dev"), strict=True)
 
     # Features (MULTI_HOT por cue): cada consumidor featuriza aguas abajo.
     X_train = [featurize_cues(h) for h in train_h]
@@ -74,7 +71,7 @@ if __name__ == "__main__":
     )
 
     weight_table = sorted(
-        zip(feature_names, model.coef_[0]),
+        zip(feature_names, model.coef_[0], strict=True),
         key=lambda par: par[1],
         reverse=True,
     )

--- a/backend/evaluation/splits.py
+++ b/backend/evaluation/splits.py
@@ -45,7 +45,7 @@ def create_splits(force: bool = False) -> None:
             "Regenerarlos invalida los resultados previos; usa force=True solo a sabiendas."
         )
 
-    headlines, labels = zip(*load_dataset())
+    headlines, labels = zip(*load_dataset(), strict=True)
 
     # 1) Se congela el test (nunca se re-baraja).
     h_rest, h_test, y_rest, y_test = train_test_split(
@@ -63,7 +63,7 @@ def create_splits(force: bool = False) -> None:
         "test": (h_test, y_test),
     }.items():
         with open(_path(name), "w", encoding="utf-8") as f:
-            for headline, label in zip(hs, ys):
+            for headline, label in zip(hs, ys, strict=True):
                 f.write(
                     json.dumps(
                         {"headline": headline, "label": label}, ensure_ascii=False

--- a/backend/integrations/guardian/client.py
+++ b/backend/integrations/guardian/client.py
@@ -1,15 +1,12 @@
 # Constants
-from backend.core.base_api import BaseAPI
-from backend.core.models import ToolResult
-from datetime import date
-from datetime import timedelta
-
+from datetime import datetime, timedelta, timezone
 
 from backend.config.settings import settings
+from backend.core.base_api import BaseAPI
+from backend.core.models import ToolResult
 
 
 class GuardianAPI(BaseAPI):
-
     BASE_URL = "https://content.guardianapis.com/"
 
     API_KEY = settings.guardian_api_key  # Key ya validada
@@ -47,7 +44,10 @@ class GuardianAPI(BaseAPI):
             ToolResult.ok([{title, url, date, content}, ...]) si hay artículos.
             ToolResult.fail("No articles found") si results está vacío o ausente.
         """
-        today = date.today()
+        # UTC explícito, no la zona de la máquina: en Docker el contenedor va en
+        # UTC y el equipo de desarrollo no, así que `date.today()` desplazaría la
+        # ventana de búsqueda un día cerca de medianoche según dónde se ejecute.
+        today = datetime.now(timezone.utc).date()
         new_date = today - timedelta(days=days)
         params = {"from-date": new_date, "show-fields": "trailText"}
         if topic:  # Usa buscador de tags

--- a/backend/integrations/nlp/incoherence.py
+++ b/backend/integrations/nlp/incoherence.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from backend.core.models import ToolResult
 
 

--- a/backend/integrations/nlp/lexical.py
+++ b/backend/integrations/nlp/lexical.py
@@ -1,5 +1,6 @@
+import ast
+import re
 from pathlib import Path
-import re, ast
 
 from backend.core.models import ToolResult
 

--- a/backend/integrations/nlp/linear.py
+++ b/backend/integrations/nlp/linear.py
@@ -1,6 +1,6 @@
-from collections import Counter
 import json
 import math
+from collections import Counter
 from pathlib import Path
 
 from backend.core.models import ToolResult
@@ -11,7 +11,7 @@ JSON_FILE = Path(__file__).resolve().parent / "linear_clickbait.json"
 # print(str(JSON_FILE))
 
 
-with open(JSON_FILE, "r", encoding="utf-8") as f:
+with open(JSON_FILE, encoding="utf-8") as f:
     JSON = json.load(f)
 
 
@@ -28,9 +28,9 @@ def featurize_cues(headline) -> list[int]:  # -> vector
 
     contador_category = Counter(categories_list)
     contador_cue = Counter(cue_list)
-    vector = list(contador_category[cat] for cat in lexical.PATTERNS) + list(
+    vector = [contador_category[cat] for cat in lexical.PATTERNS] + [
         contador_cue[cue] for cue in lexical.ALL_CUES
-    )
+    ]
     return vector
 
 
@@ -41,7 +41,7 @@ def predict(headline):
 
     vector = featurize_cues(headline)
     contribs = []
-    for w, name, x in zip(JSON["weights"], JSON["feature_names"], vector):
+    for w, name, x in zip(JSON["weights"], JSON["feature_names"], vector, strict=True):
         if x != 0:
             contr = w * x
             contribs.append((name, contr))

--- a/backend/integrations/nlp/local.py
+++ b/backend/integrations/nlp/local.py
@@ -1,11 +1,10 @@
+import asyncio
+
 from backend.core.models import ToolResult
 from backend.integrations.nlp.base import NLPBackend
 
-import asyncio
-
 
 class LocalNLPClient(NLPBackend):
-
     # Evitamos cargar en cada llamada añadiendo permanencia
     def __init__(self) -> None:
 

--- a/backend/integrations/nlp/tool.py
+++ b/backend/integrations/nlp/tool.py
@@ -5,6 +5,7 @@ NLP Tool: detección de clickbait en titulares (zero-shot).
 import json
 
 from mcp.server.fastmcp import FastMCP
+
 from backend.core.observability import log_tool_invocation
 from backend.integrations.nlp import lexical, linear, model_cards
 from backend.integrations.nlp.factory import get_nlp_backend

--- a/backend/integrations/nyt/client.py
+++ b/backend/integrations/nyt/client.py
@@ -1,14 +1,11 @@
-from backend.core.base_api import BaseAPI
-from backend.core.models import ToolResult
-from datetime import date
-from datetime import timedelta
-
+from datetime import datetime, timedelta, timezone
 
 from backend.config.settings import settings
+from backend.core.base_api import BaseAPI
+from backend.core.models import ToolResult
 
 
 class NYTAPI(BaseAPI):
-
     BASE_URL = "https://api.nytimes.com/svc/search/v2/"
 
     API_KEY = settings.nyt_api_key  # Key ya validada
@@ -51,7 +48,10 @@ class NYTAPI(BaseAPI):
             ToolResult.ok([{title, print_headline, url, date, content}, ...]) si hay artículos.
             ToolResult.fail("No articles found") si docs está vacío o ausente.
         """
-        today = date.today()
+        # UTC explícito, no la zona de la máquina: en Docker el contenedor va en
+        # UTC y el equipo de desarrollo no, así que `date.today()` desplazaría la
+        # ventana de búsqueda un día cerca de medianoche según dónde se ejecute.
+        today = datetime.now(timezone.utc).date()
         new_date = (today - timedelta(days=days)).strftime("%Y%m%d")  # Formato YYYYMMDD
         params = {"begin_date": new_date, "sort": "relevance" if topic else "newest"}
         if topic:

--- a/backend/integrations/nyt/tool.py
+++ b/backend/integrations/nyt/tool.py
@@ -6,6 +6,7 @@ import json
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
+
 from backend.core.observability import log_tool_invocation
 from backend.integrations.nyt.client import NYTAPI
 

--- a/backend/integrations/weather/client.py
+++ b/backend/integrations/weather/client.py
@@ -1,12 +1,8 @@
-import httpx
-from typing import Any
-
 from backend.core.base_api import BaseAPI
 from backend.core.models import ToolResult
 
 
 class WeatherAPI(BaseAPI):
-
     # Constants
     BASE_URL = "https://api.weather.gov"
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,17 +2,16 @@
 Servidor MCP principal.
 """
 
-from backend.core.logging import configure_logging
 import structlog
-from backend.core import health
-from backend.config.settings import settings
-
 from mcp.server.fastmcp import FastMCP
 
+from backend.config.settings import settings
+from backend.core import health
+from backend.core.logging import configure_logging
 from backend.integrations.guardian import tool as guardian_tool
-from backend.integrations.weather import tool as weather_tool
-from backend.integrations.nyt import tool as nyt_tool
 from backend.integrations.nlp import tool as nlp_tool
+from backend.integrations.nyt import tool as nyt_tool
+from backend.integrations.weather import tool as weather_tool
 
 log = structlog.get_logger()
 mcp = FastMCP("tfg-mcp-server")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,10 @@ scikit-learn
 # En una máquina sin GPU, instala antes el torch de CPU:
 #   pip install torch --index-url https://download.pytorch.org/whl/cpu
 sentence-transformers
+#
+# --- Estilo: linter + formateador (configuración en ruff.toml) ---
+# Pineado a propósito, al contrario que el resto de este fichero: ruff añade
+# reglas entre versiones, y sin fijar la versión una actualización haría fallar
+# el CI sin que cambiara una línea de código. El CI lo instala por separado
+# (`pip install ruff==...`) para no meter tooling en las deps de ejecución.
+ruff==0.16.1

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,44 @@
+# Configuración de ruff (linter + formateador).
+#
+# El conjunto de reglas se declara EXPLÍCITAMENTE en vez de heredar el de por
+# defecto: ruff lo amplía entre versiones, y con los defaults una actualización
+# de la herramienta rompería el CI sin que cambiara una línea de código.
+
+exclude = ["spikes", ".venv", "data"]
+
+[lint]
+select = [
+    "E",   # pycodestyle: errores
+    "F",   # pyflakes: imports sin usar, nombres indefinidos
+    "I",   # isort: orden de imports
+    "UP",  # pyupgrade: sintaxis moderna
+    "B",   # bugbear: patrones que suelen ser bugs
+    "C4",  # comprehensions
+    "DTZ", # datetimes sin zona horaria
+    "RUF", # reglas propias de ruff
+]
+
+# NO se selecciona `BLE` (blind-except) a propósito: capturar `Exception` en las
+# fronteras de integración es DELIBERADO, y es lo que sostiene el aislamiento de
+# fallos de todo el sistema (ToolResult.fail, gather(return_exceptions=True)).
+# Una señal caída no puede tumbar a las demás, y para eso hay que
+# capturar lo que sea que lance el proveedor.
+
+ignore = [
+    # El formateador ya mantiene el CÓDIGO dentro del ancho; lo que no puede
+    # partir son literales y prosa. Aquí E501 sólo salta en payloads simulados
+    # de los tests (hasta 196 caracteres) y en comentarios: reescribirlos a mano
+    # es puro trasiego sin ganancia.
+    "E501",
+
+    # Detectan homoglifos (cirílico disfrazado de latino). Aquí sólo saltan por
+    # comillas tipográficas (’ “ —) en texto español e inglés perfectamente
+    # legítimo.
+    "RUF001",
+    "RUF002",
+    "RUF003",
+]
+
+[lint.per-file-ignores]
+# Los tests importan fixtures y módulos por su efecto de registro.
+"tests/**" = ["F401"]

--- a/tests/integrations/test_guardian.py
+++ b/tests/integrations/test_guardian.py
@@ -1,9 +1,10 @@
 from datetime import date, timedelta
 
-from backend.integrations.guardian.client import GuardianAPI
-import respx
 import pytest
+import respx
 from httpx import Response
+
+from backend.integrations.guardian.client import GuardianAPI
 
 TAGS_URL = "https://content.guardianapis.com/tags"
 SEARCH_URL = "https://content.guardianapis.com/search"

--- a/tests/integrations/test_nlp.py
+++ b/tests/integrations/test_nlp.py
@@ -4,16 +4,15 @@ import json
 import pytest
 import respx  # Usamos en vez de htttp, ya que no hacemos llamadas de verdad, mockeamos
 from httpx import Response, TimeoutException
-
 from mcp.server.fastmcp import FastMCP
 
+from backend.config.settings import settings
 from backend.integrations.nlp import lexical, linear, model_cards
 from backend.integrations.nlp import tool as nlp_tool
 from backend.integrations.nlp.client import HFClient
+from backend.integrations.nlp.factory import get_nlp_backend
 from backend.integrations.nlp.incoherence import IncoherenceDetector
 from backend.integrations.nlp.local import LocalNLPClient
-from backend.integrations.nlp.factory import get_nlp_backend
-from backend.config.settings import settings
 
 MODELS_URL = "https://router.huggingface.co/hf-inference/models/"
 

--- a/tests/integrations/test_nyt.py
+++ b/tests/integrations/test_nyt.py
@@ -1,7 +1,8 @@
-from backend.integrations.nyt.client import NYTAPI
-import respx
 import pytest
+import respx
 from httpx import Response
+
+from backend.integrations.nyt.client import NYTAPI
 
 
 @pytest.fixture

--- a/tests/integrations/test_weather.py
+++ b/tests/integrations/test_weather.py
@@ -1,7 +1,8 @@
-from backend.integrations.weather.client import WeatherAPI
-import respx
 import pytest
+import respx
 from httpx import Response
+
+from backend.integrations.weather.client import WeatherAPI
 
 
 @pytest.fixture

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,4 +1,5 @@
 from backend.main import mcp
 
+
 def test_smoke():
     assert mcp is not None


### PR DESCRIPTION
## Adopción de ruff (linter + formateador)

El proyecto no había tenido nunca análisis estático: ni linter, ni formateador,
ni paso de estilo en CI. La primera pasada sacó 43 avisos.

### Qué incluye
- `ruff.toml`: reglas y exclusiones, cada decisión con su porqué en el fichero.
- Paso de CI que comprueba `ruff check` y `ruff format --check` en cada PR.
- `ruff==0.16.1` en `requirements-dev.txt`. El CI lo instala **aparte** de
  `requirements.txt` para no meter tooling de desarrollo en las dependencias de
  ejecución.
- 26 ficheros con los arreglos aplicados.

### El conjunto de reglas se declara explícitamente
No se heredan los defaults de ruff: los amplía entre versiones, así que
confiando en ellos **una actualización de la herramienta rompería el CI sin que
cambiara una línea de código**. Por lo mismo la versión va pineada.

Tres decisiones de configuración, todas comentadas en `ruff.toml`:
- **`BLE` no se selecciona**: capturar `Exception` en las fronteras de
  integración es deliberado — es lo que sostiene el aislamiento de fallos
  (`ToolResult.fail`, `gather(return_exceptions=True)`, R6.13).
- **`E501` desactivada**: el formateador ya mantiene el código dentro del ancho.
  Sus 62 avisos caían casi todos en payloads simulados de los tests, de hasta
  196 caracteres.
- **`RUF001-003` desactivadas**: detectan homoglifos (cirílico disfrazado de
  latino); aquí sólo saltaban por comillas tipográficas en español legítimo.

`spikes/` queda excluido: es código desechable que documentó una decisión.

### Dos hallazgos reales
**`DTZ011` — zona horaria implícita.** Guardian y NYT calculaban la ventana de
«noticias de los últimos N días» con `date.today()`, que usa el reloj de la
máquina. El equipo de desarrollo va en Madrid y un contenedor Docker en UTC: a
las 00:30 en Madrid son las 22:30 UTC del día anterior, así que **la misma
consulta pedía rangos distintos según dónde se ejecutara**. Intermitente y
silencioso; habría aparecido en H4.

**`B905` — `zip()` sin `strict`.** Ocho sitios. `zip` trunca en silencio al
iterable más corto, y el crítico es `linear.py`, que empareja pesos, nombres de
features y vector de entrada: si dejaran de cuadrar —por ejemplo al añadir un
cue a `ALL_CUES` sin reentrenar—, cada peso se atribuiría al cue equivocado y
**`top_cues` daría una explicación falsa sin que nada avisara**. En un trabajo
cuyo eje es la explicabilidad, una explicación falsa es peor que un número mal,
porque convence. Los ocho pasan a `strict=True`; ruff sólo propone
`strict=False`, que hace explícito el truncado pero no lo corrige. Verificado
sobre datos reales: las invariantes se cumplían, ahora quedan vigiladas.

### Notas
El paso de estilo va **después** de los tests a propósito: si el estilo falla,
el informe de tests ya se ha generado.

Balance: 43 avisos → 26 corregidos automáticamente, 12 con criterio, 5
desactivados por regla. 98 tests en verde.
