### PR TITLE
feat(mcp): registro automático de integraciones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,8 +1045,8 @@ Ahora `backend/integrations/discovery.py` recorre el paquete, importa el `tool` 
 El fichero pasa de cinco líneas de registro a dos, y esas dos significan algo:
 
 ```python
-discover_integrations(mcp)   # todo lo que haya en integrations/
-health.register(mcp)         # núcleo, no integración
+discover_integrations(mcp)  # todo lo que haya en integrations/
+health.register(mcp)  # núcleo, no integración
 ```
 
 **Un paquete roto no tumba el servidor.** Si una integración falla al importarse o su `register` lanza, se anota y se sigue con las demás — misma postura que con las señales en `/analyze`, y lo que piden R1.8 y R2.8. El arranque registra qué se descubrió y qué falló, porque una integración caída deja al sistema con menos herramientas **en silencio**: sin ese log, la única pista sería una tool que ya no aparece.

--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,25 @@ El segundo caso merece atención: **es el escenario de discrepancia que se habí
 
 **Límites.** Sigue sin haber `/tools`, `/history` ni `/chat`. Los 12 tests nuevos cubren la capa HTTP (validación, delegación, CORS, OpenAPI) y **no repiten la orquestación**, que ya cubre `test_analyze.py`. Y `analyze.py` mantiene un efecto de importación conocido —`_api = get_nlp_backend()` a nivel de módulo— que congela el backend NLP al importar, igual que hace `tool.py`.
 
+### Registro automático de integraciones (#91)
+
+R1.9 —escrito al ordenar la extensibilidad en #86— dice que añadir una fuente de datos o una señal de análisis no debe obligar a modificar las herramientas existentes. La mitad de interfaz ya estaba cumplida por el envoltorio uniforme de señales; la de servidor no: `main.py` listaba los `register()` a mano, así que añadir una integración obligaba a editarlo.
+
+Ahora `backend/integrations/discovery.py` recorre el paquete, importa el `tool` de cada uno y llama a su `register(mcp)`. Añadir una integración pasa a ser **crear su paquete**.
+
+**El chequeo de salud queda fuera, y no como excepción.** Al plantearlo apareció la pregunta de si `health` debía moverse a `integrations/` para que el descubrimiento lo encontrara. La respuesta es que no: **no envuelve ninguna API externa, es infraestructura básica** —del mismo tipo que el *healthcheck* de un contenedor—. Y eso lo deja **fuera del alcance de R1.9 por definición**, porque el requisito habla de «una fuente de datos o una señal de análisis». Que `main.py` lo registre explícitamente no es un caso especial que disculpar: es la separación correcta, y así queda escrita en el módulo.
+
+El fichero pasa de cinco líneas de registro a dos, y esas dos significan algo:
+
+```python
+discover_integrations(mcp)   # todo lo que haya en integrations/
+health.register(mcp)         # núcleo, no integración
+```
+
+**Un paquete roto no tumba el servidor.** Si una integración falla al importarse o su `register` lanza, se anota y se sigue con las demás — misma postura que con las señales en `/analyze`, y lo que piden R1.8 y R2.8. El arranque registra qué se descubrió y qué falló, porque una integración caída deja al sistema con menos herramientas **en silencio**: sin ese log, la única pista sería una tool que ya no aparece.
+
+**El test que importa es el que demuestra el requisito**: crea una integración de mentira en un directorio temporal y comprueba que aparece sola. El truco para no ensuciar el repositorio es extender el `__path__` del paquete `backend.integrations` —la lista donde Python busca submódulos—, de modo que el import funcione de verdad sin copiar ficheros dentro del proyecto. Sin ese test, R1.9 sería una afirmación; con él, es comprobable.
+
 ### El catálogo no es un lanzador: R5 replanteado
 
 Al preparar `/tools` se leyó R5 entero por primera vez desde que se escribió, y aparecieron tres problemas —dos de redacción y uno de concepto.

--- a/backend/integrations/discovery.py
+++ b/backend/integrations/discovery.py
@@ -1,0 +1,79 @@
+"""Descubrimiento y registro automático de integraciones (R1.9).
+
+Aquí se recorre ``backend/integrations/``, se importa el ``tool`` de cada
+paquete y se llama a su ``register(mcp)``. Añadir una integración pasa a ser
+crear el paquete; nadie toca ``main.py``.
+
+
+"""
+
+import importlib
+import pkgutil
+from dataclasses import dataclass, field
+
+import structlog
+from mcp.server.fastmcp import FastMCP
+
+log = structlog.get_logger()
+
+# Módulo que se espera dentro de cada paquete de integración.
+MODULO_TOOL = "tool"
+
+
+@dataclass(frozen=True)  # Inmutable
+class DiscoveryResult:
+    """Qué se registró y qué falló al intentarlo."""
+
+    registered: tuple[str, ...] = ()
+    failed: dict[str, str] = field(default_factory=dict)  # paquete -> motivo
+
+    # field y default factory para inmutabilidad y no compartir entre instancias.
+
+    # Ej failed: "weather_api": "ImportError: No module named 'requests'"
+
+    @property
+    def degraded(self) -> bool:
+        return bool(self.failed)
+
+
+def discover_and_register(mcp: FastMCP) -> DiscoveryResult:
+    """Registra en ``mcp`` todas las integraciones que expongan ``register``.
+
+    Un fallo al importar una integración **no tumba el servidor**: se anota y se
+    sigue con las demás, para que un paquete roto no deje al sistema sin las
+    otras diez herramientas. Es la misma postura que en ``/analyze`` con las
+    señales.
+    """
+    paquete = importlib.import_module(__package__)
+    registrados: list[str] = []
+    fallidos: dict[str, str] = {}
+
+    # Orden alfabético, no el del sistema de ficheros: el catálogo y los tests
+    # dependen de que sea siempre el mismo.
+    nombres = sorted(
+        nombre
+        for _, nombre, es_paquete in pkgutil.iter_modules(paquete.__path__)
+        if es_paquete
+    )
+
+    for nombre in nombres:
+        try:
+            modulo = importlib.import_module(f"{__package__}.{nombre}.{MODULO_TOOL}")
+            registrar = modulo.register
+        except (ImportError, AttributeError) as exc:
+            # Sin `tool.register` no es una integración registrable: puede ser un
+            # paquete de apoyo. Se anota por si es un error, pero no se levanta.
+            fallidos[nombre] = f"{type(exc).__name__}: {exc}"
+            log.warning("integracion.omitida", integracion=nombre, motivo=str(exc))
+            continue
+
+        try:
+            registrar(mcp)
+        except Exception as exc:
+            fallidos[nombre] = f"{type(exc).__name__}: {exc}"
+            log.error("integracion.fallo", integracion=nombre, motivo=str(exc))
+            continue  # Saltamos, no se detiene
+
+        registrados.append(nombre)
+
+    return DiscoveryResult(registered=tuple(registrados), failed=fallidos)

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,24 +8,18 @@ from mcp.server.fastmcp import FastMCP
 from backend.config.settings import settings
 from backend.core import health
 from backend.core.logging import configure_logging
-from backend.integrations.guardian import tool as guardian_tool
-from backend.integrations.nlp import tool as nlp_tool
-from backend.integrations.nyt import tool as nyt_tool
-from backend.integrations.weather import tool as weather_tool
+from backend.integrations.discovery import discover_and_register
 
 log = structlog.get_logger()
 mcp = FastMCP("tfg-mcp-server")
 
 
-# APIS
-weather_tool.register(mcp)
-guardian_tool.register(mcp)
-nyt_tool.register(mcp)
+# Integraciones: se descubren solas recorriendo backend/integrations/.
+# Añadir una fuente o una señal es crear su paquete; este fichero no se toca.
+integraciones = discover_and_register(mcp)
 
-# NLP
-nlp_tool.register(mcp)
-
-# Health check
+# El chequeo de salud va aparte porque NO es una integración: no envuelve
+# ninguna API externa, es infraestructura básica.
 health.register(mcp)
 
 
@@ -45,6 +39,10 @@ def main():
         port=settings.mcp_port,
         log_level=settings.log_level,
         log_format=settings.log_format,
+        # Qué se descubrió. Si una integración falló al cargar, sus tools no
+        # existen y el sistema queda degradado en silencio: aquí es donde se ve.
+        integraciones=list(integraciones.registered),
+        integraciones_fallidas=integraciones.failed or None,
     )
     mcp.run(transport=settings.mcp_transport)
 

--- a/tests/integrations/test_discovery.py
+++ b/tests/integrations/test_discovery.py
@@ -1,0 +1,145 @@
+"""Tests del descubrimiento automático de integraciones.
+
+El test central es `test_un_paquete_nuevo_aparece_sin_tocar_main`: crea una
+integración de mentira en un directorio temporal y comprueba que aparece sola.
+
+El truco para no ensuciar el repositorio es extender `__path__` del paquete
+`backend.integrations`: Python usa esa lista para localizar submódulos, así que
+añadirle un directorio temporal hace que el import funcione de verdad, sin
+copiar ficheros dentro del proyecto.
+"""
+
+import asyncio
+import sys
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from backend import integrations
+from backend.integrations import discovery
+
+INTEGRACIONES_REALES = ("guardian", "nlp", "nyt", "weather")
+
+_TOOL_OK = """
+def register(mcp):
+    @mcp.tool()
+    async def tool_de_prueba(texto: str) -> str:
+        '''Una tool de prueba.'''
+        return texto
+"""
+
+_TOOL_QUE_REVIENTA = """
+def register(mcp):
+    raise RuntimeError("esta integración está rota")
+"""
+
+_SIN_REGISTER = """
+CONSTANTE = 1
+"""
+
+
+@pytest.fixture
+def integracion_falsa(tmp_path, monkeypatch):
+    """Crea un paquete de integración temporal y lo hace descubrible."""
+    creados: list[str] = []
+
+    def crear(nombre: str, cuerpo: str = _TOOL_OK):
+        paquete = tmp_path / nombre
+        paquete.mkdir()
+        (paquete / "__init__.py").write_text("", encoding="utf-8")
+        (paquete / "tool.py").write_text(cuerpo, encoding="utf-8")
+        creados.append(nombre)
+        # `__path__` es la lista donde Python busca submódulos del paquete:
+        # ampliarla hace que `backend.integrations.<nombre>` sea importable.
+        monkeypatch.setattr(
+            integrations, "__path__", [*integrations.__path__, str(tmp_path)]
+        )
+        return nombre
+
+    yield crear
+
+    # Los módulos importados quedan cacheados en sys.modules y contaminarían
+    # otros tests, así que se retiran.
+    for nombre in creados:
+        for clave in list(sys.modules):
+            if clave.startswith(f"backend.integrations.{nombre}"):
+                del sys.modules[clave]
+
+
+def test_descubre_las_integraciones_reales():
+    resultado = discovery.discover_and_register(FastMCP("test"))
+
+    assert resultado.registered == INTEGRACIONES_REALES
+    assert not resultado.failed
+    assert not resultado.degraded
+
+
+def test_el_orden_es_determinista():
+    # El catálogo y varios tests dependen de él; el orden del sistema de
+    # ficheros no está garantizado, así que se ordena explícitamente.
+    primero = discovery.discover_and_register(FastMCP("a")).registered
+    segundo = discovery.discover_and_register(FastMCP("b")).registered
+
+    assert primero == segundo == tuple(sorted(primero))
+
+
+def test_registra_de_verdad_las_tools():
+    mcp = FastMCP("test")
+    discovery.discover_and_register(mcp)
+
+    nombres = {t.name for t in asyncio.run(mcp.list_tools())}
+    # Una de cada integración, para comprobar que no se queda a medias.
+    assert nombres >= {
+        "get_guardian_news",
+        "get_nyt_news",
+        "get_forecast",
+        "detect_clickbait_lexical",
+    }
+
+
+def test_health_no_es_una_integracion():
+    resultado = discovery.discover_and_register(FastMCP("test"))
+
+    assert "health" not in resultado.registered
+
+
+# ----- Añadir una integración sin tocar código existente -----
+
+
+def test_un_paquete_nuevo_aparece_sin_tocar_main(integracion_falsa):
+    integracion_falsa("integracion_nueva")
+    mcp = FastMCP("test")
+
+    resultado = discovery.discover_and_register(mcp)
+
+    assert "integracion_nueva" in resultado.registered
+    nombres = {t.name for t in asyncio.run(mcp.list_tools())}
+    assert "tool_de_prueba" in nombres
+    # Y las de siempre siguen ahí.
+    assert set(INTEGRACIONES_REALES) <= set(resultado.registered)
+
+
+# ----- Aislamiento de fallos -----
+
+
+def test_una_integracion_que_revienta_no_tumba_a_las_demas(integracion_falsa):
+    integracion_falsa("integracion_rota", _TOOL_QUE_REVIENTA)
+
+    resultado = discovery.discover_and_register(FastMCP("test"))
+
+    assert "integracion_rota" in resultado.failed
+    assert "RuntimeError" in resultado.failed["integracion_rota"]
+    assert resultado.degraded
+    # Las otras cuatro se registran igualmente. Un paquete roto
+    # no puede dejar al sistema sin las herramientas restantes.
+    assert set(INTEGRACIONES_REALES) <= set(resultado.registered)
+
+
+def test_un_paquete_sin_register_se_omite_sin_romper(integracion_falsa):
+    integracion_falsa("paquete_de_apoyo", _SIN_REGISTER)
+
+    resultado = discovery.discover_and_register(FastMCP("test"))
+
+    assert "paquete_de_apoyo" in resultado.failed
+    assert "paquete_de_apoyo" not in resultado.registered
+    assert set(INTEGRACIONES_REALES) <= set(resultado.registered)


### PR DESCRIPTION
## #91 · Registro automático de integraciones

Closes #91

R1.9 —escrito al ordenar la extensibilidad en #86— dice que añadir una fuente de
datos o una señal de análisis **no debe obligar a modificar las herramientas
existentes**. La mitad de interfaz ya estaba cumplida por el envoltorio uniforme
de señales; la de servidor no: `main.py` listaba los `register()` a mano, así que
añadir una integración obligaba a editarlo. Poco código, pero exactamente lo que
el requisito dice que no debe hacer falta.

### Qué incluye
- `backend/integrations/discovery.py`: recorre el paquete, importa el `tool` de
  cada uno y llama a su `register(mcp)`. Añadir una integración pasa a ser crear
  su paquete.
- `backend/main.py`: cinco líneas de registro pasan a dos.
- 7 tests en `tests/integrations/test_discovery.py`.

### El chequeo de salud queda fuera, y no como excepción
Al plantearlo apareció la pregunta de si `health` debía moverse a
`integrations/` para que el descubrimiento lo encontrara. La respuesta es que
**no**: no envuelve ninguna API externa, es infraestructura básica — del mismo
tipo que el *healthcheck* de un contenedor.

Y eso lo deja **fuera del alcance de R1.9 por definición**, porque el requisito
habla de «una fuente de datos o una señal de análisis». Que `main.py` lo registre
explícitamente no es un caso especial que disculpar: es la separación correcta, y
las dos líneas que quedan significan algo.

```python
discover_integrations(mcp)  # todo lo que haya en integrations/
health.register(mcp)  # núcleo, no integración
```

Esto además resuelve para #97 la misma pregunta, que allí aparecía como «¿qué
integración de origen tiene `health_check`?». Respuesta: ninguna.

### Un paquete roto no tumba el servidor
Si una integración falla al importarse o su `register` lanza, se anota y se sigue
con las demás — misma postura que con las señales en `/analyze`, y lo que piden
R1.8 y R2.8. El arranque registra qué se descubrió y qué falló, porque una
integración caída deja al sistema con menos herramientas **en silencio**: sin ese
log, la única pista sería una tool que ya no aparece.

### El test que demuestra el requisito
`test_un_paquete_nuevo_aparece_sin_tocar_main` crea una integración de mentira en
un directorio temporal y comprueba que aparece sola. Para no ensuciar el
repositorio, extiende el `__path__` del paquete `backend.integrations` —la lista
donde Python busca submódulos—, de modo que el import funcione de verdad sin
copiar ficheros dentro del proyecto.

Sin ese test, R1.9 sería una afirmación; con él es comprobable.

### Notas
Verificado que el servidor real sigue sirviendo **las 11 tools** por `stdio` tras
el cambio: el descubrimiento registra las mismas cuatro integraciones que estaban
escritas a mano.

El resultado del descubrimiento (`registered`, `failed`, `degraded`) se devuelve y
se registra al arrancar, pero **no se expone por HTTP**. Publicarlo es decisión de
#97, donde encaja con cómo refleja el contrato un servidor caído.

Descubierto de paso: `ruff format` también formatea el Python dentro de los
bloques de código de Markdown, así que el `README.md` entra en la comprobación de
estilo del CI.

112 tests en verde.
