### PR TITLE
feat(api): catálogo de tools por handshake MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,27 @@ El segundo caso merece atención: **es el escenario de discrepancia que se habí
 
 **Límites.** Sigue sin haber `/tools`, `/history` ni `/chat`. Los 12 tests nuevos cubren la capa HTTP (validación, delegación, CORS, OpenAPI) y **no repiten la orquestación**, que ya cubre `test_analyze.py`. Y `analyze.py` mantiene un efecto de importación conocido —`_api = get_nlp_backend()` a nivel de módulo— que congela el backend NLP al importar, igual que hace `tool.py`.
 
+### Metadata de las tools: categoría y procedencia (#97, primera parte)
+
+El catálogo necesita saber, de cada herramienta, **qué tipo de trabajo hace** y **de dónde viene**. El objeto `Tool` del protocolo MCP trae nombre, descripción y esquema, pero ninguna de esas dos cosas. MCP sí permite adjuntar un `meta` libre por herramienta, y se comprobó que **viaja intacto hasta el cliente**, así que la información se declara en el origen en vez de en un mapa cableado en la API — que obligaría a editarla cada vez que se añade una fuente, justo lo que R1.9 prohíbe.
+
+**Los dos ejes se tratan distinto a propósito.** La **categoría es un juicio** —qué tipo de trabajo hace— y no se puede derivar de dónde vive el fichero: `describe_models` está en `nlp/` pero es una utilidad, no una señal. Así que se declara, y declararla obliga a pensarla al añadir la siguiente. La **integración es un hecho de ubicación**, se deriva del módulo, y por eso **no puede mentir**: declararla a mano permitiría que el paquete dijera una cosa y el `meta` otra, en silencio — el mismo fallo que costó el renombrado del campo `signal` en H1.
+
+**Las categorías de R5.3 se renombraron.** Los ejemplos originales eran «Integración de API» y «Análisis de NLP», y ambos nombraban mal lo que separan:
+
+| Original | Problema | Ahora |
+|---|---|---|
+| Integración de API | Describe la implementación, y es **falso como distinción**: `detect_clickbait` es una llamada a la API de HuggingFace tanto como `get_nyt_news` lo es a la de NYT | **Fuentes de contenido** |
+| Análisis de NLP | Nombra una tecnología, no un propósito — y el proyecto **ya tiene su palabra**, «señal», usada en `SignalResult`, en la orquestación y en las fichas | **Señales de análisis** |
+
+Lo que de verdad separa a los cuatro primeros del resto no es que llamen a una API: es que **traen contenido** en vez de analizarlo.
+
+El renombrado tiene además una propiedad que lo confirma: **«Señales de análisis» son exactamente las cinco que llevan ficha de modelo**. Con los nombres anteriores esa correspondencia parecía casualidad; ahora la categoría *predice* si `model_card` viene o no, y R5.9 deja de ser un añadido suelto para encajar con R5.3.
+
+**Y el índice de fichas se centraliza.** `cards_by_signal()` vive junto a `MODEL_CARDS` porque lo necesitan dos consumidores —la orquestación de `/analyze`, para leer la dimensión de cada señal, y el catálogo, para adjuntar la ficha—. Dos copias del mismo índice acabarían divergiendo.
+
+_(Nota para la memoria: `get_alerts` y `get_forecast` son andamiaje del MVP y no pertenecen al dominio del clickbait. Se conservan porque son herramientas reales del sistema y ocultarlas sería deshonesto, pero su función es demostrar el mecanismo MCP con una API pública sin clave.)_
+
 ### Registro automático de integraciones (#91)
 
 R1.9 —escrito al ordenar la extensibilidad en #86— dice que añadir una fuente de datos o una señal de análisis no debe obligar a modificar las herramientas existentes. La mitad de interfaz ya estaba cumplida por el envoltorio uniforme de señales; la de servidor no: `main.py` listaba los `register()` a mano, así que añadir una integración obligaba a editarlo.

--- a/README.md
+++ b/README.md
@@ -1055,6 +1055,44 @@ El renombrado tiene además una propiedad que lo confirma: **«Señales de anál
 
 _(Nota para la memoria: `get_alerts` y `get_forecast` son andamiaje del MVP y no pertenecen al dominio del clickbait. Se conservan porque son herramientas reales del sistema y ocultarlas sería deshonesto, pero su función es demostrar el mecanismo MCP con una API pública sin clave.)_
 
+### `GET /tools`: el catálogo por handshake MCP (#97)
+
+Es **el primer sitio donde la API habla MCP de verdad**. `/analyze` importa el núcleo directamente —dos fachadas sobre el mismo código— y para él es correcto; aquí no vale, y R5.8 lo dice explícitamente: el catálogo debe construirse por descubrimiento. La razón no es purismo, es que **importar módulos daría siempre la misma respuesta aunque el servidor estuviera caído**, que es justo lo contrario de lo que un catálogo debe mostrar.
+
+**Sesión por petición, no persistente.** Al planificar el issue se había propuesto mantener la sesión viva en el `lifespan` para ahorrar los 0,212 s del *handshake*. Al implementarlo no se sostiene: `/tools` se consulta cuando alguien abre la pantalla de Sistema, no en bucle, así que esa latencia es imperceptible. A cambio, la sesión persistente obliga a gestionar reconexión, guardar estado mutable compartido y responder si `ClientSession` aguanta uso concurrente. Se pagará esa complejidad cuando haya un consumidor caliente que la justifique —el agente, con muchas invocaciones por turno— y con una medición delante.
+
+La decisión tiene un efecto que la confirma: **hace desaparecer otra pregunta abierta**. «¿Arranca la API si no hay servidor MCP?» sólo existía porque el catálogo se construía al arrancar. Sin sesión persistente no hay nada que conectar en el arranque: la API arranca siempre, y `/tools` informa del estado real en el momento de la llamada.
+
+**Un servidor caído no rompe la respuesta**, igual que una señal caída no rompe `/analyze`: sale en `servers` con estado `unreachable` y su motivo, `degraded` queda a `true` y las herramientas de los demás se sirven igual. Con la configuración como lista, R1.8 deja de ser un requisito vacío aunque la lista tenga un solo elemento.
+
+**Y sin servidores configurados, el catálogo sale vacío pero NO degradado.** Parece un descuido y es deliberado: `degraded` significa «algo declarado no responde», y sin nada declarado no ha fallado nada — eso es una **mala configuración**, no una degradación. La distinción se conserva porque el contrato permite separarlas: `servers` vacío significa que no hay nada configurado; `servers` con entradas `unreachable` significa que está declarado y no contesta. Si la lista vacía marcara `degraded`, ambas situaciones colapsarían en una y la interfaz no podría decir cuál está ocurriendo.
+
+El resultado, con el servidor real:
+
+```
+servidores: [('tfg-mcp-server', 'ok', 11)]   degradado: False
+
+  detect_clickbait_lexical      Señales de análisis   nlp      interpretable/forma
+  detect_clickbait_incoherence  Señales de análisis   nlp      híbrido/engano
+  analyze_sentiment             Señales de análisis   nlp      opaco/tono
+  get_nyt_news                  Fuentes de contenido  nyt      -
+  health_check                  Utilidades            None     -
+```
+
+El nombre del servidor no sale de la configuración: lo **declara él mismo** en el `handshake` (`serverInfo.name`), lo que demuestra que hubo conversación real y no una lista leída de un fichero.
+
+#### Tres obstáculos que costaron encontrar
+
+Los tests hablan el protocolo completo contra la app **en el mismo proceso**, con un `httpx.AsyncClient` montado sobre `ASGITransport`. Aquí no es una optimización sino una necesidad: el servidor arranca por defecto en `stdio`, así que durante los tests no hay nada escuchando en ningún puerto.
+
+**El *lifespan* no admite una fixture asíncrona.** El primer intento falló con «attempted to exit cancel scope in a different task»: un *cancel scope* de anyio —la región cancelable que abre el `lifespan`— exige abrirse y cerrarse **en la misma tarea**, y pytest-asyncio puede ejecutar la fixture y el cuerpo del test en tareas distintas. Se resuelve con un `@asynccontextmanager` abierto dentro del propio test.
+
+**El gestor de sesiones es de un solo uso, y eso rompió un test que ya funcionaba.** `StreamableHTTPSessionManager.run()` sólo puede llamarse una vez por instancia, y `backend.main.mcp` es un singleton de módulo: el primer test que levantara su app HTTP dejaba el gestor gastado para los demás. Lo grave no es el fallo sino su forma — **dependía del orden de ejecución**, así que `test_main.py` pasaba aislado y fallaba en conjunto. Es el patrón que se acaba etiquetando de *flaky* sin llegar a entenderlo. La solución es una fixture que **construye un servidor nuevo por test**, montado igual que `main.py`; que eso sean tres líneas es rédito directo del descubrimiento automático de #91.
+
+**Y un tercero que hizo lo que debía**: el test que fija las rutas de OpenAPI falló al añadir `/tools`, porque afirmaba que sólo había dos. Un contrato que avisa cuando cambia.
+
+**Límites.** El filtro por categoría (R5.4) y la búsqueda (R5.6) quedan fuera: bajaron a PODRÁ al revisar los requisitos, y once herramientas caben en una pantalla sin desplazarse. Sigue sin existir `/tools/{name}/execute` (R4.3) ni `/history` (R4.4).
+
 ### Registro automático de integraciones (#91)
 
 R1.9 —escrito al ordenar la extensibilidad en #86— dice que añadir una fuente de datos o una señal de análisis no debe obligar a modificar las herramientas existentes. La mitad de interfaz ya estaba cumplida por el envoltorio uniforme de señales; la de servidor no: `main.py` listaba los `register()` a mano, así que añadir una integración obligaba a editarlo.

--- a/backend/api/analyze.py
+++ b/backend/api/analyze.py
@@ -42,7 +42,7 @@ from backend.core.models import ToolResult
 from backend.integrations.nlp import lexical, linear
 from backend.integrations.nlp.factory import get_nlp_backend
 from backend.integrations.nlp.incoherence import IncoherenceDetector
-from backend.integrations.nlp.model_cards import MODEL_CARDS
+from backend.integrations.nlp.model_cards import cards_by_signal
 
 # Instancias únicas: LocalNLPClient cachea los pipelines por instancia y el
 # detector carga el modelo de forma perezosa, así que crearlos por petición
@@ -56,7 +56,7 @@ _detector = IncoherenceDetector()
 # dimensión ni el tipo de cada señal: se leen de MODEL_CARDS (R3.9). Un desajuste
 # entre esta clave y el nombre real de la tool lo detecta antes de llegar aquí
 # test_model_cards_signals_match_registered_tools.
-_CARDS = {card["signal"]: card for card in MODEL_CARDS}
+_CARDS = cards_by_signal()
 
 # TODO(deuda): estos ids están duplicados en integrations/nlp/tool.py. Unificar
 # leyéndolos de MODEL_CARDS["name"] exige antes normalizar ese campo, que hoy

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -27,7 +27,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.api.analyze import analyze
-from backend.api.schemas import AnalyzeRequest, AnalyzeResponse
+from backend.api.catalog import fetch_catalog
+from backend.api.schemas import AnalyzeRequest, AnalyzeResponse, CatalogResponse
 from backend.config.settings import settings
 from backend.core.health import check_health
 from backend.core.logging import configure_logging
@@ -95,6 +96,22 @@ async def post_analyze(request: AnalyzeRequest) -> AnalyzeResponse:
     engaño no se puede evaluar.
     """
     return await analyze(request)
+
+
+@app.get("/tools", response_model=CatalogResponse, tags=["catálogo"])
+async def get_tools() -> CatalogResponse:
+    """Catálogo de herramientas disponibles, descubierto en el momento.
+
+    No es un menú de lanzamiento: responde **qué compone el sistema y con qué
+    límites**. Cada herramienta trae su categoría, de qué integración procede y
+    —si es una señal de análisis— su ficha de modelo, con el tipo, la dimensión
+    que mide y sus límites conocidos.
+
+    Devuelve **200 aunque un servidor MCP no responda**: sale en `servers` con
+    estado `unreachable` y `degraded` queda a `true`, pero las herramientas de
+    los demás se sirven igual.
+    """
+    return await fetch_catalog()
 
 
 @app.get("/health", tags=["operación"])

--- a/backend/api/catalog.py
+++ b/backend/api/catalog.py
@@ -1,0 +1,148 @@
+"""Construcción del catálogo de herramientas — ``GET /tools``.
+
+A diferencia de ``/analyze``, que importa el núcleo directamente, aquí se habla
+**MCP de verdad**: el catálogo se construye por descubrimiento
+(*handshake*), porque debe reflejar lo que hay conectado en ese momento y no una
+lista escrita a mano. Importar módulos daría siempre la misma respuesta aunque
+el servidor estuviera caído — que es justo lo contrario de lo que se quiere
+mostrar.
+
+**Sesión por petición, no persistente.** El catálogo se consulta cuando alguien
+abre la pantalla de Sistema, no en bucle, así que los ~0,2 s del handshake son
+imperceptibles. Mantener la sesión viva a cambio obligaría a gestionar
+reconexión, guardar estado mutable compartido y responder si ``ClientSession``
+aguanta uso concurrente. Se paga esa complejidad cuando haya un consumidor
+caliente que la justifique —el agente, con muchas invocaciones por turno— y con
+una medición delante.
+
+Tiene un efecto secundario que la hace más atractiva: **la API no necesita
+conectarse al arrancar**. Arranca siempre, y ``/tools`` informa del estado real
+en el momento de la llamada.
+
+**Un servidor caído no rompe la respuesta.** Sale en ``servers`` con estado
+``unreachable`` y su motivo, y las herramientas de los demás se sirven igual.
+Es el mismo patrón que las señales de ``/analyze``.
+"""
+
+import asyncio
+
+import httpx
+import structlog
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.types import Tool
+
+from backend.api.schemas import (
+    CatalogResponse,
+    Dimension,
+    ServerInfo,
+    ServerStatus,
+    SignalType,
+    ToolInfo,
+    ToolModelCard,
+)
+from backend.config.settings import settings
+from backend.integrations.nlp.model_cards import cards_by_signal
+
+log = structlog.get_logger()
+
+
+def _http_client() -> httpx.AsyncClient:
+    """Cliente HTTP para hablar con un servidor MCP.
+
+    Aislado en una función para que los tests lo sustituyan por uno montado
+    sobre ``ASGITransport`` y hablen el protocolo en el mismo proceso, sin abrir
+    puertos. El timeout es lo que distingue «caído» de «colgado»: sin él, un
+    servidor que acepta la conexión y no contesta dejaría ``/tools`` esperando.
+    """
+    return httpx.AsyncClient(timeout=settings.mcp_timeout)
+
+
+async def fetch_catalog() -> CatalogResponse:
+    """Consulta todos los servidores configurados y funde sus catálogos."""
+    resultados = await asyncio.gather(
+        *(_consultar(url) for url in settings.mcp_servers),
+        return_exceptions=True,
+    )
+
+    servers: list[ServerInfo] = []
+    tools: list[ToolInfo] = []
+
+    # gather conserva el orden de entrada, así que cada resultado corresponde a
+    # la URL de su misma posición.
+    for url, resultado in zip(settings.mcp_servers, resultados, strict=True):
+        if isinstance(resultado, BaseException):
+            log.warning(
+                "catalogo.servidor_inalcanzable", url=url, motivo=str(resultado)
+            )
+            servers.append(
+                ServerInfo(
+                    url=url,
+                    status=ServerStatus.UNREACHABLE,
+                    detail=f"{type(resultado).__name__}: {resultado}",
+                )
+            )
+            continue
+
+        info, del_servidor = resultado
+        servers.append(info)
+        tools.extend(del_servidor)
+
+    return CatalogResponse(servers=servers, tools=tools)
+
+
+async def _consultar(url: str) -> tuple[ServerInfo, list[ToolInfo]]:
+    """Abre una sesión MCP, se presenta y pide el catálogo de ese servidor."""
+    async with (
+        _http_client() as http_client,
+        streamable_http_client(url, http_client=http_client) as (read, write, _),
+        ClientSession(read, write) as session,
+    ):
+        inicializacion = await session.initialize()
+        listado = await session.list_tools()
+
+    nombre = inicializacion.serverInfo.name
+    herramientas = [_envolver(tool, nombre) for tool in listado.tools]
+
+    return (
+        ServerInfo(
+            url=url,
+            name=nombre,
+            status=ServerStatus.OK,
+            tool_count=len(herramientas),
+        ),
+        herramientas,
+    )
+
+
+def _envolver(tool: Tool, servidor: str) -> ToolInfo:
+    """Traduce una ``Tool`` del protocolo al contrato del catálogo."""
+    meta = tool.meta or {}
+
+    return ToolInfo(
+        name=tool.name,
+        description=tool.description,
+        input_schema=tool.inputSchema,
+        category=meta.get("category"),
+        integration=meta.get("integration"),
+        server=servidor,
+        model_card=_ficha_de(tool.name),
+    )
+
+
+def _ficha_de(nombre: str) -> ToolModelCard | None:
+    """Busca la ficha de modelo de una tool, si es una señal de análisis.
+
+    El índice vive en ``model_cards`` porque lo comparte con la orquestación de
+    ``/analyze``: dos copias acabarían divergiendo. Devuelve None para las
+    herramientas que no son señales — fuentes de contenido y utilidades.
+    """
+    card = cards_by_signal().get(nombre)
+    if card is None:
+        return None
+
+    return ToolModelCard(
+        type=SignalType(card["type"]),
+        dimension=Dimension(card["dimension"]),
+        limitations=card["limitations"],
+    )

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -35,7 +35,7 @@ Tres principios lo gobiernan:
 from enum import Enum
 from typing import Annotated, Any
 
-from pydantic import BaseModel, Field, StringConstraints
+from pydantic import BaseModel, Field, StringConstraints, computed_field
 
 # Recorta antes de medir. Con un simple `min_length=1`, un titular de un solo
 # espacio pasa la validación —mide 1 carácter— y llega hasta las señales, que
@@ -169,3 +169,105 @@ class AnalyzeResponse(BaseModel):
         """¿Alguna señal llegó a ejecutarse? Si no, la respuesta es informativa
         (dice por qué falló cada una) pero no hay análisis que mostrar."""
         return any(s.status == SignalStatus.OK for s in self.signals)
+
+
+# --------------------------------------------------------------------------
+# Catálogo de herramientas — GET /tools
+#
+# El catálogo NO es un menú de lanzamiento: es la superficie que responde «qué
+# compone este sistema y con qué límites». Por eso cada herramienta puede traer
+# su ficha de modelo, y no sólo su nombre y su esquema.
+# --------------------------------------------------------------------------
+
+
+class ServerStatus(str, Enum):
+    """Estado de un servidor MCP consultado."""
+
+    OK = "ok"
+    UNREACHABLE = "unreachable"  # no respondió, o tardó más que el timeout
+
+
+class ServerInfo(BaseModel):
+    """Un servidor MCP declarado en la configuración, respondiera o no.
+
+    Aparece aunque esté caído: es lo que convierte «seguir operando con los
+    restantes y reflejar el estado degradado» en algo observable en vez de en
+    una lista más corta sin explicación.
+    """
+
+    url: str
+    name: str | None = Field(
+        default=None,
+        description="Nombre que el propio servidor declara en el handshake.",
+    )
+    status: ServerStatus
+    tool_count: int = 0
+    detail: str | None = Field(
+        default=None, description="Motivo legible cuando no se pudo consultar."
+    )
+
+
+class ToolModelCard(BaseModel):
+    """Ficha del modelo que hay detrás de una señal de análisis.
+
+    Es lo que evita que el catálogo enseñe «detect_clickbait_linear — Señales de
+    análisis» y esconda que es interpretable, que mide forma y que su F1 cae
+    fuera de dominio. Reutiliza los enums de las señales en vez de duplicar
+    cadenas sueltas.
+    """
+
+    type: SignalType
+    dimension: Dimension
+    limitations: list[str]
+
+
+class ToolInfo(BaseModel):
+    """Una herramienta del catálogo, con su procedencia y sus metadatos."""
+
+    name: str
+    description: str | None = Field(
+        default=None, description="Docstring de la tool, tal como la lee el LLM."
+    )
+    input_schema: dict[str, Any] = Field(
+        description=(
+            "Esquema JSON de los parámetros, CRUDO. No se aplana: perdería las "
+            "restricciones (mínimos, máximos, valores por defecto) que la "
+            "interfaz necesita para validar el formulario antes de enviar."
+        )
+    )
+
+    category: str | None = Field(
+        default=None,
+        description="Qué tipo de trabajo hace: fuente, señal de análisis o utilidad.",
+    )
+    integration: str | None = Field(
+        default=None,
+        description=(
+            "Paquete del que procede (nyt, guardian, weather, nlp). None si es "
+            "del núcleo y no envuelve ninguna fuente externa."
+        ),
+    )
+    server: str = Field(description="Servidor MCP que la expone.")
+
+    model_card: ToolModelCard | None = Field(
+        default=None,
+        description="Sólo para las señales de análisis; None para el resto.",
+    )
+
+
+class CatalogResponse(BaseModel):
+    """Catálogo completo: qué servidores se consultaron y qué ofrecen."""
+
+    servers: list[ServerInfo]
+    tools: list[ToolInfo]
+
+    @computed_field
+    @property
+    def degraded(self) -> bool:
+        """¿Falta algún servidor por responder?
+
+        Va como campo calculado y no como ``@property`` a secas porque la
+        interfaz lo necesita EN EL JSON: una propiedad normal no se serializa,
+        y obligaría al frontend a recorrer la lista para deducir lo mismo.
+        """
+        return any(s.status != ServerStatus.OK for s in self.servers)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -40,5 +40,20 @@ class Settings(BaseSettings):
     mcp_host: str = "127.0.0.1"
     mcp_port: int = 8765
 
+    # Servidores MCP que consulta la API para construir el catálogo.
+    #
+    # Es una LISTA aunque hoy tenga un elemento:sirve para agregar los
+    # catálogos de todos los servidores conectados indicando el origen de cada
+    # herramienta, y pasar de `str` a `list[str]` más tarde tocaría a la vez la
+    # configuración, el catálogo y su contrato. Cuesta lo mismo ahora.
+    #
+    # Desde el entorno se pasa como JSON:
+    #   MCP_SERVERS='["http://mcp:8765/mcp","http://otro:8765/mcp"]'
+    mcp_servers: list[str] = ["http://127.0.0.1:8765/mcp"]
+
+    # Corte para dar un servidor por inalcanzable. Sin él, un servidor que acepta
+    # la conexión y no responde dejaría /tools colgado en vez de degradado.
+    mcp_timeout: float = 5.0
+
 
 settings = Settings()  # type: ignore #Activa la validación al importar

--- a/backend/core/health.py
+++ b/backend/core/health.py
@@ -7,6 +7,7 @@ from mcp.server.fastmcp import FastMCP
 
 from backend.config.settings import settings
 from backend.core.observability import log_tool_invocation
+from backend.integrations.metadata import tool_meta
 
 PROBE_TIMEOUT = 5
 
@@ -63,7 +64,9 @@ async def check_health() -> dict:
 
 
 def register(mcp: FastMCP):
-    @mcp.tool()
+    # `integration` sale None: vive en core/ y no envuelve ninguna fuente
+    # externa. Es infraestructura, no una integración.
+    @mcp.tool(meta=tool_meta("Utilidades", __name__))
     @log_tool_invocation
     async def health_check() -> dict:
         """Comprueba la salud de las apis haciendo una llamada a cada una

--- a/backend/integrations/guardian/tool.py
+++ b/backend/integrations/guardian/tool.py
@@ -9,13 +9,14 @@ from pydantic import Field
 
 from backend.core.observability import log_tool_invocation
 from backend.integrations.guardian.client import GuardianAPI
+from backend.integrations.metadata import tool_meta
 
 
 def register(mcp: FastMCP):
 
     api = GuardianAPI()
 
-    @mcp.tool()
+    @mcp.tool(meta=tool_meta("Fuentes de contenido", __name__))
     @log_tool_invocation
     async def get_guardian_news(
         topic: str | None = Field(

--- a/backend/integrations/metadata.py
+++ b/backend/integrations/metadata.py
@@ -1,0 +1,54 @@
+"""Metadata declarada en cada tool MCP, para el catálogo.
+
+El objeto ``Tool`` del protocolo trae nombre, descripción y esquema, pero **no
+categoría ni procedencia**. MCP permite adjuntar un ``meta`` libre por tool, y
+eso viaja intacto hasta el cliente, así que la información se declara en el
+origen en vez de en un mapa cableado en la API — que obligaría a editar la API
+cada vez que se añade una fuente.
+
+**Dos ejes, y se tratan distinto a propósito.**
+
+La **categoría** es un juicio: qué tipo de trabajo hace la herramienta. No se
+puede derivar de dónde vive el fichero — ``describe_models`` está en ``nlp/``
+pero es una utilidad, no una señal de análisis. Así que se declara, y declararla
+obliga a pensarla al añadir la siguiente.
+
+La **integración** es un hecho de ubicación: de qué paquete viene. Se deriva del
+módulo, y por eso **no puede mentir**. Declararla a mano permitiría que el
+paquete dijera una cosa y el ``meta`` otra, en silencio — el mismo fallo que el
+campo ``signal`` de las fichas de modelo.
+"""
+
+from typing import Any, Literal
+
+# Cerradas a propósito: si hiciera falta una cuarta, es una decisión, no un
+# descuido de quien añade una tool.
+#
+#
+# Efecto secundario útil: «Señales de análisis» son exactamente las que llevan
+# ficha de modelo, así que la categoría predice si `model_card` viene o no.
+Categoria = Literal["Fuentes de contenido", "Señales de análisis", "Utilidades"]
+
+# Prefijo de los paquetes de integración, para recortarlo al derivar el origen.
+_PREFIJO = "backend.integrations."
+
+
+def tool_meta(categoria: Categoria, modulo: str) -> dict[str, Any]:
+    """Construye el ``meta`` de una tool. Se usa como ``@mcp.tool(meta=...)``.
+
+    ``modulo`` es siempre ``__name__``: de ahí sale la integración. Para una
+    herramienta del núcleo —fuera de ``backend/integrations/``— la integración
+    es ``None``, que significa «no envuelve ninguna fuente externa».
+
+    >>> tool_meta("Señales de análisis", "backend.integrations.nlp.tool")
+    {'category': 'Señales de análisis', 'integration': 'nlp'}
+    """
+    return {"category": categoria, "integration": _integracion_de(modulo)}
+
+
+def _integracion_de(modulo: str) -> str | None:
+    """Saca el nombre del paquete de integración de un módulo, o None."""
+    if not modulo.startswith(_PREFIJO):
+        return None
+    return modulo[len(_PREFIJO) :].split(".", 1)[0]
+    # Recorta el prefijo y coge la primera parte, que es el paquete de integración.

--- a/backend/integrations/nlp/model_cards.py
+++ b/backend/integrations/nlp/model_cards.py
@@ -27,6 +27,18 @@ no significan que el titular engañe. Sin este campo, el backend tendría que
 cablear qué señal es cuál — justo lo que se evita.
 """
 
+
+def cards_by_signal() -> dict[str, dict]:
+    """Índice de fichas por nombre de tool.
+
+    Vive aquí y no en quien lo usa porque lo necesitan DOS consumidores —la
+    orquestación de ``/analyze``, para leer la dimensión de cada señal, y el
+    catálogo, para adjuntar la ficha— y dos copias del mismo índice acabarían
+    divergiendo.
+    """
+    return {card["signal"]: card for card in MODEL_CARDS}
+
+
 MODEL_CARDS = [
     {
         "signal": "detect_clickbait",

--- a/backend/integrations/nlp/tool.py
+++ b/backend/integrations/nlp/tool.py
@@ -7,6 +7,7 @@ import json
 from mcp.server.fastmcp import FastMCP
 
 from backend.core.observability import log_tool_invocation
+from backend.integrations.metadata import tool_meta
 from backend.integrations.nlp import lexical, linear, model_cards
 from backend.integrations.nlp.factory import get_nlp_backend
 from backend.integrations.nlp.incoherence import IncoherenceDetector
@@ -17,7 +18,7 @@ def register(mcp: FastMCP):
     api = get_nlp_backend()
     detector = IncoherenceDetector()
 
-    @mcp.tool()
+    @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
     async def detect_clickbait(headline: str) -> str:
         """Detecta si un titular de noticia es clickbait o informativo (factual).
@@ -45,7 +46,7 @@ def register(mcp: FastMCP):
             return response.error or "Error al analizar el titular"
         return json.dumps(response.data)
 
-    @mcp.tool()
+    @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
     async def analyze_sentiment(text: str) -> str:
         """Analiza el sentimiento de un texto (p.ej. un titular de noticia).
@@ -68,7 +69,7 @@ def register(mcp: FastMCP):
             return response.error or "Error al analizar el sentimiento"
         return json.dumps(response.data)
 
-    @mcp.tool()
+    @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
     async def detect_clickbait_incoherence(headline: str, content: str) -> str:
         """Detecta posible clickbait midiendo la (in)coherencia entre titular y cuerpo.
@@ -96,7 +97,7 @@ def register(mcp: FastMCP):
             return response.error or "Error al analizar incoherencia en el titular"
         return json.dumps(response.data)
 
-    @mcp.tool()
+    @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
     async def detect_clickbait_lexical(headline: str) -> str:
         """
@@ -121,7 +122,7 @@ def register(mcp: FastMCP):
             return response.error or "Error al analizar léxico en el titular"
         return json.dumps(response.data)
 
-    @mcp.tool()
+    @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
     async def detect_clickbait_linear(headline: str) -> str:
         """Detecta clickbait con un modelo lineal interpretable (regresión logística
@@ -140,7 +141,9 @@ def register(mcp: FastMCP):
             return response.error or "Error al predecir clickbait en el titular"
         return json.dumps(response.data)
 
-    @mcp.tool()
+    # Utilidad, no señal: describe los modelos, no analiza nada. Es el caso que
+    # demuestra que la categoría no se puede derivar del paquete.
+    @mcp.tool(meta=tool_meta("Utilidades", __name__))
     @log_tool_invocation
     async def describe_models() -> str:
         """Divulga los modelos/señales que emplea el sistema (transparencia, R3.9).

--- a/backend/integrations/nyt/tool.py
+++ b/backend/integrations/nyt/tool.py
@@ -8,6 +8,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
 from backend.core.observability import log_tool_invocation
+from backend.integrations.metadata import tool_meta
 from backend.integrations.nyt.client import NYTAPI
 
 
@@ -15,7 +16,7 @@ def register(mcp: FastMCP):
 
     api = NYTAPI()
 
-    @mcp.tool()
+    @mcp.tool(meta=tool_meta("Fuentes de contenido", __name__))
     @log_tool_invocation
     async def get_nyt_news(
         topic: str | None = Field(

--- a/backend/integrations/weather/tool.py
+++ b/backend/integrations/weather/tool.py
@@ -1,6 +1,7 @@
 from mcp.server.fastmcp import FastMCP
 
 from backend.core.observability import log_tool_invocation
+from backend.integrations.metadata import tool_meta
 from backend.integrations.weather.client import WeatherAPI
 
 
@@ -8,7 +9,7 @@ def register(mcp: FastMCP):
 
     api = WeatherAPI()
 
-    @mcp.tool()
+    @mcp.tool(meta=tool_meta("Fuentes de contenido", __name__))
     @log_tool_invocation
     async def get_alerts(state: str) -> str | dict:
         """Get weather alerts for a US state.
@@ -22,7 +23,7 @@ def register(mcp: FastMCP):
 
         return response.data  # type: ignore
 
-    @mcp.tool()
+    @mcp.tool(meta=tool_meta("Fuentes de contenido", __name__))
     @log_tool_invocation
     async def get_forecast(latitude: float, longitude: float) -> str:
         """Get weather forecast for a location.

--- a/docs/requisitos.md
+++ b/docs/requisitos.md
@@ -94,7 +94,7 @@ Este documento define los requisitos para un Trabajo de Fin de Grado (TFG) que i
 
 1. EL Tool_Catalog DEBERÁ **exponer** las MCP_Tools disponibles con sus metadatos. _(Antes «mantener un registro»; contradecía a R5.8. Ver memoria de cambios.)_
 2. EL Tool_Catalog DEBERÁ exponer, por cada herramienta, su nombre, descripción, esquema de parámetros y categoría. _(Antes «CUANDO se registre… almacenar»: en un catálogo dinámico ese evento no existe. Ver memoria de cambios.)_
-3. EL Tool_Catalog DEBERÁ admitir la categorización de herramientas (por ejemplo, «Integración de API», «Análisis de NLP», «Utilidades»).
+3. EL Tool_Catalog DEBERÁ admitir la categorización de herramientas: «Fuentes de contenido», «Señales de análisis» y «Utilidades». _(Los ejemplos originales eran «Integración de API» y «Análisis de NLP»; el primero describía la implementación —y era falso como distinción, porque las señales también llaman a APIs— y el segundo nombraba una tecnología en vez de un propósito. Ver memoria de cambios.)_
 4. AL consultar el catálogo, EL Tool_Catalog **PODRÁ** devolver las herramientas filtradas por categoría si así se solicita. _(Antes DEBERÁ. Ver memoria de cambios.)_
 5. EL Tool_Catalog DEBERÁ incluir esquemas de validación de parámetros para cada herramienta.
 6. EL Tool_Catalog **PODRÁ** admitir la búsqueda de herramientas por nombre o palabras clave de descripción. _(Antes DEBERÁ; desproporcionado para el número de tools previsto. Ver memoria de cambios.)_

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -149,7 +149,7 @@ def test_cors_rechaza_un_origen_no_declarado():
 def test_openapi_documenta_las_rutas_y_el_contrato():
     esquema = client.get("/openapi.json").json()
 
-    assert set(esquema["paths"]) == {"/analyze", "/health"}
+    assert set(esquema["paths"]) == {"/analyze", "/tools", "/health"}
     # Las descripciones de los Field llegan al esquema: son lo que ve quien
     # consume /docs y lo que hereda el cliente TypeScript generado.
     propiedades = esquema["components"]["schemas"]["SignalResult"]["properties"]

--- a/tests/api/test_catalog.py
+++ b/tests/api/test_catalog.py
@@ -1,0 +1,185 @@
+"""Tests del catálogo — `GET /tools`.
+
+Ninguno abre un puerto. Se sustituye `catalog._http_client` por uno montado
+sobre `ASGITransport` contra la app MCP real: el protocolo se habla entero
+—handshake, `list_tools`— en el mismo proceso. Es el mismo truco de
+`test_main.py`, y aquí es además necesario, porque el servidor arranca por
+defecto en `stdio` y no hay nada escuchando en el puerto durante los tests.
+
+**Por qué un gestor de contexto y no una fixture asíncrona.** El *lifespan* de
+la app abre un ámbito de cancelación de anyio, y pytest-asyncio puede ejecutar
+la fixture y el cuerpo del test en tareas distintas: al salir, anyio protesta
+con «attempted to exit cancel scope in a different task». Abriéndolo dentro del
+propio test, entrada y salida ocurren en la misma tarea.
+"""
+
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+
+from backend.api import catalog
+from backend.api.schemas import ServerStatus
+from backend.config.settings import settings
+
+# El Host debe llevar puerto: la protección anti DNS-rebinding de FastMCP acepta
+# `127.0.0.1:*` y rechazaría con 421 un Host sin él.
+_BASE = "http://127.0.0.1:8765"
+_URL = f"{_BASE}/mcp"
+
+
+@asynccontextmanager
+async def servidor_en_proceso(monkeypatch, mcp):
+    """Hace que el catálogo hable con la app MCP sin salir del proceso."""
+    app = mcp.streamable_http_app()
+
+    # El gestor de sesiones de FastMCP arranca en el lifespan de la app, y
+    # ASGITransport no lo ejecuta: hay que entrarlo a mano o toda petición falla.
+    async with app.router.lifespan_context(app):
+        monkeypatch.setattr(
+            catalog,
+            "_http_client",
+            lambda: httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url=_BASE
+            ),
+        )
+        monkeypatch.setattr(settings, "mcp_servers", [_URL])
+        yield
+
+
+async def _catalogo(monkeypatch, mcp):
+    """Atajo: levanta el servidor en proceso y devuelve el catálogo."""
+    async with servidor_en_proceso(monkeypatch, mcp):
+        return await catalog.fetch_catalog()
+
+
+async def _tools(monkeypatch, mcp):
+    return {t.name: t for t in (await _catalogo(monkeypatch, mcp)).tools}
+
+
+# ----- Descubrimiento -----
+
+
+@pytest.mark.asyncio
+async def test_el_catalogo_se_construye_por_handshake(monkeypatch, servidor_mcp):
+    resultado = await _catalogo(monkeypatch, servidor_mcp)
+
+    assert len(resultado.servers) == 1
+    servidor = resultado.servers[0]
+    assert servidor.status == ServerStatus.OK
+    # El nombre lo declara el propio servidor en el handshake, no la config.
+    assert servidor.name == "tfg-mcp-server"
+    assert servidor.tool_count == len(resultado.tools) == 11
+    assert not resultado.degraded
+
+
+@pytest.mark.asyncio
+async def test_cada_tool_trae_nombre_descripcion_y_esquema(monkeypatch, servidor_mcp):
+    # El esquema de parámetros viaja crudo, con sus restricciones.
+    tools = await _tools(monkeypatch, servidor_mcp)
+
+    lexical = tools["detect_clickbait_lexical"]
+    assert lexical.description
+    assert "headline" in lexical.input_schema["properties"]
+    assert lexical.server == "tfg-mcp-server"
+
+
+# ----- Categoría y procedencia  -----
+
+
+@pytest.mark.asyncio
+async def test_las_tools_declaran_categoria_y_procedencia(monkeypatch, servidor_mcp):
+    tools = await _tools(monkeypatch, servidor_mcp)
+
+    assert tools["get_nyt_news"].category == "Fuentes de contenido"
+    assert tools["get_nyt_news"].integration == "nyt"
+    assert tools["detect_clickbait_lexical"].category == "Señales de análisis"
+    assert tools["detect_clickbait_lexical"].integration == "nlp"
+
+
+@pytest.mark.asyncio
+async def test_la_categoria_no_se_deriva_del_paquete(monkeypatch, servidor_mcp):
+    # `describe_models` vive en nlp/ pero es una utilidad: describe modelos, no
+    # analiza nada. Es el caso que obliga a declarar la categoría a mano.
+    tools = await _tools(monkeypatch, servidor_mcp)
+
+    assert tools["describe_models"].integration == "nlp"
+    assert tools["describe_models"].category == "Utilidades"
+
+
+@pytest.mark.asyncio
+async def test_una_tool_del_nucleo_no_tiene_integracion(monkeypatch, servidor_mcp):
+    # health_check vive en core/ y no envuelve ninguna fuente externa.
+    tools = await _tools(monkeypatch, servidor_mcp)
+
+    assert tools["health_check"].category == "Utilidades"
+    assert tools["health_check"].integration is None
+
+
+# ----- Fichas de modelo -----
+
+
+@pytest.mark.asyncio
+async def test_las_senales_traen_su_ficha_de_modelo(monkeypatch, servidor_mcp):
+    tools = await _tools(monkeypatch, servidor_mcp)
+
+    ficha = tools["detect_clickbait_lexical"].model_card
+    assert ficha is not None
+    assert ficha.type.value == "interpretable"
+    assert ficha.dimension.value == "forma"
+    # Los límites medidos son lo que evita que el catálogo prometa de más.
+    assert any("0.498" in limite for limite in ficha.limitations)
+
+
+@pytest.mark.asyncio
+async def test_solo_las_senales_traen_ficha(monkeypatch, servidor_mcp):
+    tools = await _tools(monkeypatch, servidor_mcp)
+
+    con_ficha = {n for n, t in tools.items() if t.model_card is not None}
+    senales = {n for n, t in tools.items() if t.category == "Señales de análisis"}
+
+    # La categoría predice si hay ficha: no es casualidad, es el criterio.
+    assert con_ficha == senales
+
+
+# ----- Degradación  -----
+
+
+@pytest.mark.asyncio
+async def test_sin_servidores_configurados_no_es_degradacion(monkeypatch):
+    """Cero servidores da catálogo vacío pero NO degradado, y es lo correcto.
+
+    `gather()` sin corrutinas devuelve `[]`, el bucle no se ejecuta y `any([])`
+    es False. Pero lo que importa es la semántica: `degraded` significa «algo
+    declarado no responde», y sin nada declarado no ha fallado nada. Esto es una
+    **mala configuración**, no una degradación.
+
+    La distinción vale la pena porque el contrato permite separar las dos formas
+    de acabar sin herramientas: `servers` vacío es que no hay nada configurado;
+    `servers` con entradas `unreachable` es que está declarado y no responde. Si
+    la lista vacía marcara `degraded`, ambas colapsarían en una y la interfaz no
+    podría decir cuál de las dos está pasando.
+    """
+    monkeypatch.setattr(settings, "mcp_servers", [])
+
+    resultado = await catalog.fetch_catalog()
+
+    assert resultado.servers == []
+    assert resultado.tools == []
+    assert not resultado.degraded
+
+
+@pytest.mark.asyncio
+async def test_un_servidor_caido_no_rompe_la_respuesta(monkeypatch, servidor_mcp):
+    monkeypatch.setattr(settings, "mcp_servers", ["http://127.0.0.1:1/mcp"])
+    monkeypatch.setattr(settings, "mcp_timeout", 1.0)
+
+    resultado = await catalog.fetch_catalog()
+
+    assert resultado.degraded
+    servidor = resultado.servers[0]
+    assert servidor.status == ServerStatus.UNREACHABLE
+    assert servidor.detail  # el motivo, para poder diagnosticarlo
+    assert servidor.tool_count == 0
+    # Lo importante: hay respuesta, no una excepción.
+    assert resultado.tools == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,30 @@
 import pytest
 import structlog
+from mcp.server.fastmcp import FastMCP
+
+from backend.core import health
+from backend.integrations.discovery import discover_and_register
+
+
+@pytest.fixture
+def servidor_mcp() -> FastMCP:
+    """Un servidor MCP recién construido, con las mismas tools que `main.py`.
+
+    NO se reutiliza `backend.main.mcp`, que es un singleton de módulo, porque
+    `StreamableHTTPSessionManager.run()` **sólo puede llamarse una vez por
+    instancia**: el primer test que levantara su app dejaría el gestor gastado y
+    los siguientes fallarían con «can only be called once per instance» — un
+    fallo que además depende del orden de ejecución, así que aparece y
+    desaparece según qué tests se corran juntos.
+
+    Se monta igual que `main.py` para que lo que se prueba sea el servidor real
+    y no una maqueta: descubrimiento de integraciones más el chequeo de salud.
+    """
+    mcp = FastMCP("tfg-mcp-server")
+    discover_and_register(mcp)
+    health.register(mcp)
+    return mcp
+
 
 # Encontrado fallo de aislamiento entre tests al usar capsys.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -69,7 +69,7 @@ def test_ambos_transportes_son_validos(transporte):
 
 
 @pytest.mark.asyncio
-async def test_el_servidor_sirve_de_verdad_por_http():
+async def test_el_servidor_sirve_de_verdad_por_http(servidor_mcp):
     """El servidor responde el protocolo MCP completo por HTTP.
 
     Los tests de arriba espían `mcp.run`, así que comprueban el CABLEADO pero no
@@ -80,7 +80,9 @@ async def test_el_servidor_sirve_de_verdad_por_http():
     montado sobre `ASGITransport`, así que las peticiones entran directas en la
     app sin tocar la red.
     """
-    app = main_mod.mcp.streamable_http_app()
+    # Servidor recién construido, no el singleton de main: su gestor de
+    # sesiones sólo puede arrancar una vez por instancia (ver conftest).
+    app = servidor_mcp.streamable_http_app()
     transporte = httpx.ASGITransport(app=app)
 
     # El gestor de sesiones de FastMCP arranca en el lifespan de la app, y


### PR DESCRIPTION
## #97 · `GET /tools`: catálogo dinámico con fichas de modelo

Closes #97

Segunda pieza de H2, y **el primer sitio donde la API habla MCP de verdad**.
`/analyze` importa el núcleo directamente —dos fachadas sobre el mismo código— y
para él es correcto; aquí no vale, y R5.8 lo exige explícitamente. La razón no es
purismo: **importar módulos daría siempre la misma respuesta aunque el servidor
estuviera caído**, que es justo lo contrario de lo que un catálogo debe mostrar.

### Qué incluye
- `backend/integrations/metadata.py`: `tool_meta()`, aplicado a las 11 tools.
- `backend/api/catalog.py`: cliente MCP y ensamblado del catálogo.
- `backend/api/schemas.py`: `ServerInfo`, `ToolInfo`, `ToolModelCard`,
  `CatalogResponse`.
- `GET /tools` en la app.
- `cards_by_signal()` centralizado en `model_cards.py`, que ya consume también
  `analyze.py` — dos copias del mismo índice acabarían divergiendo.
- 9 tests nuevos.

### Categoría declarada, integración derivada
El objeto `Tool` de MCP no trae ninguna de las dos. MCP sí permite adjuntar un
`meta` libre por herramienta, y se verificó que **viaja intacto** hasta el
cliente, así que se declara en el origen en vez de en un mapa cableado en la API
—que obligaría a editarla al añadir una fuente, lo que R1.9 prohíbe—.

Los dos ejes se tratan distinto a propósito. La **categoría es un juicio** y no
se puede derivar de dónde vive el fichero: `describe_models` está en `nlp/` pero
es una utilidad, no una señal. La **integración es un hecho de ubicación**, se
deriva del módulo, y por eso **no puede mentir**; declararla a mano permitiría
que el paquete dijera una cosa y el `meta` otra, en silencio — el fallo que costó
el renombrado del campo `signal` en H1.

### Las categorías de R5.3, renombradas
«Integración de API» describía la implementación y era **falso como distinción**:
`detect_clickbait` es una llamada a la API de HuggingFace tanto como
`get_nyt_news` lo es a la de NYT. Y «Análisis de NLP» nombraba una tecnología
cuando el proyecto ya tiene su palabra, «señal», usada en `SignalResult` y en la
orquestación.

Pasan a **Fuentes de contenido** y **Señales de análisis**. El renombrado tiene
una propiedad que lo confirma: «Señales de análisis» son exactamente las cinco
que llevan ficha de modelo, así que la categoría *predice* si `model_card` viene
o no. Con los nombres anteriores parecía casualidad.

### Sesión por petición, rectificando lo planificado
El issue proponía mantener la sesión viva en el `lifespan` para ahorrar los
0,212 s del handshake. Al implementarlo no se sostiene: `/tools` se consulta al
abrir la pantalla de Sistema, no en bucle, así que esa latencia es
imperceptible. A cambio, la sesión persistente obliga a gestionar reconexión,
guardar estado mutable compartido y responder si `ClientSession` aguanta uso
concurrente.

La decisión **hizo desaparecer otra pregunta abierta del issue**: «¿arranca la
API sin servidor MCP?» sólo existía porque el catálogo se construía al arrancar.
Sin sesión persistente no hay nada que conectar en el arranque.

### Degradación, con una distinción que se conserva
Un servidor caído sale en `servers` como `unreachable` con su motivo, `degraded`
queda a `true` y las herramientas de los demás se sirven igual.

**Sin servidores configurados, en cambio, el catálogo sale vacío pero NO
degradado.** Parece un descuido y es deliberado: `degraded` significa «algo
declarado no responde», y sin nada declarado no ha fallado nada — eso es una mala
configuración. El contrato separa las dos formas de acabar sin herramientas:
`servers` vacío es que no hay nada configurado; `servers` con entradas
`unreachable` es que está declarado y no contesta. Si la lista vacía marcara
`degraded`, ambas colapsarían y la interfaz no podría decir cuál está pasando —
una te manda a revisar la configuración, la otra a mirar si el contenedor vive.

### Tres obstáculos en los tests
Los tests hablan el protocolo entero contra la app **en el mismo proceso**, con
`ASGITransport`. Aquí no es optimización sino necesidad: el servidor arranca por
defecto en `stdio`, así que no hay nada escuchando en ningún puerto.

- **El `lifespan` no admite una fixture asíncrona.** Falla con «attempted to exit
  cancel scope in a different task»: un *cancel scope* de anyio exige abrirse y
  cerrarse en la misma tarea, y pytest-asyncio puede ejecutar fixture y test en
  tareas distintas. Resuelto con un `@asynccontextmanager` abierto dentro del test.
- **El gestor de sesiones es de un solo uso, y rompió un test que ya
  funcionaba.** `StreamableHTTPSessionManager.run()` sólo puede llamarse una vez
  por instancia, y `backend.main.mcp` es un singleton de módulo. Lo grave no es el
  fallo sino su forma: **dependía del orden de ejecución**, así que `test_main.py`
  pasaba aislado y fallaba en conjunto — el patrón que se acaba etiquetando de
  *flaky* sin entenderlo. Resuelto con una fixture que construye un servidor nuevo
  por test; que sean tres líneas es rédito de #91.
- **El test de OpenAPI falló al añadir la ruta**, porque afirmaba que sólo había
  dos. Hizo exactamente su trabajo.

### Notas
Verificado contra el servidor real: 11 herramientas, las cinco señales con su
tipo y dimensión, y el nombre del servidor tomado del `handshake`
(`serverInfo.name`) y no de la configuración — prueba de que hubo conversación.

Fuera de alcance: filtro por categoría (R5.4) y búsqueda (R5.6), que bajaron a
PODRÁ al revisar los requisitos porque once herramientas caben en una pantalla.
Siguen sin existir `/tools/{name}/execute` (R4.3) e `/history` (R4.4), que son lo
que queda de H2.

121 tests en verde.
