### PR TITLE
docs(requisitos): replantear R5 — el catálogo es transparencia, no lanzador

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,30 @@ El segundo caso merece atención: **es el escenario de discrepancia que se habí
 
 **Límites.** Sigue sin haber `/tools`, `/history` ni `/chat`. Los 12 tests nuevos cubren la capa HTTP (validación, delegación, CORS, OpenAPI) y **no repiten la orquestación**, que ya cubre `test_analyze.py`. Y `analyze.py` mantiene un efecto de importación conocido —`_api = get_nlp_backend()` a nivel de módulo— que congela el backend NLP al importar, igual que hace `tool.py`.
 
+### El catálogo no es un lanzador: R5 replanteado
+
+Al preparar `/tools` se leyó R5 entero por primera vez desde que se escribió, y aparecieron tres problemas —dos de redacción y uno de concepto.
+
+**Una contradicción interna.** R5.1 decía «mantener un registro» y R5.2 «CUANDO se registre una nueva herramienta… almacenar». Eso describe un catálogo **con estado**: una tabla que se rellena en un evento de alta. Pero R5.8 exige construirlo **dinámicamente** por *handshake* MCP, que es una **vista calculada** en cada consulta. No pueden ser las dos cosas — y en el modelo dinámico el evento «se registra una tool» **nunca ocurre**: las herramientas simplemente aparecen o dejan de aparecer en `list_tools`. Corregido a *exponer*. La entrada del glosario arrastraba el mismo error («sistema de registro») y se reescribió igual.
+
+**Un requisito desproporcionado.** R5.6 exigía búsqueda por nombre o palabras clave sobre un catálogo de **11 herramientas**, que caben en una pantalla sin desplazarse. Es un criterio pensado para catálogos de cientos de entradas. Baja a PODRÁ, junto con el filtro por categoría (R5.4), por el mismo motivo. El autor añade una razón de uso: invocar una herramienta concreta en vez de dejar que el sistema elija **es una operación avanzada**, no el camino del usuario medio.
+
+**Y el problema de fondo: el catálogo no es un lanzador.** La historia de usuario original —«descubrir qué herramientas hay y **cómo usarlas**»— venía de concebirlo como un menú desde el que invocar herramientas sueltas. Pero el usuario medio no entra por ahí: entra por *Analizar* o por el chat. Lo que sí necesita es saber **qué compone este sistema y con qué límites**, que es exactamente lo que hace la pantalla *Sistema* del prototipo y lo que piden R3.8 y R3.9.
+
+De ahí sale **R5.9, nuevo**: donde una herramienta sea una señal de análisis, el catálogo debe exponer su **ficha de modelo**. Sin él, el catálogo mostraría
+
+```
+detect_clickbait_linear  →  «Análisis de NLP»
+```
+
+y escondería lo que ya está escrito en `model_cards.py`: que es **interpretable** (no una caja negra), que mide **forma** (no engaño), y que su F1 cae de **0.865 en dominio a 0.476 fuera**. Un catálogo que tira esa metadata desperdicia justamente el eje del trabajo.
+
+**R5.7 reinterpretado.** Decía «agregar las herramientas de todos los MCP_Server conectados». Con un solo servidor eso se cumple trivialmente y no demuestra nada — el mismo problema que R1.7. Pero tiene una lectura que sí aporta: **de qué integración procede** cada herramienta (NYT, Guardian, meteorología, NLP). Esa es información real y útil hoy; la agregación multi-servidor se mantiene como capacidad para cuando haya varios.
+
+**R4.3 se queda, con sus consumidores anotados.** Ese endpoint —ejecutar una tool concreta— existía para que el catálogo lanzara herramientas, así que al dejar de ser lanzador parecía quedarse sin uso. No es el caso: le quedan dos reales, ejecutar **una señal suelta** (sólo el sentimiento, sin lanzar las cuatro) y **traer una noticia** desde la pantalla de análisis. Lo que estaba mal era su justificación, no su forma.
+
+**El nombre se mantiene.** Se valoró renombrar `Tool_Catalog`, ya que no aparece en el código y el cambio saldría barato. Se descarta: un catálogo es **descriptivo por naturaleza** —el de un museo describe obras que no te llevas— y lo que empujaba hacia el lanzador era la historia de usuario, ya corregida. Además la historia de R13 depende del término: *«que el sistema decida por mí qué herramientas usar sin necesidad de conocer el catálogo»* sólo tiene sentido si existe un catálogo que uno podría conocer.
+
 ### Transporte del servidor MCP, configurable (#90)
 
 R1.6 llevaba escrito desde la ampliación de requisitos de Fase B y era un **DEBERÁ sin cumplir**: `main.py` cableaba `mcp.run(transport="stdio")`. El problema no es de forma — **`stdio` exige que el cliente arranque el servidor como subproceso y hable con él por tuberías**, cosa que no cruza contenedores. Sin transporte HTTP, H4 no puede separar el servidor MCP de la API.

--- a/docs/requisitos.md
+++ b/docs/requisitos.md
@@ -12,7 +12,7 @@ Este documento define los requisitos para un Trabajo de Fin de Grado (TFG) que i
 - **MCP_Tool**: Herramienta individual que expone funcionalidad a través del protocolo MCP.
 - **API_Consumer**: Componente que realiza llamadas a APIs públicas externas.
 - **Web_Interface**: Aplicación Angular que permite interactuar con las herramientas MCP.
-- **Tool_Catalog**: Sistema de registro y descubrimiento de herramientas disponibles.
+- **Tool_Catalog**: Vista **calculada en cada consulta** de las herramientas disponibles y de lo que declara cada una. No almacena: descubre por *handshake* MCP. _(Ver memoria de cambios.)_
 - **NLP_Analyzer**: Componente que realiza análisis de procesamiento de lenguaje natural.
 - **Backend_API**: API REST implementada con FastAPI que expone funcionalidad del servidor MCP.
 - **Agent_Orchestrator**: Agente conversacional que interpreta consultas en lenguaje natural y decide qué MCP_Tools invocar (*tool calling*). Actúa como cliente MCP.
@@ -79,27 +79,28 @@ Este documento define los requisitos para un Trabajo de Fin de Grado (TFG) que i
 
 1. La Backend_API DEBERÁ implementarse utilizando FastAPI.
 2. La Backend_API DEBERÁ exponer un endpoint para enumerar todas las MCP_Tools disponibles con sus descripciones y parámetros.
-3. La Backend_API DEBERÁ exponer un endpoint para ejecutar una MCP_Tool específica con los parámetros proporcionados.
+3. La Backend_API DEBERÁ exponer un endpoint para ejecutar una MCP_Tool específica con los parámetros proporcionados. _(Sus consumidores son ejecutar **una señal suelta** —p. ej. sólo el sentimiento, sin lanzar las cuatro— y **traer una noticia** desde la pantalla de análisis; no un catálogo que haga de lanzador. Ver memoria de cambios.)_
 4. La Backend_API DEBERÁ exponer un endpoint para recuperar el historial de ejecución de las herramientas.
 5. CUANDO se reciba una solicitud de ejecución de una herramienta, LA Backend_API DEBERÁ validar los parámetros de entrada antes de la ejecución.
 6. LA Backend_API DEBERÁ devolver respuestas en formato JSON con una estructura coherente.
 7. LA Backend_API DEBERÁ incluir la configuración CORS para permitir las solicitudes de la aplicación frontend.
 8. DONDE sea beneficioso para desarrollo y documentación, LA Backend_API PODRÁ incluir documentación automática usando OpenAPI de FastAPI.
 
-### Requisito 5: Sistema de catálogo de tools
+### Requisito 5: Catálogo de tools y transparencia del sistema
 
-**Historia de usuario:** Como usuario del sistema, quiero un catálogo de herramientas disponibles, para que pueda descubrir y entender qué herramientas están disponibles y cómo usarlas.
+**Historia de usuario:** Como usuario del sistema, quiero ver qué herramientas y señales lo componen y con qué límites, para entender de dónde sale un veredicto y qué puedo esperar de él.
 
 **Criterios de aceptación:**
 
-1. EL Tool_Catalog DEBERÁ mantener un registro de todas las MCP_Tools disponibles con metadatos.
-2. CUANDO se registre una nueva herramienta, EL Tool_Catalog DEBERÁ almacenar su nombre, descripción, esquema de parámetros y categoría.
+1. EL Tool_Catalog DEBERÁ **exponer** las MCP_Tools disponibles con sus metadatos. _(Antes «mantener un registro»; contradecía a R5.8. Ver memoria de cambios.)_
+2. EL Tool_Catalog DEBERÁ exponer, por cada herramienta, su nombre, descripción, esquema de parámetros y categoría. _(Antes «CUANDO se registre… almacenar»: en un catálogo dinámico ese evento no existe. Ver memoria de cambios.)_
 3. EL Tool_Catalog DEBERÁ admitir la categorización de herramientas (por ejemplo, «Integración de API», «Análisis de NLP», «Utilidades»).
-4. AL consultar el catálogo, EL Tool_Catalog DEBERÁ devolver las herramientas filtradas por categoría si así se solicita.
+4. AL consultar el catálogo, EL Tool_Catalog **PODRÁ** devolver las herramientas filtradas por categoría si así se solicita. _(Antes DEBERÁ. Ver memoria de cambios.)_
 5. EL Tool_Catalog DEBERÁ incluir esquemas de validación de parámetros para cada herramienta.
-6. EL Tool_Catalog DEBERÁ admitir la búsqueda de herramientas por nombre o palabras clave de descripción.
-7. EL Tool_Catalog DEBERÁ **agregar las herramientas de todos los MCP_Server conectados**, indicando de qué servidor procede cada una.
+6. EL Tool_Catalog **PODRÁ** admitir la búsqueda de herramientas por nombre o palabras clave de descripción. _(Antes DEBERÁ; desproporcionado para el número de tools previsto. Ver memoria de cambios.)_
+7. EL Tool_Catalog DEBERÁ indicar **de qué integración procede** cada herramienta (NYT, Guardian, meteorología, NLP…). DONDE haya varios MCP_Server conectados, DEBERÁ además agregar sus catálogos indicando el servidor de origen. _(Reinterpretado. Ver memoria de cambios.)_
 8. EL Tool_Catalog DEBERÁ construirse **dinámicamente** mediante el descubrimiento de herramientas de cada servidor (*handshake* MCP), sin listas cableadas en el código ni en el frontend.
+9. DONDE una herramienta sea una **señal de análisis**, EL Tool_Catalog DEBERÁ exponer su **ficha de modelo**: tipo (interpretable / híbrido / opaco), dimensión que mide y límites conocidos. _(Nuevo; enlaza con R3.8 y R3.9. Ver memoria de cambios.)_
 
 ### Requisito 6: Interfaz web
 


### PR DESCRIPTION
## R5 replanteado: el catálogo no es un lanzador

Sin issue asociado: es la reescritura de requisitos previa al endpoint del
catálogo, y debe mergear antes para que ese issue se redacte contra el R5 final.

Al preparar el catálogo se leyó R5 entero por primera vez desde que se escribió,
y aparecieron tres problemas: dos de redacción y uno de concepto.

### Una contradicción interna
R5.1 decía «mantener un registro» y R5.2 «CUANDO se registre una nueva
herramienta… almacenar». Eso describe un catálogo **con estado**. Pero R5.8
exige construirlo **dinámicamente** por *handshake* MCP, que es una **vista
calculada** en cada consulta.

No pueden ser las dos cosas — y en el modelo dinámico el evento «se registra una
tool» **nunca ocurre**: las herramientas simplemente aparecen o dejan de
aparecer en `list_tools`. Corregido a *exponer*. El glosario arrastraba el mismo
error («sistema de registro») y se reescribió igual.

### Un requisito desproporcionado
R5.6 exigía búsqueda por nombre o palabras clave sobre un catálogo de **11
herramientas**, que caben en una pantalla sin desplazarse. Baja a PODRÁ, junto
con el filtro por categoría (R5.4). Razón añadida por el autor: invocar una
herramienta concreta en vez de dejar que el sistema elija **es una operación
avanzada**, no el camino del usuario medio.

### Y el problema de fondo
La historia de usuario original —«descubrir qué herramientas hay y **cómo
usarlas**»— concebía el catálogo como un menú de lanzamiento. Pero el usuario
medio no entra por ahí: entra por *Analizar* o por el chat. Lo que necesita es
saber **qué compone el sistema y con qué límites**, que es lo que hace la
pantalla *Sistema* del prototipo y lo que piden R3.8 y R3.9.

De ahí **R5.9, nuevo**: donde una herramienta sea una señal de análisis, el
catálogo debe exponer su **ficha de modelo**. Sin él mostraría

    detect_clickbait_linear  →  «Análisis de NLP»

y escondería lo que ya está en `model_cards.py`: que es **interpretable** (no
una caja negra), que mide **forma** (no engaño), y que su F1 cae de **0.865 en
dominio a 0.476 fuera**. Un catálogo que tira esa metadata desperdicia el eje
del trabajo.

### Qué cambia en `docs/requisitos.md`
- **Glosario** — `Tool_Catalog`: de «sistema de registro» a vista calculada.
- **R5.1 · R5.2** — `almacenar` → `exponer`.
- **R5.4 · R5.6** — DEBERÁ → PODRÁ.
- **R5.7** — reinterpretado hacia **de qué integración procede** cada tool (NYT,
  Guardian, meteorología, NLP). Con un solo servidor, «agregar de todos los
  MCP_Server» era vacío — el mismo problema que R1.7. La agregación
  multi-servidor se mantiene como capacidad.
- **R5.9** — nuevo.
- **Título e historia de usuario** — de «usar» a «entender».
- **R4.3** — sin cambio de fondo, con sus dos consumidores anotados: ejecutar
  una señal suelta y traer una noticia. Lo que estaba mal era su justificación.

### Notas
**El nombre se mantiene.** Se valoró renombrar `Tool_Catalog` —no aparece en el
código, así que salía barato—. Se descarta: un catálogo es descriptivo por
naturaleza, y lo que empujaba hacia el lanzador era la historia de usuario, ya
corregida. Además R13 depende del término: «sin necesidad de conocer el
catálogo» sólo tiene sentido si existe uno.

**Habilitador verificado** para el issue siguiente: `@mcp.tool(meta={...})` y
ese `meta` sobrevive el viaje hasta `Tool.meta` en el cliente. Así la categoría
se declara en la propia tool —cumpliendo R1.9— en vez de en un mapa cableado en
la API.

**Sin código.** Sólo documentación; 105 tests siguen en verde. Etiquetar las 11
tools con su categoría es alcance del issue del catálogo.
