### PR TITLE
feat(api): ejecución de tools y contrato de retorno estructurado

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,68 @@ El segundo caso merece atención: **es el escenario de discrepancia que se habí
 
 **Límites.** Sigue sin haber `/tools`, `/history` ni `/chat`. Los 12 tests nuevos cubren la capa HTTP (validación, delegación, CORS, OpenAPI) y **no repiten la orquestación**, que ya cubre `test_analyze.py`. Y `analyze.py` mantiene un efecto de importación conocido —`_api = get_nlp_backend()` a nivel de módulo— que congela el backend NLP al importar, igual que hace `tool.py`.
 
+### Ejecutar una herramienta, y el contrato de retorno que lo bloqueaba (#100)
+
+`/tools` ya publicaba el `inputSchema` de cada herramienta, así que la interfaz podía construir el formulario. Faltaba el endpoint que ejecutara lo que ese formulario produce — para cuando no se quieren las cuatro señales, sólo el sentimiento, o para traer una noticia con la que luego analizar.
+
+Al medirlo antes de escribir nada apareció un bloqueo previo.
+
+#### El endpoint no podía saber si la ejecución había salido bien
+
+| Escenario | `isError` | `content[0].text` |
+|---|---|---|
+| Titular válido | `False` | `{"score": 3, "is_clickbait": true, …}` |
+| Titular vacío (**la tool falla**) | **`False`** | `El titular está vacío o no es válido` |
+| Parámetro inexistente | `True` | `Error executing tool …: validation error` |
+
+`isError` sólo se activaba cuando el fallo ocurría en la **capa MCP**. Si la herramienta *devolvía* un mensaje de error —que es lo que hacían las once— para el protocolo eso era un éxito. Éxito y fallo salían por el mismo canal y sin marca. Y «parsear como JSON» no valía de heurística: `get_forecast` devuelve prosa formateada siendo una ejecución correcta.
+
+**Se descartó `-> ToolResult`**, que era la opción aparentemente obvia por existir ya. Su esquema describe **el sobre, no la carta** —`data` queda como `anyOf: [{}, null]`, «cualquier cosa o nada»— y duplica el eje que MCP ya tiene: como `ToolResult.fail` se devuelve y no se lanza, produciría respuestas con `isError: false` y `success: false` **a la vez**, peor que la ambigüedad de partida. `ToolResult` sigue intacto donde estaba: en los `client.py` y `base_api.py`, transportando resultados dentro del proceso. No aparecía ni aparece en ningún `tool.py`.
+
+#### Un fallo que llevaba desde la Épica 1 escondido
+
+Al hacer que las tools lanzaran, el mensaje de error **seguía perdiéndose**, sustituido por una queja de Pydantic sobre el esquema de salida. La causa estaba en `log_tool_invocation`:
+
+```python
+except Exception:
+    log.error(..., exception=traceback.format_exc())
+    return "Internal error while executing tool"
+```
+
+**El decorador de observabilidad capturaba toda excepción y devolvía una cadena.** Consecuencia real, y anterior a este issue: un `KeyError` o un fallo de red no capturado dentro de una tool llegaba al cliente como **texto normal con `isError` a False** — indistinguible de un análisis correcto.
+
+Y explica por qué el contrato *parecía* coherente: no era que unas tools devolvieran errores por decisión y otras no. Era que el decorador **aplanaba todo a texto**, lo devuelto a propósito y lo lanzado por accidente. El arreglo es un `raise` en lugar de un `return`, con el principio detrás escrito en el código: **el decorador es para observar, no para decidir qué se responde**. El traceback completo sigue yendo al log.
+
+#### Salida estructurada: qué cuesta y qué no
+
+| Retorno declarado | `outputSchema` | `structuredContent` |
+|---|---|---|
+| `-> str` con `json.dumps` *(lo anterior)* | `{"result": string}` | el JSON **como texto** |
+| `-> dict` a secas | **`None`** | **`None`** |
+| `TypedDict` propio | **describe los campos reales** | el objeto, directo |
+
+Anotar `-> dict` no sirve de nada: MCP necesita un tipo **declarado**. Con él, el esquema publicado incluye además el docstring del tipo como `description`, así que el catálogo entrega documentación junto al contrato.
+
+Nueve herramientas declaran su tipo. **`get_alerts` y `get_forecast` se quedan en `-> str`**, y no es una carencia: producen prosa formateada para leer, no datos con estructura; declararles un tipo obligaría a inventar campos que la salida no tiene.
+
+#### El endpoint
+
+`POST /tools/{name}/execute` valida los argumentos contra el `inputSchema` **antes** de invocar (R4.5), acumulando todos los problemas en vez de parar en el primero — quien rellena un formulario prefiere corregirlo de una vez. Que la validación sea *previa* es lo que permite distinguir un campo mal escrito (**422**, con el nombre del campo) de un análisis que salió mal.
+
+Tres categorías, tres respuestas: **404** si la herramienta no existe, **422** si los argumentos no encajan, y **200 con `status` en `error`** si la herramienta se ejecutó y falló. Lo último no es un error HTTP: la petición era correcta y el servidor la atendió, así que se responde igual que en `/analyze`, donde una señal caída no tumba la respuesta.
+
+Y un timeout propio: `mcp_timeout` son 5 s, de sobra para un `list_tools`, pero `detect_clickbait_incoherence` tarda ~20 s la primera vez cargando el modelo de embeddings. Con el margen del descubrimiento, esa llamada moriría siempre en frío.
+
+#### Un fallo que habría llegado a producción
+
+Las excepciones lanzadas **dentro de una sesión MCP salen envueltas en `ExceptionGroup`**, porque la sesión abre un *task group* de anyio y anyio agrupa lo que se lance dentro. El `except InvalidArguments` de la ruta no la habría reconocido, y un argumento mal escrito habría devuelto un **500 en vez del 422** que le corresponde.
+
+La lógica ahora **devuelve** lo que ha ocurrido y decide fuera de la sesión qué excepción sale. Es una restricción general de cualquier código construido sobre anyio, y la segunda vez que aparece en este proyecto: la primera fueron los *cancel scopes* de los tests del catálogo.
+
+#### Y un hueco de cobertura que el cambio destapó
+
+Rehacer el contrato de las once herramientas **no rompió un solo test**. No porque estuviera bien cubierto, sino porque **nadie probaba las tools MCP**: todos los tests atacan la capa cliente (`lexical.detect`, `HFClient`), que devuelve `ToolResult` y no ha cambiado. `tests/integrations/test_tool_contract.py` cubre ahora esa frontera — que todas publiquen esquema, que un fallo marque `isError`, y que las de texto se envuelvan como corresponde.
+
 ### Metadata de las tools: categoría y procedencia (#97, primera parte)
 
 El catálogo necesita saber, de cada herramienta, **qué tipo de trabajo hace** y **de dónde viene**. El objeto `Tool` del protocolo MCP trae nombre, descripción y esquema, pero ninguna de esas dos cosas. MCP sí permite adjuntar un `meta` libre por herramienta, y se comprobó que **viaja intacto hasta el cliente**, así que la información se declara en el origen en vez de en un mapa cableado en la API — que obligaría a editarla cada vez que se añade una fuente, justo lo que R1.9 prohíbe.

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -23,12 +23,19 @@ conectadas en runtime no se puede hacer importando módulos.
 from contextlib import asynccontextmanager
 
 import structlog
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.api.analyze import analyze
 from backend.api.catalog import fetch_catalog
-from backend.api.schemas import AnalyzeRequest, AnalyzeResponse, CatalogResponse
+from backend.api.execute import InvalidArguments, ToolNotFound, execute_tool
+from backend.api.schemas import (
+    AnalyzeRequest,
+    AnalyzeResponse,
+    CatalogResponse,
+    ExecuteRequest,
+    ExecuteResponse,
+)
 from backend.config.settings import settings
 from backend.core.health import check_health
 from backend.core.logging import configure_logging
@@ -112,6 +119,32 @@ async def get_tools() -> CatalogResponse:
     los demás se sirven igual.
     """
     return await fetch_catalog()
+
+
+@app.post("/tools/{name}/execute", response_model=ExecuteResponse, tags=["catálogo"])
+async def post_execute(name: str, request: ExecuteRequest) -> ExecuteResponse:
+    """Ejecuta una herramienta concreta con los argumentos indicados.
+
+    Para cuando no se quieren las cuatro señales —sólo el sentimiento, por
+    ejemplo— o para traer una noticia con la que luego analizar.
+
+    Los argumentos se validan contra el `input_schema` que publica `/tools`
+    **antes** de invocar, así que un campo mal escrito devuelve un 422 diciendo
+    cuál, en vez de llegar como un fallo de ejecución indistinguible de un
+    análisis que salió mal.
+
+    Devuelve **404** si la herramienta no existe, **422** si los argumentos no
+    encajan, y **200 con `status` en `error`** si la herramienta se ejecutó y
+    falló: eso último no es un error HTTP, porque la petición era correcta.
+    """
+    try:
+        return await execute_tool(name, request.arguments)
+    except ToolNotFound:
+        raise HTTPException(
+            status_code=404, detail=f"No hay ninguna herramienta llamada '{name}'."
+        ) from None
+    except InvalidArguments as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from None
 
 
 @app.get("/health", tags=["operación"])

--- a/backend/api/catalog.py
+++ b/backend/api/catalog.py
@@ -26,12 +26,10 @@ Es el mismo patrón que las señales de ``/analyze``.
 
 import asyncio
 
-import httpx
 import structlog
-from mcp import ClientSession
-from mcp.client.streamable_http import streamable_http_client
 from mcp.types import Tool
 
+from backend.api.mcp_session import open_session
 from backend.api.schemas import (
     CatalogResponse,
     Dimension,
@@ -45,17 +43,6 @@ from backend.config.settings import settings
 from backend.integrations.nlp.model_cards import cards_by_signal
 
 log = structlog.get_logger()
-
-
-def _http_client() -> httpx.AsyncClient:
-    """Cliente HTTP para hablar con un servidor MCP.
-
-    Aislado en una función para que los tests lo sustituyan por uno montado
-    sobre ``ASGITransport`` y hablen el protocolo en el mismo proceso, sin abrir
-    puertos. El timeout es lo que distingue «caído» de «colgado»: sin él, un
-    servidor que acepta la conexión y no contesta dejaría ``/tools`` esperando.
-    """
-    return httpx.AsyncClient(timeout=settings.mcp_timeout)
 
 
 async def fetch_catalog() -> CatalogResponse:
@@ -93,12 +80,7 @@ async def fetch_catalog() -> CatalogResponse:
 
 async def _consultar(url: str) -> tuple[ServerInfo, list[ToolInfo]]:
     """Abre una sesión MCP, se presenta y pide el catálogo de ese servidor."""
-    async with (
-        _http_client() as http_client,
-        streamable_http_client(url, http_client=http_client) as (read, write, _),
-        ClientSession(read, write) as session,
-    ):
-        inicializacion = await session.initialize()
+    async with open_session(url, settings.mcp_timeout) as (session, inicializacion):
         listado = await session.list_tools()
 
     nombre = inicializacion.serverInfo.name

--- a/backend/api/execute.py
+++ b/backend/api/execute.py
@@ -1,0 +1,131 @@
+"""Ejecución de una herramienta concreta — ``POST /tools/{name}/execute``.
+
+Sus dos consumidores son ejecutar **una señal suelta** —sólo el sentimiento, sin
+lanzar las cuatro— y **traer una noticia** desde la pantalla de análisis. No un
+catálogo que haga de lanzador.
+
+**Los parámetros se validan antes de invocar** (R4.5), contra el ``inputSchema``
+que el propio servidor publica. Se podría dejar que validara MCP, pero entonces
+un argumento mal escrito llegaría como fallo de ejecución y sería
+indistinguible de un análisis que salió mal: validando aquí, la API puede
+responder 422 y decir qué campo falla.
+
+**Tres errores, tres categorías distintas:**
+
+- La herramienta no existe → **404**. La petición pide algo que no hay.
+- Los argumentos no encajan en su esquema → **422**. La petición está mal
+  formada.
+- La herramienta se ejecuta y falla → **200 con ``status`` en ``error``**. La
+  petición era correcta y el servidor la atendió; lo que falló es el análisis.
+  Mismo criterio que en ``/analyze``, donde una señal caída no tumba la
+  respuesta.
+"""
+
+import structlog
+from jsonschema import Draft7Validator
+from mcp.types import CallToolResult, Tool
+
+from backend.api.mcp_session import open_session
+from backend.api.schemas import ExecuteResponse, ExecuteStatus
+from backend.config.settings import settings
+
+log = structlog.get_logger()
+
+
+class ToolNotFound(Exception):
+    """La herramienta no está en ningún servidor configurado."""
+
+
+class InvalidArguments(Exception):
+    """Los argumentos no encajan en el esquema que publica la herramienta."""
+
+
+async def execute_tool(name: str, arguments: dict) -> ExecuteResponse:
+    """Localiza la herramienta, valida los argumentos y la invoca.
+
+    **Nada se lanza desde dentro de la sesión.** La sesión MCP abre un *task
+    group* de anyio, y anyio envuelve en un ``ExceptionGroup`` lo que se lance
+    ahí dentro: el ``except InvalidArguments`` de la ruta no lo capturaría y
+    saldría un 500 donde toca un 422. Por eso ``_intentar`` **devuelve** lo que
+    ha pasado y es aquí, ya fuera, donde se decide qué excepción sale.
+    """
+    for url in settings.mcp_servers:
+        intento = await _intentar(url, name, arguments)
+        if intento is None:
+            continue  # esta herramienta no está en este servidor
+
+        problemas, resultado, servidor = intento
+        if problemas:
+            raise InvalidArguments(problemas)
+        return _envolver(resultado, name, servidor)
+
+    raise ToolNotFound(name)
+
+
+async def _intentar(
+    url: str, name: str, arguments: dict
+) -> tuple[str | None, CallToolResult | None, str] | None:
+    """Busca la herramienta en un servidor y, si está, la valida y la invoca.
+
+    Devuelve ``None`` si no la tiene. Si la tiene, ``(problemas, resultado,
+    servidor)``: con ``problemas`` los argumentos no pasaron la validación y no
+    se llegó a invocar nada.
+    """
+    async with open_session(url, settings.mcp_execute_timeout) as (
+        session,
+        inicializacion,
+    ):
+        tools = {t.name: t for t in (await session.list_tools()).tools}
+        if name not in tools:
+            return None
+
+        servidor = inicializacion.serverInfo.name
+        problemas = _problemas(arguments, tools[name])
+        if problemas:
+            return problemas, None, servidor
+
+        return None, await session.call_tool(name, arguments), servidor
+
+
+def _problemas(arguments: dict, tool: Tool) -> str | None:
+    """Valida los argumentos contra el ``inputSchema``; None si están bien.
+
+    Se acumulan **todos** los problemas en vez de parar en el primero: quien
+    rellena un formulario prefiere corregirlo de una vez a descubrirlos de uno
+    en uno.
+    """
+    errores = sorted(
+        Draft7Validator(tool.inputSchema).iter_errors(arguments),
+        key=lambda e: list(e.path),
+    )
+    if not errores:
+        return None
+
+    return "; ".join(
+        f"{'.'.join(str(p) for p in e.path) or '(raíz)'}: {e.message}" for e in errores
+    )
+
+
+def _envolver(resultado: CallToolResult, name: str, servidor: str) -> ExecuteResponse:
+    """Traduce la respuesta del protocolo al contrato de la API.
+
+    ``isError`` es fiable desde que las herramientas **lanzan** en vez de
+    devolver el mensaje de error: antes un fallo llegaba por el mismo canal que
+    un resultado válido y aquí no habría forma de distinguirlos.
+    """
+    if resultado.isError:
+        motivo = resultado.content[0].text if resultado.content else "Error desconocido"
+        log.warning("tool.execute.failed", tool=name, motivo=motivo)
+        return ExecuteResponse(
+            tool=name,
+            server=servidor,
+            status=ExecuteStatus.ERROR,
+            detail=motivo,
+        )
+
+    return ExecuteResponse(
+        tool=name,
+        server=servidor,
+        status=ExecuteStatus.OK,
+        data=resultado.structuredContent,
+    )

--- a/backend/api/mcp_session.py
+++ b/backend/api/mcp_session.py
@@ -13,7 +13,7 @@ conectarse al arrancar**: arranca siempre e informa del estado real en cada
 llamada.
 """
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import httpx
@@ -36,7 +36,7 @@ def _http_client(timeout: float) -> httpx.AsyncClient:
 @asynccontextmanager
 async def open_session(
     url: str, timeout: float
-) -> AsyncIterator[tuple[ClientSession, InitializeResult]]:
+) -> AsyncGenerator[tuple[ClientSession, InitializeResult]]:
     """Abre una sesión MCP ya inicializada contra ``url``.
 
     Devuelve también el resultado del *handshake*, porque de ahí sale el nombre

--- a/backend/api/mcp_session.py
+++ b/backend/api/mcp_session.py
@@ -1,0 +1,57 @@
+"""Apertura de sesiones MCP desde la API.
+
+Extraído porque lo comparten dos consumidores —el catálogo y la ejecución de
+herramientas— y duplicar el montaje de tres gestores de contexto anidados era
+pedir que se desincronizaran.
+
+**Sesión por petición, no persistente.** Ni el catálogo ni la ejecución son
+endpoints calientes: se consultan cuando alguien abre una pantalla o pulsa un
+botón, así que los ~0,2 s del handshake son imperceptibles. Mantener la sesión
+viva obligaría a gestionar reconexión, estado mutable compartido y uso
+concurrente de ``ClientSession``. Como efecto secundario, **la API no necesita
+conectarse al arrancar**: arranca siempre e informa del estado real en cada
+llamada.
+"""
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.types import InitializeResult
+
+
+def _http_client(timeout: float) -> httpx.AsyncClient:
+    """Cliente HTTP para hablar con un servidor MCP.
+
+    Aislado en una función para que los tests lo sustituyan por uno montado
+    sobre ``ASGITransport`` y hablen el protocolo en el mismo proceso, sin abrir
+    puertos. El timeout es lo que distingue «caído» de «colgado»: sin él, un
+    servidor que acepta la conexión y no contesta dejaría la petición esperando.
+    """
+    return httpx.AsyncClient(timeout=timeout)
+
+
+@asynccontextmanager
+async def open_session(
+    url: str, timeout: float
+) -> AsyncIterator[tuple[ClientSession, InitializeResult]]:
+    """Abre una sesión MCP ya inicializada contra ``url``.
+
+    Devuelve también el resultado del *handshake*, porque de ahí sale el nombre
+    que **declara el propio servidor** (``serverInfo.name``) — no el que figure
+    en la configuración.
+
+    Las tres capas, de dentro afuera: el cliente httpx pone el transporte y el
+    timeout, ``streamable_http_client`` traduce HTTP a los dos flujos que MCP
+    necesita, y ``ClientSession`` habla el protocolo sobre ellos. Se cierran en
+    orden inverso.
+    """
+    async with (
+        _http_client(timeout) as http_client,
+        streamable_http_client(url, http_client=http_client) as (read, write, _),
+        ClientSession(read, write) as session,
+    ):
+        inicializacion = await session.initialize()
+        yield session, inicializacion

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -271,3 +271,59 @@ class CatalogResponse(BaseModel):
         y obligaría al frontend a recorrer la lista para deducir lo mismo.
         """
         return any(s.status != ServerStatus.OK for s in self.servers)
+
+
+# --------------------------------------------------------------------------
+# Ejecución de una herramienta — POST /tools/{name}/execute
+# --------------------------------------------------------------------------
+
+
+class ExecuteRequest(BaseModel):
+    """Parámetros con los que invocar la herramienta.
+
+    Van en un diccionario libre y no en campos declarados porque **cada
+    herramienta tiene los suyos**: la forma correcta la publica su
+    ``input_schema`` en el catálogo, y contra ese esquema se validan antes de
+    ejecutar.
+    """
+
+    arguments: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Argumentos de la herramienta, según su `input_schema`.",
+    )
+
+
+class ExecuteStatus(str, Enum):
+    """Cómo acabó la ejecución."""
+
+    OK = "ok"
+    ERROR = "error"  # la herramienta se ejecutó y falló
+
+
+class ExecuteResponse(BaseModel):
+    """Resultado de ejecutar una herramienta.
+
+    Que la herramienta falle **no es un error HTTP**: la petición era válida y
+    el servidor la atendió: lo que falló es el análisis. Por eso se responde 200
+    con ``status`` en ``error``, igual que una señal caída en ``/analyze`` no
+    tumba la respuesta. Los códigos de error se reservan para lo que sí es
+    culpa de la petición: 404 si la herramienta no existe, 422 si los argumentos
+    no encajan en su esquema.
+    """
+
+    tool: str
+    server: str
+    status: ExecuteStatus
+
+    data: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Salida estructurada de la herramienta, tal como la declara su "
+            "`output_schema`. Las que devuelven texto o listas llegan envueltas "
+            "en `result`, porque el protocolo sólo deja sin envolver los "
+            "objetos."
+        ),
+    )
+    detail: str | None = Field(
+        default=None, description="Motivo legible cuando `status` es `error`."
+    )

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -55,5 +55,11 @@ class Settings(BaseSettings):
     # la conexión y no responde dejaría /tools colgado en vez de degradado.
     mcp_timeout: float = 5.0
 
+    # Ejecutar una herramienta necesita mucho más margen que descubrirla: un
+    # `list_tools` tarda milésimas, pero `detect_clickbait_incoherence` puede
+    # tardar ~20 s la primera vez porque carga el modelo de embeddings. Con el
+    # timeout de descubrimiento, esa llamada moriría siempre en frío.
+    mcp_execute_timeout: float = 60.0
+
 
 settings = Settings()  # type: ignore #Activa la validación al importar

--- a/backend/core/health.py
+++ b/backend/core/health.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Literal, TypedDict
 
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -10,6 +10,26 @@ from backend.core.observability import log_tool_invocation
 from backend.integrations.metadata import tool_meta
 
 PROBE_TIMEOUT = 5
+
+
+class Sonda(TypedDict):
+    """Resultado de sondear una integración."""
+
+    reachable: bool
+    error: str | None
+
+
+class Salud(TypedDict):
+    """Estado agregado del sistema y de cada integración por separado.
+
+    Se devuelven las dos cosas a propósito: el agregado sirve para un semáforo,
+    pero sin el detalle por integración no se puede saber **cuál** falla.
+    """
+
+    status: Literal["ok", "degraded", "down"]
+    timestamp: str
+    integrations: dict[str, Sonda]
+
 
 PROBES = {
     "weather": {
@@ -47,7 +67,7 @@ def _aggregate_status(integrations: dict) -> Literal["ok", "degraded", "down"]:
     return "degraded"
 
 
-async def check_health() -> dict:
+async def check_health() -> Salud:
     """Sondea todas las integraciones y agrega su estado.
 
     Vive fuera de ``register`` porque lo consumen DOS fachadas: la tool MCP de
@@ -68,7 +88,7 @@ def register(mcp: FastMCP):
     # externa. Es infraestructura, no una integración.
     @mcp.tool(meta=tool_meta("Utilidades", __name__))
     @log_tool_invocation
-    async def health_check() -> dict:
+    async def health_check() -> Salud:
         """Comprueba la salud de las apis haciendo una llamada a cada una
 
         Returns:

--- a/backend/core/observability.py
+++ b/backend/core/observability.py
@@ -47,6 +47,15 @@ def log_tool_invocation(func):
                 success=False,
                 exception=traceback.format_exc(),  # Guarda el traceback completo como string
             )
-            return "Internal error while executing tool"
+            # RELANZAR, no devolver un texto. Devolviéndolo, la excepción no
+            # llegaba nunca a MCP: el protocolo la veía como un resultado válido
+            # (`isError` a False) y el consumidor no podía distinguir un fallo de
+            # un análisis correcto. Además, con salida estructurada declarada,
+            # esa cadena tampoco encaja en el esquema y el motivo real se perdía
+            # detrás de un error de validación de Pydantic.
+            #
+            # El decorador es para OBSERVAR, no para decidir qué se responde: el
+            # traceback completo queda en el log, y quien llama recibe el error.
+            raise
 
     return wrapper

--- a/backend/integrations/guardian/tool.py
+++ b/backend/integrations/guardian/tool.py
@@ -2,14 +2,29 @@
 News API for The Guardian
 """
 
-import json
+from typing import TypedDict
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from backend.core.observability import log_tool_invocation
 from backend.integrations.guardian.client import GuardianAPI
 from backend.integrations.metadata import tool_meta
+
+
+class Articulo(TypedDict):
+    """Un artículo de The Guardian.
+
+    Todos los campos son opcionales porque el cliente los extrae con ``.get()``:
+    la API no garantiza que estén, y declararlos obligatorios haría que el
+    esquema publicado prometiera más de lo que se puede cumplir.
+    """
+
+    title: str | None
+    url: str | None
+    date: str | None
+    content: str | None  # el teaser (`trailText`), lo que alimenta la incoherencia
 
 
 def register(mcp: FastMCP):
@@ -26,7 +41,7 @@ def register(mcp: FastMCP):
         days: int = Field(
             default=7, ge=1, le=30, description="Días hacia atrás desde hoy (1-30)."
         ),
-    ) -> str:
+    ) -> list[Articulo]:
         """Busca noticias de The Guardian. Se puede indicar de hace cuantos días buscar(por defecto, última semana)
 
         Args:
@@ -34,10 +49,13 @@ def register(mcp: FastMCP):
             days (int, Optional): número de días que se incluyen en la busqueda desde hoy (Default = 7)
 
         Returns:
-            JSON serializado con lista de artículos {title, url, date}, o un mensaje de error
-            si no hay resultados o la API falla
+            Lista de artículos {title, url, date, content}, donde `content` es el
+            teaser — lo que necesita `detect_clickbait_incoherence`.
+
+        Raises:
+            Si no hay resultados o la API falla.
         """
         response = await api.search_articles(topic, days)
         if not response.has_content():
-            return response.error or "Error fetching news"
-        return json.dumps(response.data)
+            raise ToolError(response.error or "Error fetching news")
+        return response.data

--- a/backend/integrations/nlp/outputs.py
+++ b/backend/integrations/nlp/outputs.py
@@ -1,0 +1,80 @@
+"""Tipos de salida de las tools NLP, para que MCP publique su ``outputSchema``.
+
+Sin un tipo **declarado** en la firma, MCP no genera esquema de salida: se
+comprobó que anotar ``-> dict`` a secas deja ``outputSchema`` en ``None`` y
+``structuredContent`` vacío, y que ``-> str`` con ``json.dumps`` obliga al
+consumidor a parsear texto a ciegas.
+
+Con estos tipos, el catálogo publica qué devuelve cada herramienta y el cliente
+recibe el objeto ya estructurado. Son ``TypedDict`` y no modelos Pydantic
+porque las capas de cliente ya devuelven diccionarios: así no hay que convertir
+nada, sólo declarar la forma que ya tienen.
+
+**No se declara aquí el éxito o el fallo.** Ese eje lo lleva el protocolo, con
+``isError``: las tools **lanzan** cuando algo va mal, en vez de devolver un
+mensaje de error por el mismo canal que un resultado válido.
+"""
+
+from typing import TypedDict
+
+
+class Etiqueta(TypedDict):
+    """Salida de un clasificador: la etiqueta ganadora y su confianza."""
+
+    label: str
+    score: float
+
+
+class Pista(TypedDict):
+    """Una marca léxica encontrada en el titular, y dónde aparece."""
+
+    category: str
+    cue: str
+    span: list[int]  # [inicio, fin] sobre el titular original
+
+
+class SalidaLexica(TypedDict):
+    """Salida del detector por reglas. La evidencia ES la explicación (R3.8)."""
+
+    score: int
+    is_clickbait: bool
+    matches: list[Pista]
+    headline: str
+
+
+class SalidaLineal(TypedDict):
+    """Salida del modelo lineal interpretable.
+
+    ``top_cues`` empareja cada cue con su contribución al veredicto (peso ×
+    frecuencia); es la explicación intrínseca del modelo.
+    """
+
+    is_clickbait: bool
+    probability: float
+    top_cues: list[tuple[str, float]]
+    headline: str
+
+
+class SalidaIncoherencia(TypedDict):
+    """Salida del contraste titular↔cuerpo.
+
+    Devuelve los textos comparados además de la similitud: sin ellos, el
+    resultado no es verificable por quien lo lee.
+    """
+
+    similarity: float
+    incoherent: bool
+    headline: str
+    content: str
+
+
+class FichaModelo(TypedDict):
+    """Una entrada de la divulgación de modelos."""
+
+    signal: str
+    name: str
+    task: str
+    type: str
+    dimension: str
+    limitations: list[str]
+    backend: str

--- a/backend/integrations/nlp/tool.py
+++ b/backend/integrations/nlp/tool.py
@@ -1,16 +1,28 @@
 """
 NLP Tool: detección de clickbait en titulares (zero-shot).
+
+Cada tool declara su tipo de salida, así que MCP publica un ``outputSchema`` y
+el cliente recibe el objeto estructurado en vez de una cadena que tenga que
+parsear. Y los fallos se **lanzan**: el protocolo los marca con ``isError``, en
+vez de devolver el mensaje por el mismo canal que un resultado válido — que era
+indistinguible desde fuera.
 """
 
-import json
-
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 
 from backend.core.observability import log_tool_invocation
 from backend.integrations.metadata import tool_meta
 from backend.integrations.nlp import lexical, linear, model_cards
 from backend.integrations.nlp.factory import get_nlp_backend
 from backend.integrations.nlp.incoherence import IncoherenceDetector
+from backend.integrations.nlp.outputs import (
+    Etiqueta,
+    FichaModelo,
+    SalidaIncoherencia,
+    SalidaLexica,
+    SalidaLineal,
+)
 
 
 def register(mcp: FastMCP):
@@ -20,7 +32,7 @@ def register(mcp: FastMCP):
 
     @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
-    async def detect_clickbait(headline: str) -> str:
+    async def detect_clickbait(headline: str) -> Etiqueta:
         """Detecta si un titular de noticia es clickbait o informativo (factual).
 
         Usa clasificación zero-shot (NLI) con las etiquetas fijas "clickbait" y
@@ -31,9 +43,11 @@ def register(mcp: FastMCP):
             headline (str): titular a evaluar (en inglés).
 
         Returns:
-            JSON con la etiqueta ganadora y su confianza (0-1),
-            p.ej. {"label": "clickbait", "score": 0.79}. Devuelve un mensaje
-            de error si la llamada al modelo falla.
+            La etiqueta ganadora y su confianza (0-1), p.ej.
+            {"label": "clickbait", "score": 0.79}.
+
+        Raises:
+            Si la llamada al modelo falla (timeout o caída del proveedor).
         """
         response = await api.zero_shot(
             headline,
@@ -43,12 +57,12 @@ def register(mcp: FastMCP):
             # Labels para crear y descartar hipotesis. FIJOS para no confundir LLM.
         )
         if not response.has_content():
-            return response.error or "Error al analizar el titular"
-        return json.dumps(response.data)
+            raise ToolError(response.error or "Error al analizar el titular")
+        return response.data
 
     @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
-    async def analyze_sentiment(text: str) -> str:
+    async def analyze_sentiment(text: str) -> Etiqueta:
         """Analiza el sentimiento de un texto (p.ej. un titular de noticia).
 
         Clasifica en tres clases: positive, neutral o negative (modelo en
@@ -58,20 +72,24 @@ def register(mcp: FastMCP):
             text (str): texto a analizar (en inglés).
 
         Returns:
-            JSON con la etiqueta ganadora y su confianza (0-1),
-            p.ej. {"label": "neutral", "score": 0.62}. Devuelve un mensaje
-            de error si la llamada al modelo falla.
+            La etiqueta ganadora y su confianza (0-1), p.ej.
+            {"label": "neutral", "score": 0.62}.
+
+        Raises:
+            Si la llamada al modelo falla (timeout o caída del proveedor).
         """
         response = await api.classify(
             text, "cardiffnlp/twitter-roberta-base-sentiment-latest"
         )
         if not response.has_content():
-            return response.error or "Error al analizar el sentimiento"
-        return json.dumps(response.data)
+            raise ToolError(response.error or "Error al analizar el sentimiento")
+        return response.data
 
     @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
-    async def detect_clickbait_incoherence(headline: str, content: str) -> str:
+    async def detect_clickbait_incoherence(
+        headline: str, content: str
+    ) -> SalidaIncoherencia:
         """Detecta posible clickbait midiendo la (in)coherencia entre titular y cuerpo.
 
         Genera embeddings del titular y del contenido con un modelo de
@@ -86,20 +104,24 @@ def register(mcp: FastMCP):
             content (str): cuerpo o teaser de la noticia con el que contrastar.
 
         Returns:
-            JSON con la similitud (0-1), si se considera incoherente
-            (incoherent: true si está por debajo del umbral) y los textos
-            comparados, p.ej. {"similarity": 0.18, "incoherent": true,
-            "headline": "...", "content": "..."}. Devuelve un mensaje de error
-            si el cálculo falla.
+            La similitud (0-1), si se considera incoherente (`incoherent` a true
+            cuando está por debajo del umbral) y los textos comparados, p.ej.
+            {"similarity": 0.18, "incoherent": true, "headline": "...",
+            "content": "..."}.
+
+        Raises:
+            Si el cálculo de los embeddings falla.
         """
         response = await detector.detect(headline, content)
         if not response.has_content():
-            return response.error or "Error al analizar incoherencia en el titular"
-        return json.dumps(response.data)
+            raise ToolError(
+                response.error or "Error al analizar incoherencia en el titular"
+            )
+        return response.data
 
     @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
-    async def detect_clickbait_lexical(headline: str) -> str:
+    async def detect_clickbait_lexical(headline: str) -> SalidaLexica:
         """
         Detecta clickbait por pistas léxicas y estructurales del titular (señal explicable).
 
@@ -113,18 +135,20 @@ def register(mcp: FastMCP):
             headline (str): titular a evaluar (en inglés).
 
         Returns:
-            JSON con `score` (nº de pistas), `is_clickbait` (score ≥ umbral),
-            `matches` (lista de {category, cue, span}) y `headline`. Mensaje de
-            error si el titular está vacío.
+            `score` (nº de pistas), `is_clickbait` (score ≥ umbral), `matches`
+            (lista de {category, cue, span}) y `headline`.
+
+        Raises:
+            Si el titular está vacío.
         """
         response = lexical.detect(headline)
         if not response.has_content():
-            return response.error or "Error al analizar léxico en el titular"
-        return json.dumps(response.data)
+            raise ToolError(response.error or "Error al analizar léxico en el titular")
+        return response.data
 
     @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
-    async def detect_clickbait_linear(headline: str) -> str:
+    async def detect_clickbait_linear(headline: str) -> SalidaLineal:
         """Detecta clickbait con un modelo lineal interpretable (regresión logística
         entrenada sobre pistas léxicas).
 
@@ -132,29 +156,33 @@ def register(mcp: FastMCP):
             headline: el titular a analizar.
 
         Returns:
-            JSON con is_clickbait, probability y top_cues — los cues que más empujaron
-            el veredicto (peso x frecuencia), como explicación intrínseca (R3.8).
-            Cuarta señal contrastable frente a zero-shot, incoherencia y léxico.
+            `is_clickbait`, `probability` y `top_cues` — los cues que más
+            empujaron el veredicto (peso × frecuencia), como explicación
+            intrínseca (R3.8). Cuarta señal contrastable frente a zero-shot,
+            incoherencia y léxico.
+
+        Raises:
+            Si el titular está vacío.
         """
         response = linear.predict(headline)
         if not response.has_content():
-            return response.error or "Error al predecir clickbait en el titular"
-        return json.dumps(response.data)
+            raise ToolError(response.error or "Error al predecir clickbait")
+        return response.data
 
     # Utilidad, no señal: describe los modelos, no analiza nada. Es el caso que
     # demuestra que la categoría no se puede derivar del paquete.
     @mcp.tool(meta=tool_meta("Utilidades", __name__))
     @log_tool_invocation
-    async def describe_models() -> str:
+    async def describe_models() -> list[FichaModelo]:
         """Divulga los modelos/señales que emplea el sistema (transparencia, R3.9).
 
         Devuelve, por cada señal, su nombre, tarea, tipo (interpretable /
-        híbrido / opaco) y limitaciones conocidas. Sin argumentos. Útil para la
-        transparencia de sistema y para decidir qué señal usar según su
-        naturaleza (white-box vs caja negra) y sus límites.
+        híbrido / opaco), dimensión que mide y limitaciones conocidas. Sin
+        argumentos. Útil para la transparencia de sistema y para decidir qué
+        señal usar según su naturaleza (white-box vs caja negra) y sus límites.
 
         Returns:
-            JSON con la lista de fichas de modelo (name, task, type,
+            La lista de fichas de modelo (signal, name, task, type, dimension,
             limitations, backend).
         """
-        return json.dumps(model_cards.MODEL_CARDS)
+        return model_cards.MODEL_CARDS

--- a/backend/integrations/nyt/tool.py
+++ b/backend/integrations/nyt/tool.py
@@ -2,14 +2,32 @@
 News API for The New York Times (NYT)
 """
 
-import json
+from typing import TypedDict
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from backend.core.observability import log_tool_invocation
 from backend.integrations.metadata import tool_meta
 from backend.integrations.nyt.client import NYTAPI
+
+
+class Articulo(TypedDict):
+    """Un artículo del New York Times.
+
+    Todos los campos son opcionales porque el cliente los extrae con ``.get()``.
+
+    ``print_headline`` es el titular de la edición impresa, y no siempre coincide
+    con el de web: esa discrepancia es material de análisis en sí misma, porque
+    la versión impresa suele ser la sobria.
+    """
+
+    title: str | None
+    print_headline: str | None
+    url: str | None
+    date: str | None
+    content: str | None  # el `abstract`, lo que alimenta la incoherencia
 
 
 def register(mcp: FastMCP):
@@ -26,7 +44,7 @@ def register(mcp: FastMCP):
         days: int = Field(
             default=7, ge=1, le=30, description="Días hacia atrás desde hoy (1-30)."
         ),
-    ) -> str:
+    ) -> list[Articulo]:
         """Busca noticias del New York Times. Se puede indicar de hace cuantos días buscar(por defecto, última semana)
 
         Args:
@@ -34,10 +52,14 @@ def register(mcp: FastMCP):
             days (int, Optional): número de días que se incluyen en la busqueda desde hoy (Default = 7)
 
         Returns:
-            JSON serializado con lista de artículos {title, url, date}, o un mensaje de error
-            si no hay resultados o la API falla
+            Lista de artículos {title, print_headline, url, date, content}, donde
+            `content` es el abstract — lo que necesita
+            `detect_clickbait_incoherence`.
+
+        Raises:
+            Si no hay resultados o la API falla.
         """
         response = await api.search_articles(topic, days)
         if not response.has_content():
-            return response.error or "Error fetching news"
-        return json.dumps(response.data)
+            raise ToolError(response.error or "Error fetching news")
+        return response.data

--- a/backend/integrations/weather/tool.py
+++ b/backend/integrations/weather/tool.py
@@ -1,8 +1,13 @@
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 
 from backend.core.observability import log_tool_invocation
 from backend.integrations.metadata import tool_meta
 from backend.integrations.weather.client import WeatherAPI
+
+# Estas dos tools se quedan devolviendo `str`, y NO es una carencia: producen
+# prosa formateada para leer, no datos con estructura. Declararles un tipo
+# estructurado obligaría a inventar campos que la salida no tiene.
 
 
 def register(mcp: FastMCP):
@@ -11,15 +16,21 @@ def register(mcp: FastMCP):
 
     @mcp.tool(meta=tool_meta("Fuentes de contenido", __name__))
     @log_tool_invocation
-    async def get_alerts(state: str) -> str | dict:
+    async def get_alerts(state: str) -> str:
         """Get weather alerts for a US state.
 
         Args:
             state: Two-letter US state code (e.g. CA, NY)
+
+        Returns:
+            The active alerts as formatted text, or a note saying there are none.
+
+        Raises:
+            If the weather API fails.
         """
         response = await api.get_alerts_API(state)
         if not response.has_content():
-            return response.error or "Error fetching alerts"
+            raise ToolError(response.error or "Error fetching alerts")
 
         return response.data  # type: ignore
 
@@ -31,21 +42,27 @@ def register(mcp: FastMCP):
         Args:
             latitude: Latitude of the location
             longitude: Longitude of the location
+
+        Returns:
+            The next five forecast periods as formatted text.
+
+        Raises:
+            If the location cannot be resolved or the weather API fails.
         """
         # First get the forecast grid endpoint
         zone_url = await api.get_zone_by_points(latitude, longitude)
 
         if not zone_url.has_content():
-            return zone_url.error or "Unknown error while fetching zone"
+            raise ToolError(zone_url.error or "Unknown error while fetching zone")
 
         # Get the forecast URL from the points response
         response = await api.get_forecast_API(zone_url.data)  # type: ignore
         if not response.has_content():
-            return response.error or "Unknown error while retrieving forecast"
+            raise ToolError(response.error or "Unknown error while retrieving forecast")
 
         periods = response.data.get("properties", {}).get("periods")  # type: ignore
         if not periods:
-            return "No forecast periods available"
+            raise ToolError("No forecast periods available")
 
         forecasts = []
         for period in periods[:5]:  # Only show next 5 periods

--- a/requirements.in
+++ b/requirements.in
@@ -18,3 +18,6 @@ structlog
 aiolimiter 
 
 transformers
+# Validación de argumentos de tool contra su inputSchema. Ya entraba
+# como transitiva de MCP; se declara porque el código la usa directamente.
+jsonschema

--- a/spikes/tool_calling_fase5_descripciones_reales.py
+++ b/spikes/tool_calling_fase5_descripciones_reales.py
@@ -1,0 +1,172 @@
+"""Spike #82 - Fase 5: revalidar la selección con las descripciones REALES.
+
+Motivo: al cambiar el contrato de retorno (#100) los docstrings pasaron de
+prometer «devuelve un mensaje de error si falla» a declarar una sección
+``Raises:``. Y el docstring **es la interfaz que lee el LLM**, así que había que
+comprobar que el modelo sigue eligiendo igual.
+
+Al ir a ejecutar la Fase 2 apareció que **no servía para esto**: dice usar «las
+descripciones REALES (docstrings de tool.py)» pero las lleva copiadas a mano,
+resumidas en dos o tres líneas. Medía unos textos que no habían cambiado.
+
+Aquí las descripciones se piden al servidor por ``list_tools``, igual que hará
+el agente en producción. Dos consecuencias: lo que se mide es lo que hay, y el
+spike **no puede volver a desfasarse** del código.
+
+Se reutilizan las 20 consultas y el criterio de acierto de la Fase 2, para que
+las cifras sean comparables.
+
+Ejecutar:  OLLAMA_HOST=127.0.0.1:11435 python spikes/tool_calling_fase5_descripciones_reales.py [modelo] [num_ctx]
+"""
+
+import asyncio
+import json
+import os
+import sys
+import time
+import urllib.request
+from collections import Counter
+from pathlib import Path
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.server.fastmcp import FastMCP
+
+# El spike vive fuera de los paquetes del proyecto; se añade la raíz al path
+# para poder leer las herramientas reales sin convertir spikes/ en paquete.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from backend.core import health  # noqa: E402
+from backend.integrations.discovery import discover_and_register  # noqa: E402
+from spikes.tool_calling_fase2 import PRUEBAS, parametros_validos  # noqa: E402
+
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "127.0.0.1:11434")
+OLLAMA_URL = f"http://{OLLAMA_HOST}/api/chat"
+MODEL = sys.argv[1] if len(sys.argv) > 1 else "qwen3.5:2b"
+NUM_CTX = int(sys.argv[2]) if len(sys.argv) > 2 else 2048
+
+_BASE = "http://127.0.0.1:8765"
+
+
+async def tools_del_servidor() -> list[dict]:
+    """Pide el catálogo al servidor real y lo traduce al formato de Ollama.
+
+    Se habla el protocolo contra la app en el mismo proceso (``ASGITransport``):
+    sin puertos ni subprocesos, pero con las descripciones y los esquemas
+    exactos que recibirá el agente.
+
+    El ``inputSchema`` de MCP ya es JSON Schema, y `parameters` de Ollama
+    también, así que pasa tal cual.
+    """
+    mcp = FastMCP("tfg-mcp-server")
+    discover_and_register(mcp)
+    health.register(mcp)
+    app = mcp.streamable_http_app()
+
+    async with (
+        app.router.lifespan_context(app),
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as cliente,
+        streamable_http_client(f"{_BASE}/mcp", http_client=cliente) as (r, w, _),
+        ClientSession(r, w) as sesion,
+    ):
+        await sesion.initialize()
+        listado = await sesion.list_tools()
+
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description or "",
+                "parameters": t.inputSchema,
+            },
+        }
+        for t in listado.tools
+    ]
+
+
+def chat(messages, tools, timeout=600):
+    payload = {
+        "model": MODEL,
+        "messages": messages,
+        "stream": False,
+        "options": {"num_ctx": NUM_CTX},
+        "tools": tools,
+    }
+    peticion = urllib.request.Request(
+        OLLAMA_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    inicio = time.perf_counter()
+    with urllib.request.urlopen(peticion, timeout=timeout) as respuesta:
+        datos = json.loads(respuesta.read())
+    return datos, time.perf_counter() - inicio
+
+
+def main():
+    tools = asyncio.run(tools_del_servidor())
+    largos = [len(t["function"]["description"]) for t in tools]
+
+    print(f"Modelo: {MODEL} | num_ctx: {NUM_CTX} | host: {OLLAMA_HOST}")
+    print(f"{len(tools)} herramientas leídas del servidor por list_tools")
+    print(f"Descripción media: {sum(largos) // len(largos)} caracteres "
+          f"(la Fase 2 usaba resúmenes de ~150)\n")
+
+    por_categoria = Counter()
+    aciertos = Counter()
+    latencias = []
+    params_ok = params_total = 0
+    fallos = []
+
+    for categoria, consulta, aceptables in PRUEBAS:
+        datos, segundos = chat([{"role": "user", "content": consulta}], tools)
+        latencias.append(segundos)
+
+        llamadas = datos.get("message", {}).get("tool_calls") or []
+        elegidas = {c.get("function", {}).get("name") for c in llamadas}
+
+        # Sin tools esperadas, acertar es NO llamar a ninguna.
+        acierto = (not elegidas) if not aceptables else bool(elegidas & aceptables)
+
+        por_categoria[categoria] += 1
+        aciertos[categoria] += int(acierto)
+        if not acierto:
+            fallos.append((categoria, consulta[:52], sorted(elegidas) or "(ninguna)"))
+
+        for llamada in llamadas:
+            funcion = llamada.get("function", {})
+            valido, _ = parametros_validos(
+                funcion.get("name"), funcion.get("arguments") or {}
+            )
+            params_total += 1
+            params_ok += int(valido)
+
+        print(f"  {'OK ' if acierto else 'FALLO'} {categoria:13s} "
+              f"{segundos:5.1f}s  {sorted(elegidas) or '-'}")
+
+    print("\n--- Selección por categoría ---")
+    for categoria in ["GENERICA", "ESPECIFICA", "OTRO_DOMINIO", "SIN_TOOL"]:
+        if por_categoria[categoria]:
+            print(f"  {categoria:13s} {aciertos[categoria]}/{por_categoria[categoria]}")
+    total = sum(aciertos.values())
+    print(f"  {'TOTAL':13s} {total}/{sum(por_categoria.values())}")
+
+    if params_total:
+        print(f"\nParámetros válidos: {params_ok}/{params_total}")
+
+    latencias.sort()
+    print(f"Latencia: mediana {latencias[len(latencias) // 2]:.1f}s | "
+          f"min {latencias[0]:.1f}s | max {latencias[-1]:.1f}s")
+
+    if fallos:
+        print("\n--- Fallos ---")
+        for categoria, consulta, elegidas in fallos:
+            print(f"  {categoria:13s} {consulta!r} -> {elegidas}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -149,7 +149,12 @@ def test_cors_rechaza_un_origen_no_declarado():
 def test_openapi_documenta_las_rutas_y_el_contrato():
     esquema = client.get("/openapi.json").json()
 
-    assert set(esquema["paths"]) == {"/analyze", "/tools", "/health"}
+    assert set(esquema["paths"]) == {
+        "/analyze",
+        "/tools",
+        "/tools/{name}/execute",
+        "/health",
+    }
     # Las descripciones de los Field llegan al esquema: son lo que ve quien
     # consume /docs y lo que hereda el cliente TypeScript generado.
     propiedades = esquema["components"]["schemas"]["SignalResult"]["properties"]

--- a/tests/api/test_catalog.py
+++ b/tests/api/test_catalog.py
@@ -18,7 +18,7 @@ from contextlib import asynccontextmanager
 import httpx
 import pytest
 
-from backend.api import catalog
+from backend.api import catalog, mcp_session
 from backend.api.schemas import ServerStatus
 from backend.config.settings import settings
 
@@ -37,9 +37,9 @@ async def servidor_en_proceso(monkeypatch, mcp):
     # ASGITransport no lo ejecuta: hay que entrarlo a mano o toda petición falla.
     async with app.router.lifespan_context(app):
         monkeypatch.setattr(
-            catalog,
+            mcp_session,
             "_http_client",
-            lambda: httpx.AsyncClient(
+            lambda _timeout: httpx.AsyncClient(
                 transport=httpx.ASGITransport(app=app), base_url=_BASE
             ),
         )

--- a/tests/api/test_execute.py
+++ b/tests/api/test_execute.py
@@ -1,0 +1,160 @@
+"""Tests de la ejecución de una herramienta — `POST /tools/{name}/execute`.
+
+Mismo montaje que el catálogo: se sustituye `mcp_session._http_client` por uno
+sobre `ASGITransport`, así que el protocolo se habla entero en el mismo proceso
+y sin abrir puertos. Se usan sólo tools locales y deterministas: nada de red.
+"""
+
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+
+from backend.api import execute, mcp_session
+from backend.api.schemas import ExecuteStatus
+from backend.config.settings import settings
+
+_BASE = "http://127.0.0.1:8765"
+_URL = f"{_BASE}/mcp"
+
+
+@asynccontextmanager
+async def servidor_en_proceso(monkeypatch, mcp):
+    app = mcp.streamable_http_app()
+
+    # El gestor de sesiones de FastMCP arranca en el lifespan de la app, y
+    # ASGITransport no lo ejecuta: hay que entrarlo a mano.
+    async with app.router.lifespan_context(app):
+        monkeypatch.setattr(
+            mcp_session,
+            "_http_client",
+            lambda _timeout: httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url=_BASE
+            ),
+        )
+        monkeypatch.setattr(settings, "mcp_servers", [_URL])
+        yield
+
+
+async def _ejecutar(monkeypatch, mcp, nombre, argumentos):
+    """Ejecuta dentro del servidor en proceso y relanza los fallos FUERA.
+
+    Si una excepción escapara atravesando `lifespan_context`, anyio la
+    envolvería en un `ExceptionGroup` —el *lifespan* abre un task group— y
+    `pytest.raises(InvalidArguments)` no la reconocería. Es artefacto del
+    andamiaje, no del código: en producción la ruta no corre dentro del ciclo de
+    vida del servidor MCP.
+    """
+    resultado = fallo = None
+    async with servidor_en_proceso(monkeypatch, mcp):
+        try:
+            resultado = await execute.execute_tool(nombre, argumentos)
+        except Exception as exc:  # se relanza intacta más abajo
+            fallo = exc
+
+    if fallo is not None:
+        raise fallo
+    return resultado
+
+
+# ----- Camino correcto -----
+
+
+@pytest.mark.asyncio
+async def test_ejecuta_y_devuelve_datos_estructurados(monkeypatch, servidor_mcp):
+    resultado = await _ejecutar(
+        monkeypatch,
+        servidor_mcp,
+        "detect_clickbait_lexical",
+        {"headline": "10 Things You Won't Believe"},
+    )
+
+    assert resultado.status == ExecuteStatus.OK
+    assert resultado.tool == "detect_clickbait_lexical"
+    assert resultado.server == "tfg-mcp-server"
+    # Estructurado, no una cadena que haya que parsear.
+    assert resultado.data["is_clickbait"] is True
+    assert resultado.detail is None
+
+
+@pytest.mark.asyncio
+async def test_una_salida_de_texto_llega_envuelta_en_result(monkeypatch, servidor_mcp):
+    # `describe_models` devuelve una lista, y el protocolo sólo deja sin
+    # envolver los objetos: por eso llega bajo `result`. No es una carencia.
+    resultado = await _ejecutar(monkeypatch, servidor_mcp, "describe_models", {})
+
+    assert resultado.status == ExecuteStatus.OK
+    assert len(resultado.data["result"]) == 5
+
+
+# ----- La herramienta se ejecuta y falla: 200 con status error -----
+
+
+@pytest.mark.asyncio
+async def test_un_fallo_de_la_tool_no_es_un_error_http(monkeypatch, servidor_mcp):
+    """La petición era correcta y el servidor la atendió; lo que falló es el
+    análisis. Mismo criterio que en `/analyze`, donde una señal caída no tumba
+    la respuesta.
+
+    Esto sólo se puede distinguir desde que las tools **lanzan** en vez de
+    devolver el error: antes llegaba por el mismo canal que un resultado válido.
+    """
+    resultado = await _ejecutar(
+        monkeypatch, servidor_mcp, "detect_clickbait_lexical", {"headline": "   "}
+    )
+
+    assert resultado.status == ExecuteStatus.ERROR
+    assert resultado.data is None
+    # El motivo real, no una queja genérica.
+    assert "vacío" in resultado.detail
+
+
+# ----- Errores de la petición -----
+
+
+@pytest.mark.asyncio
+async def test_una_herramienta_inexistente_es_404(monkeypatch, servidor_mcp):
+    with pytest.raises(execute.ToolNotFound):
+        await _ejecutar(monkeypatch, servidor_mcp, "no_existe", {})
+
+
+@pytest.mark.asyncio
+async def test_un_argumento_que_falta_es_422(monkeypatch, servidor_mcp):
+    with pytest.raises(execute.InvalidArguments, match="headline"):
+        await _ejecutar(monkeypatch, servidor_mcp, "detect_clickbait_lexical", {})
+
+
+@pytest.mark.asyncio
+async def test_un_argumento_del_tipo_equivocado_es_422(monkeypatch, servidor_mcp):
+    with pytest.raises(execute.InvalidArguments):
+        await _ejecutar(
+            monkeypatch, servidor_mcp, "detect_clickbait_lexical", {"headline": 42}
+        )
+
+
+@pytest.mark.asyncio
+async def test_se_acumulan_todos_los_problemas_de_validacion(monkeypatch, servidor_mcp):
+    """Quien rellena un formulario prefiere corregirlo de una vez a descubrir
+    los errores de uno en uno."""
+    with pytest.raises(execute.InvalidArguments) as error:
+        await _ejecutar(
+            monkeypatch,
+            servidor_mcp,
+            "get_nyt_news",
+            {"topic": 1, "days": 999},  # tipo malo y fuera de rango
+        )
+
+    assert "topic" in str(error.value)
+    assert "days" in str(error.value)
+
+
+@pytest.mark.asyncio
+async def test_la_validacion_ocurre_antes_de_invocar(monkeypatch, servidor_mcp):
+    """R4.5. Importa que sea *antes*: si validara MCP, un argumento mal escrito
+    llegaría como fallo de ejecución y sería indistinguible de un análisis que
+    salió mal — 200 con status error en vez del 422 que corresponde.
+    """
+    with pytest.raises(execute.InvalidArguments):
+        await _ejecutar(
+            monkeypatch, servidor_mcp, "detect_clickbait_lexical", {"headline": None}
+        )

--- a/tests/core/test_observability.py
+++ b/tests/core/test_observability.py
@@ -40,9 +40,12 @@ async def test_log_tool_invocation_logs_failure(monkeypatch, capsys):
     async def failing_tool(state: str) -> str:
         raise RuntimeError("boom")
 
-    result = await failing_tool(state="CA")
-
-    assert result == "Internal error while executing tool"
+    # El decorador RELANZA: observar no es decidir qué se responde. Antes
+    # devolvía "Internal error while executing tool", y esa cadena impedía que
+    # la excepción llegara a MCP — el protocolo la tomaba por un resultado
+    # válido (`isError` a False) y el fallo era indistinguible de un éxito.
+    with pytest.raises(RuntimeError, match="boom"):
+        await failing_tool(state="CA")
 
     captured = capsys.readouterr()
 

--- a/tests/integrations/test_tool_contract.py
+++ b/tests/integrations/test_tool_contract.py
@@ -1,0 +1,131 @@
+"""Tests del contrato de retorno de las tools MCP.
+
+Este fichero cubre un hueco que se destapó al cambiar el contrato: los tests
+existentes prueban la **capa cliente** (`lexical.detect`, `HFClient`…), que
+devuelve `ToolResult`, pero nadie comprobaba cómo traduce eso la tool al
+protocolo. Por eso el cambio de «devolver el error» a «lanzarlo» pasó sin que
+fallara un solo test.
+
+Se habla el protocolo real contra la app en el mismo proceso, con
+`ASGITransport`. Se usan sólo tools locales y deterministas: nada de red.
+"""
+
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+_BASE = "http://127.0.0.1:8765"
+
+# Las que devuelven prosa formateada para leer, no datos: su esquema envuelto
+# en `result` es correcto, no una carencia.
+TOOLS_DE_TEXTO = {"get_alerts", "get_forecast"}
+
+
+@asynccontextmanager
+async def sesion(mcp):
+    """Abre una sesión MCP contra la app, sin abrir puertos."""
+    app = mcp.streamable_http_app()
+    async with (
+        app.router.lifespan_context(app),
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as http_client,
+        streamable_http_client(f"{_BASE}/mcp", http_client=http_client) as (r, w, _),
+        ClientSession(r, w) as s,
+    ):
+        await s.initialize()
+        yield s
+
+
+@pytest.mark.asyncio
+async def test_todas_las_tools_publican_su_esquema_de_salida(servidor_mcp):
+    """Sin tipo declarado, MCP no publica `outputSchema` y el consumidor queda a
+    ciegas: se comprobó que `-> dict` a secas lo deja en None."""
+    async with sesion(servidor_mcp) as s:
+        sin_esquema = [
+            t.name for t in (await s.list_tools()).tools if not t.outputSchema
+        ]
+
+    assert sin_esquema == []
+
+
+@pytest.mark.asyncio
+async def test_las_tools_de_datos_describen_sus_campos(servidor_mcp):
+    """Las que devuelven datos declaran sus campos; las de texto los envuelven.
+
+    Un esquema con una sola propiedad `result` significa que la salida no es un
+    objeto —una lista o una cadena— y MCP la envuelve. Correcto para las de
+    texto; sospechoso para una señal de análisis, que sí tiene estructura.
+    """
+    async with sesion(servidor_mcp) as s:
+        tools = {t.name: t for t in (await s.list_tools()).tools}
+
+    lexical = tools["detect_clickbait_lexical"]
+    assert set(lexical.outputSchema["properties"]) == {
+        "score",
+        "is_clickbait",
+        "matches",
+        "headline",
+    }
+
+    # Las de texto sí van envueltas, y es lo esperado.
+    for nombre in TOOLS_DE_TEXTO:
+        assert list(tools[nombre].outputSchema["properties"]) == ["result"]
+
+
+@pytest.mark.asyncio
+async def test_una_lista_declara_el_tipo_de_sus_elementos(servidor_mcp):
+    # Envuelta en `result` por no ser objeto, pero con el esquema del elemento
+    # dentro: el consumidor sabe qué campos trae cada artículo.
+    async with sesion(servidor_mcp) as s:
+        tools = {t.name: t for t in (await s.list_tools()).tools}
+
+    esquema = tools["get_nyt_news"].outputSchema
+    assert esquema["properties"]["result"]["type"] == "array"
+    articulo = esquema["$defs"]["Articulo"]
+    assert "print_headline" in articulo["properties"]
+
+
+# ----- El eje éxito/fallo lo lleva el protocolo -----
+
+
+@pytest.mark.asyncio
+async def test_una_ejecucion_correcta_devuelve_datos_estructurados(servidor_mcp):
+    async with sesion(servidor_mcp) as s:
+        resultado = await s.call_tool(
+            "detect_clickbait_lexical", {"headline": "10 Things You Won't Believe"}
+        )
+
+    assert resultado.isError is False
+    # Estructurado, no una cadena que haya que parsear.
+    assert resultado.structuredContent["is_clickbait"] is True
+    assert resultado.structuredContent["matches"]
+
+
+@pytest.mark.asyncio
+async def test_un_fallo_de_la_tool_marca_isError(servidor_mcp):
+    """El caso que motivó el cambio.
+
+    Antes, un titular vacío devolvía el mensaje de error por el mismo canal que
+    un resultado válido, con `isError` a False: desde fuera era indistinguible
+    de un éxito. Ahora la tool lanza y el protocolo lo marca.
+    """
+    async with sesion(servidor_mcp) as s:
+        resultado = await s.call_tool("detect_clickbait_lexical", {"headline": "   "})
+
+    assert resultado.isError is True
+    assert resultado.structuredContent is None
+    # El motivo sigue siendo legible para quien lo reciba.
+    assert "vacío" in resultado.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_un_parametro_invalido_tambien_marca_isError(servidor_mcp):
+    # Este ya funcionaba: lo valida la capa MCP antes de llegar a la tool.
+    async with sesion(servidor_mcp) as s:
+        resultado = await s.call_tool("detect_clickbait_lexical", {"mal": "parametro"})
+
+    assert resultado.isError is True


### PR DESCRIPTION
## #100 · `POST /tools/{name}/execute` y el contrato de retorno

Closes #100

El objetivo era el endpoint: `/tools` ya publicaba el `inputSchema` de cada
herramienta, así que faltaba lo que ejecutara el formulario construido con él.
Al medirlo antes de escribir código apareció que **no podía existir tal cual**, y
de ahí salió la mitad de esta PR.

### El bloqueo: éxito y fallo eran indistinguibles

| Escenario | `isError` | `content[0].text` |
|---|---|---|
| Titular válido | `False` | `{"score": 3, "is_clickbait": true, …}` |
| Titular vacío (**la tool falla**) | **`False`** | `El titular está vacío o no es válido` |
| Parámetro inexistente | `True` | `Error executing tool …: validation error` |

`isError` sólo se activaba cuando el fallo ocurría en la capa MCP. Si la
herramienta *devolvía* un mensaje de error —lo que hacían las once— para el
protocolo era un éxito. Y «parsear como JSON» no valía de heurística:
`get_forecast` devuelve prosa siendo una ejecución correcta.

**Se descartó `-> ToolResult`**, la opción aparentemente obvia por existir ya. Su
esquema describe **el sobre, no la carta** —`data` queda como
`anyOf: [{}, null]`— y duplica el eje que MCP ya tiene: como `ToolResult.fail` se
devuelve y no se lanza, daría respuestas con `isError: false` y `success: false`
**a la vez**. `ToolResult` sigue intacto donde estaba, en los `client.py` y
`base_api.py`; no aparecía ni aparece en ningún `tool.py`.

### Un fallo que llevaba desde la Épica 1 escondido

Al hacer que las tools lanzaran, el mensaje **seguía perdiéndose**. La causa
estaba en `log_tool_invocation`:

```python
except Exception:
    log.error(..., exception=traceback.format_exc())
    return "Internal error while executing tool"
```

**El decorador de observabilidad capturaba toda excepción y devolvía una
cadena.** Consecuencia anterior a este issue: un `KeyError` o un fallo de red no
capturado dentro de una tool llegaba al cliente como texto normal con `isError` a
False — indistinguible de un análisis correcto.

Y explica por qué el contrato *parecía* coherente: no era que unas tools
devolvieran errores por decisión y otras no, es que el decorador **aplanaba todo
a texto**, lo devuelto a propósito y lo lanzado por accidente. El arreglo es un
`raise` en vez de un `return`, con el principio escrito en el código: *el
decorador es para observar, no para decidir qué se responde*.

### Salida estructurada: qué cuesta

| Retorno declarado | `outputSchema` | `structuredContent` |
|---|---|---|
| `-> str` con `json.dumps` *(lo anterior)* | `{"result": string}` | el JSON **como texto** |
| `-> dict` a secas | **`None`** | **`None`** |
| `TypedDict` propio | **describe los campos reales** | el objeto, directo |

Anotar `-> dict` no sirve: MCP necesita un tipo **declarado**. Se usan
`TypedDict` y no modelos Pydantic porque las capas de cliente ya devuelven
diccionarios — así no hay conversión, sólo se declara la forma que ya tienen. El
esquema publicado incluye además el docstring del tipo como `description`.

Nueve herramientas declaran el suyo. **`get_alerts` y `get_forecast` se quedan en
`-> str`**: producen prosa para leer, y forzarles estructura sería inventar
campos que la salida no tiene.

### El endpoint

Valida los argumentos contra el `inputSchema` **antes** de invocar (R4.5), con
`iter_errors` en vez de `validate` para acumular todos los problemas — quien
rellena un formulario prefiere corregirlo de una vez. Que la validación sea
*previa* es lo que permite distinguir un campo mal escrito de un análisis que
salió mal.

| Situación | Respuesta |
|---|---|
| La herramienta no existe | **404** |
| Los argumentos no encajan | **422**, con el campo y el motivo |
| La herramienta se ejecuta y falla | **200** con `status: error` |

La última no es un error HTTP: la petición era correcta y el servidor la atendió.
Mismo criterio que `/analyze`.

Y un timeout propio (`mcp_execute_timeout`, 60 s): `mcp_timeout` son 5 s, de
sobra para un `list_tools` de 0,036 s, pero `detect_clickbait_incoherence` tarda
~20 s en frío cargando embeddings. Con el margen del descubrimiento moriría
siempre.

### Un fallo que habría llegado a producción

Las excepciones lanzadas **dentro de una sesión MCP salen envueltas en
`ExceptionGroup`**: la sesión abre un *task group* de anyio. El
`except InvalidArguments` de la ruta no la habría reconocido y un argumento mal
escrito habría dado **500 en vez de 422**. La lógica ahora **devuelve** lo
ocurrido y decide fuera de la sesión.

Es la segunda vez que anyio aparece en el proyecto — la primera fueron los
*cancel scopes* en los tests del catálogo.

### Un hueco de cobertura

Rehacer el contrato de las once herramientas **no rompió un solo test**. No por
estar bien cubierto: porque **nadie probaba las tools MCP**. Todos los tests
atacan la capa cliente, que devuelve `ToolResult` y no ha cambiado.
`test_tool_contract.py` cubre ahora esa frontera.

### Un dato para cuando llegue el agente (R13)

Se intentó revalidar la selección de herramientas con los scripts del spike #82,
porque los docstrings son la interfaz que lee el LLM. Dos cosas aparecieron, y
ninguna bloquea esta PR:

**El spike #82 no medía lo que decía medir.** Afirma usar «las descripciones
REALES (docstrings de tool.py)» pero las lleva **copiadas a mano**, resumidas a
unos 150 caracteres. Nunca probó los textos que recibe el agente.

**Y las descripciones reales no caben en el contexto que asumía aquel spike:**

| | Herramientas | Tamaño |
|---|---|---|
| Spike #82 (resúmenes) | 8 | 3.203 chars · ~800 tokens |
| Descripciones reales | 11 | 9.448 chars · **~2.362 tokens** |
| `num_ctx` del spike | | **2.048 tokens** |

Las definiciones **por sí solas** desbordan la ventana, antes de añadir la
consulta. Con esa configuración el modelo llegó a inventarse una herramienta
(`detect_clicks_incoherence`) y a pedir alertas meteorológicas para analizar un
titular — síntomas de una lista truncada, no de unos docstrings peores.

La revalidación del agente **se aplaza al hito de R13**, cuando haya infra
adecuada: el agente no forma parte de H2 y el hardware local es una restricción
del entorno de desarrollo, no del diseño.

### Notas

Seis commits, ordenados para poder leerse por partes: el arreglo del decorador va
**solo y primero**, porque es un bug preexistente e independiente y no debería
quedar enterrado entre el resto.

`jsonschema` pasa a dependencia directa: ya entraba como transitiva de MCP, pero
ahora el código la importa.

135 tests en verde.
