### PR TITLE
feat(mcp): transporte configurable (stdio | streamable-http)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,7 +1046,11 @@ MCP_TRANSPORT=streamable-http MCP_PORT=8765 python -m backend.main
 
 **El valor por defecto sigue siendo `stdio`, y eso es deliberado.** Es lo que espera un cliente que lanza el servidor como subproceso —así está conectado el entorno de desarrollo del autor— y cambiar el defecto habría roto esa conexión sin que ningún test fallara. Hay un test que fija ese defecto precisamente para que nadie lo cambie por descuido.
 
-Verificado **por los dos caminos**, arrancando el entry point real y conectando un cliente MCP de verdad: por HTTP expone las 11 tools y responde a `call_tool`; por `stdio` sigue haciendo exactamente lo mismo. Los tests unitarios usan un espía sobre `mcp.run` —que bloquea el proceso— así que la comprobación de que el servidor *sirve* tenía que hacerse aparte.
+Verificado **por los dos caminos**, arrancando el entry point real y conectando un cliente MCP de verdad: por HTTP expone las 11 tools y responde a `call_tool`; por `stdio` sigue haciendo exactamente lo mismo.
+
+**Y la verificación de HTTP quedó automatizada**, que era el hueco evidente: los tests que espían `mcp.run` comprueban el *cableado* pero no que el servidor sirva, porque `run()` bloquea el proceso. La salida no es levantar un servidor en un puerto —lento y frágil en CI— sino pasarle al cliente MCP un `httpx.AsyncClient` montado sobre `ASGITransport`: el protocolo completo corre **contra la app en el mismo proceso**, sin red. Cuesta **0,03 s**, así que va en cada CI en vez de quedarse como comprobación manual.
+
+Dos obstáculos que costaron encontrar y conviene dejar escritos. El primero, que el gestor de sesiones de FastMCP arranca en el *lifespan* de la app y `ASGITransport` no lo ejecuta, así que hay que entrarlo a mano o toda petición falla. El segundo, un `421 Misdirected Request` que resultó ser la protección anti *DNS rebinding* del propio servidor: acepta `127.0.0.1:*` y `ASGITransport` enviaba `Host: 127.0.0.1` sin puerto. Se resuelve poniendo puerto en la URL base — **dejando la protección activa**, que era la tentación fácil de desactivar.
 
 Un detalle de diseño: `host` y `port` se asignan siempre, aunque `stdio` los ignore. Meter un `if` para no tocar dos campos inertes añade una rama que hay que leer y mantener a cambio de nada.
 

--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,22 @@ El segundo caso merece atención: **es el escenario de discrepancia que se habí
 
 **Límites.** Sigue sin haber `/tools`, `/history` ni `/chat`. Los 12 tests nuevos cubren la capa HTTP (validación, delegación, CORS, OpenAPI) y **no repiten la orquestación**, que ya cubre `test_analyze.py`. Y `analyze.py` mantiene un efecto de importación conocido —`_api = get_nlp_backend()` a nivel de módulo— que congela el backend NLP al importar, igual que hace `tool.py`.
 
+### Transporte del servidor MCP, configurable (#90)
+
+R1.6 llevaba escrito desde la ampliación de requisitos de Fase B y era un **DEBERÁ sin cumplir**: `main.py` cableaba `mcp.run(transport="stdio")`. El problema no es de forma — **`stdio` exige que el cliente arranque el servidor como subproceso y hable con él por tuberías**, cosa que no cruza contenedores. Sin transporte HTTP, H4 no puede separar el servidor MCP de la API.
+
+Ahora sale de configuración (`mcp_transport`, `mcp_host`, `mcp_port`):
+
+```bash
+MCP_TRANSPORT=streamable-http MCP_PORT=8765 python -m backend.main
+```
+
+**El valor por defecto sigue siendo `stdio`, y eso es deliberado.** Es lo que espera un cliente que lanza el servidor como subproceso —así está conectado el entorno de desarrollo del autor— y cambiar el defecto habría roto esa conexión sin que ningún test fallara. Hay un test que fija ese defecto precisamente para que nadie lo cambie por descuido.
+
+Verificado **por los dos caminos**, arrancando el entry point real y conectando un cliente MCP de verdad: por HTTP expone las 11 tools y responde a `call_tool`; por `stdio` sigue haciendo exactamente lo mismo. Los tests unitarios usan un espía sobre `mcp.run` —que bloquea el proceso— así que la comprobación de que el servidor *sirve* tenía que hacerse aparte.
+
+Un detalle de diseño: `host` y `port` se asignan siempre, aunque `stdio` los ignore. Meter un `if` para no tocar dos campos inertes añade una rama que hay que leer y mantener a cambio de nada.
+
 ### Análisis estático: adopción de ruff
 
 El proyecto no había tenido nunca linter. Se adopta [`ruff`](https://docs.astral.sh/ruff/) —linter y formateador en un binario, sustituto de la pila flake8 + isort + pyupgrade + black— y el CI lo comprueba en cada PR.

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -25,5 +25,20 @@ class Settings(BaseSettings):
     # entorno se pasa como JSON: CORS_ORIGINS='["https://ejemplo.org"]'
     cors_origins: list[str] = ["http://localhost:4200"]
 
+    # Transporte del servidor MCP.
+    #
+    # `stdio` es el valor por defecto porque es lo que espera un cliente que
+    # lanza el servidor como SUBPROCESO y habla con él por tuberías — así está
+    # conectado hoy en local. Cambiar el defecto rompería esa conexión.
+    #
+    # `streamable-http` lo expone por red, que es la precondición para
+    # desplegarlo como contenedor independiente: stdio no cruza contenedores,
+    # porque exige que el cliente sea quien arranca el proceso.
+    #
+    # host/port sólo los usa el transporte HTTP; con stdio son inertes.
+    mcp_transport: Literal["stdio", "streamable-http"] = "stdio"
+    mcp_host: str = "127.0.0.1"
+    mcp_port: int = 8765
+
 
 settings = Settings()  # type: ignore #Activa la validación al importar

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,14 +32,21 @@ health.register(mcp)
 def main():
     # Initialize and run the server
     configure_logging()
+
+    # host/port los ignora el transporte stdio.
+    mcp.settings.host = settings.mcp_host
+    mcp.settings.port = settings.mcp_port
+
     log.info(
         "server.start",
         server="tfg-mcp-server",
-        transport="stdio",
+        transport=settings.mcp_transport,
+        host=settings.mcp_host,
+        port=settings.mcp_port,
         log_level=settings.log_level,
         log_format=settings.log_format,
     )
-    mcp.run(transport="stdio")
+    mcp.run(transport=settings.mcp_transport)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,13 +4,21 @@
 doble que sólo anota con qué se le llamó.
 """
 
+import httpx
 import pytest
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
 from pydantic import ValidationError
 
 from backend import main as main_mod
 from backend.config.settings import Settings, settings
 
 _CLAVES = {"guardian_api_key": "x", "nyt_api_key": "x", "hf_token": "x"}
+
+# El Host DEBE llevar puerto: la protección anti DNS-rebinding de FastMCP acepta
+# `127.0.0.1:*`, y ASGITransport enviaría `Host: 127.0.0.1` pelado, que no casa
+# y se rechaza con 421. Se deja la protección activa en vez de desactivarla.
+_BASE = "http://127.0.0.1:8765"
 
 
 @pytest.fixture
@@ -58,3 +66,53 @@ def test_un_transporte_desconocido_se_rechaza_al_arrancar():
 # Prueba con uno, luego con otro
 def test_ambos_transportes_son_validos(transporte):
     assert Settings(mcp_transport=transporte, **_CLAVES).mcp_transport == transporte
+
+
+@pytest.mark.asyncio
+async def test_el_servidor_sirve_de_verdad_por_http():
+    """El servidor responde el protocolo MCP completo por HTTP.
+
+    Los tests de arriba espían `mcp.run`, así que comprueban el CABLEADO pero no
+    que el servidor sirva. Éste sí: habla el protocolo real —handshake,
+    `list_tools`, `call_tool`— contra la app ASGI **en el mismo proceso**.
+
+    Sin puerto ni subproceso: al cliente MCP se le pasa un `httpx.AsyncClient`
+    montado sobre `ASGITransport`, así que las peticiones entran directas en la
+    app sin tocar la red.
+    """
+    app = main_mod.mcp.streamable_http_app()
+    transporte = httpx.ASGITransport(app=app)
+
+    # El gestor de sesiones de FastMCP arranca en el lifespan de la app, y
+    # ASGITransport no lo ejecuta: hay que entrar a mano o toda petición falla.
+    async with (
+        app.router.lifespan_context(app),
+        httpx.AsyncClient(transport=transporte, base_url=_BASE) as http_client,
+        streamable_http_client(f"{_BASE}/mcp", http_client=http_client) as (
+            read,
+            write,
+            _,
+        ),
+        # Basicamente, gestión de tubería bidireccional, necesario con streamable porque MCP necesita stream continuo
+    ):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = await session.list_tools()
+            assert {t.name for t in tools.tools} >= {
+                "detect_clickbait_lexical",
+                "health_check",
+            }
+            lexical = next(
+                t for t in tools.tools if t.name == "detect_clickbait_lexical"
+            )
+            assert lexical.description
+            assert "headline" in lexical.inputSchema["properties"]
+
+            # Y ejecutar de verdad, no sólo enumerar. Se elige una tool
+            # local y determinista: no toca red ni carga modelos.
+            resultado = await session.call_tool(
+                "detect_clickbait_lexical",
+                {"headline": "10 Things You Won't Believe"},
+            )
+            assert '"is_clickbait": true' in resultado.content[0].text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,60 @@
+"""Tests del arranque del servidor MCP (R1.6).
+
+`mcp.run()` bloquea el proceso, así que en todos estos tests se sustituye por un
+doble que sólo anota con qué se le llamó.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from backend import main as main_mod
+from backend.config.settings import Settings, settings
+
+_CLAVES = {"guardian_api_key": "x", "nyt_api_key": "x", "hf_token": "x"}
+
+
+@pytest.fixture
+def run_espia(monkeypatch):
+    """Sustituye `mcp.run` y devuelve un dict con los argumentos recibidos."""
+    recibido = {}
+    monkeypatch.setattr(
+        main_mod.mcp, "run", lambda transport: recibido.update(transport=transport)
+    )
+    monkeypatch.setattr(main_mod.mcp.settings, "host", "sin-tocar")
+    monkeypatch.setattr(main_mod.mcp.settings, "port", 0)
+    return recibido
+
+
+def test_el_transporte_por_defecto_es_stdio():
+    assert Settings.model_fields["mcp_transport"].default == "stdio"
+
+
+def test_main_arranca_con_el_transporte_configurado(monkeypatch, run_espia):
+    monkeypatch.setattr(settings, "mcp_transport", "streamable-http")
+
+    main_mod.main()
+
+    assert run_espia["transport"] == "streamable-http"
+
+
+def test_main_propaga_host_y_puerto_al_servidor(monkeypatch, run_espia):
+    monkeypatch.setattr(settings, "mcp_host", "0.0.0.0")
+    monkeypatch.setattr(settings, "mcp_port", 9999)
+
+    main_mod.main()
+
+    assert main_mod.mcp.settings.host == "0.0.0.0"
+    assert main_mod.mcp.settings.port == 9999
+
+
+def test_un_transporte_desconocido_se_rechaza_al_arrancar():
+    # La validación ocurre al construir Settings, no al llamar a mcp.run(): así
+    # una configuración mal escrita falla en el arranque y no a mitad de uso.
+    with pytest.raises(ValidationError):
+        Settings(mcp_transport="websocket", **_CLAVES)
+
+
+@pytest.mark.parametrize("transporte", ["stdio", "streamable-http"])
+# Prueba con uno, luego con otro
+def test_ambos_transportes_son_validos(transporte):
+    assert Settings(mcp_transport=transporte, **_CLAVES).mcp_transport == transporte


### PR DESCRIPTION
## #90 · Transporte del servidor MCP configurable

Closes #90

R1.6 llevaba escrito desde la ampliación de requisitos de Fase B y era un
**DEBERÁ sin cumplir**: `main.py` cableaba `mcp.run(transport="stdio")`.

No es un detalle de forma. **`stdio` exige que el cliente arranque el servidor
como subproceso y hable con él por tuberías**, así que no cruza contenedores:
sin transporte HTTP, H4 no puede separar el servidor MCP de la API, y el cliente
que necesitará `/tools` no tiene por dónde conectarse.

### Qué incluye
- Settings `mcp_transport`, `mcp_host` y `mcp_port`.
- `main.py` los usa en vez de cablear el transporte.
- 7 tests en `tests/test_main.py`.

```bash
MCP_TRANSPORT=streamable-http MCP_PORT=8765 python -m backend.main
```

### El defecto sigue siendo `stdio`, a propósito
Es lo que espera un cliente que lanza el servidor como subproceso, que es como
está conectado el entorno de desarrollo. Cambiarlo porque suene más moderno
**rompería esa conexión sin que ningún test fallara**, así que hay uno que fija
el defecto explícitamente para que no ocurra por descuido.

### El servidor se prueba sirviendo de verdad, no sólo cableado
Los tests que espían `mcp.run` comprueban que el transporte llega, pero no que
el servidor responda: `run()` bloquea el proceso.

La salida no es levantar un servidor en un puerto —lento y frágil en CI— sino
pasarle al cliente MCP un `httpx.AsyncClient` sobre `ASGITransport`: el
protocolo completo (handshake, `list_tools`, `call_tool`) corre **contra la app
en el mismo proceso, sin red**, en **0,03 s**. Va en cada CI.

Dos obstáculos que conviene dejar escritos:
- El gestor de sesiones de FastMCP arranca en el *lifespan* de la app y
  `ASGITransport` no lo ejecuta; hay que entrarlo a mano o toda petición falla.
- Un `421 Misdirected Request` resultó ser la protección anti *DNS rebinding*
  del propio servidor: acepta `127.0.0.1:*` y `ASGITransport` enviaba
  `Host: 127.0.0.1` sin puerto. Resuelto poniendo puerto en la URL base,
  **dejando la protección activa**.

El test comprueba además que `list_tools` devuelve `description` e
`inputSchema` — que es justo sobre lo que se construirá `/tools` (R4.2).

### Verificación manual complementaria
Arrancando el entry point real y conectando un cliente MCP:

| Transporte | Resultado |
|---|---|
| `streamable-http` vía variable de entorno | handshake OK, 11 tools, `call_tool` responde |
| `stdio` (defecto) | idéntico — 11 tools, `call_tool` responde |

La segunda fila es la que importaba: era la regresión con consecuencias reales.
`stdio` no tiene test automático porque exige subproceso, y su coste no compensa
para un camino que el entorno de desarrollo ejercita a diario.

### Notas
`host` y `port` se asignan siempre aunque `stdio` los ignore: un `if` para no
tocar dos campos inertes añade una rama que leer y mantener a cambio de nada.

Detectado de paso: `streamablehttp_client` está deprecado en el SDK a favor de
`streamable_http_client`. El test usa el nuevo.

105 tests en verde.
