### PR TITLE
feat(api): historial persistente y GET /history con paginación (#102)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ __pycache__/
 .vscode/settings.json
 
 CLAUDE.md
+
+# Estado mutable en ejecución (base de datos del historial). A diferencia de
+# data/, que guarda datasets y splits versionados, esto NO debe commitearse.
+var/
+repomix-output.xml

--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,95 @@ La lógica ahora **devuelve** lo que ha ocurrido y decide fuera de la sesión qu
 
 Rehacer el contrato de las once herramientas **no rompió un solo test**. No porque estuviera bien cubierto, sino porque **nadie probaba las tools MCP**: todos los tests atacan la capa cliente (`lexical.detect`, `HFClient`), que devuelve `ToolResult` y no ha cambiado. `tests/integrations/test_tool_contract.py` cubre ahora esa frontera — que todas publiquen esquema, que un fallo marque `isError`, y que las de texto se envuelvan como corresponde.
 
+### Historial persistente: la API deja de ser sin estado (#102)
+
+Hasta aquí cada petición se atendía con lo que traía dentro y no dejaba rastro: reiniciar el proceso no perdía nada porque no había nada que perder. R9 rompe eso — el usuario tiene que poder volver a ver un análisis de ayer— y con ello aparece la primera escritura a disco del backend.
+
+#### Se guardan análisis, no invocaciones
+
+Al pie de la letra, «registrar cada ejecución de herramienta» significaría que un solo `POST /analyze` dejara **cinco filas**, una por señal. La pantalla resultante sería una lista de `detect_clickbait_lexical` repetido, sin el titular por ningún sitio: nadie reconoce ahí lo que hizo.
+
+Esa granularidad sí hace falta, pero **ya existe**: `log_tool_invocation` registra cada invocación con parámetros y duración. Son dos registros con dos públicos —depuración y persona— y mezclarlos estropea los dos. Aquí se guarda lo que el usuario reconoce: un análisis, con su titular y su veredicto.
+
+Se guarda la respuesta **completa**, no sólo el veredicto. Reejecutar al abrir la entrada no valdría por dos motivos: cuesta ~20 s en frío por la carga perezosa de MiniLM, y las señales remotas **no son deterministas**, así que el «resultado anterior» podría salir distinto. Un historial que cambia lo que dice no es un historial.
+
+#### SQLite detrás de tres funciones
+
+Lo que protege de un cambio de requisitos no es elegir el almacén más flexible, sino **aislarlo**: sólo `backend/api/history.py` sabe que hay SQL, y cambiar de motor es reescribir ese fichero sin tocar endpoints ni sus tests. Mismo patrón que `get_nlp_backend`, que permitió pasar de HuggingFace a local sin tocar ninguna señal.
+
+Se descartó **JSONL** —una línea por análisis, aún más simple— porque los requisitos piden paginación, filtros y orden inverso, y con un fichero plano *cada* consulta tendría que leerlo entero, parsearlo y ordenarlo en memoria para quedarse con veinte. Las consultas son justo lo que un fichero plano no sabe hacer.
+
+El aislamiento incluye **el formato**, no sólo el motor: el `json.dumps` y el `json.loads` viven los dos dentro del módulo. Que el segundo estuviera fuera —en `app.py`— hacía el aislamiento falso en una línea: con Postgres y una columna `jsonb` el driver ya devuelve el objeto construido, y ese `json.loads` externo habría reventado con un `TypeError` en un fichero que, por diseño, no debía tocarse.
+
+La base va a **`var/` y no a `data/`**: `data/` está versionado —datasets y splits congelados, que no deben cambiar nunca— y esto es estado que cambia en cada petición. Juntarlos acaba en un `git add data/` que commitea la base de datos. `var/` es además el directorio que se montará como volumen en H4.
+
+`origin` (`form` / `chat` / `api`) se declara desde el primer día aunque el chat no exista todavía: el prototipo ya distingue esos orígenes y añadir la columna después obligaría a migrar. Lo mismo con `tool`, `verdict` y `status`, que sólo se consultarán al llegar el filtrado (#103).
+
+#### Un fallo al guardar no hunde la respuesta
+
+`record` captura y devuelve `None`. Capturar `Exception` a secas suele ser mala señal, y aquí la distinción está en **qué papel juega lo que falla**: el análisis ya se hizo y es correcto, guardarlo es un efecto colateral. Con el disco lleno, devolver un 500 y tirar un análisis bueno de 20 s es peor que servirlo sin guardarlo. El motivo queda en el log.
+
+Es lo contrario del fallo de `log_tool_invocation` corregido en #100, donde lo tragado **era la respuesta**. La regla que separa los dos casos: puedes tragarte un fallo si lo que falla no es lo que te preguntaron.
+
+#### Tres «mejoras evidentes», medidas
+
+Una revisión externa señaló cinco puntos de rendimiento. Medirlos antes de aplicarlos descartó tres y destapó uno que no estaba en la lista.
+
+| Operación | Coste |
+|---|---|
+| `Path.mkdir(parents=True, exist_ok=True)` sobre directorio existente | 7,2 µs |
+| `CREATE TABLE IF NOT EXISTS` sobre tabla existente | 9,9 µs |
+| `_conectar()` + `INSERT` + `commit` | **193 792 µs** |
+
+Ejecutar el esquema y el `mkdir` en cada conexión cuesta el **0,005 %** y el **0,004 %** de lo que envuelven. Se quedan: hacen que el sistema funcione recién clonado el repo sin ningún paso de instalación, y evitar esa comprobación exigiría cachearla en una variable de módulo — que rompe los tests, porque el segundo test que apunta a otro `tmp_path` encontraría el indicador ya puesto y fallaría con `no such table`.
+
+El **timeout** que se proponía añadir ya existía: `sqlite3.connect` lo trae en 5 s por defecto, y medirlo lo confirma (esperó 5,01 s antes de `database is locked`). No fallaba «casi inmediatamente».
+
+#### WAL: la recomendación de manual, descartada por medición
+
+Activar `journal_mode=WAL` es el consejo estándar para SQLite bajo una aplicación web, y aquí **sale más lento**:
+
+| `journal_mode` | `synchronous` | ms/escritura |
+|---|---|---|
+| DELETE *(por defecto)* | FULL | 164 |
+| WAL | FULL | 226 |
+| WAL | NORMAL | 251 |
+| WAL | OFF | 0,47 |
+
+El motivo: al cerrar la **última** conexión a una base en modo WAL, SQLite ejecuta un checkpoint completo. Con «una conexión por operación» eso ocurre en cada escritura. WAL rinde cuando las conexiones se mantienen abiertas — exactamente lo que este diseño no hace. Son dos decisiones acopladas, y quedarse con media de cada una es peor que con cualquiera entera.
+
+Los 0,47 ms de `synchronous=OFF` prueban que esos ~164 ms son **todo `fsync`**. No se toca: un historial que se pierde al cortarse la luz no es un historial, y es el único de los cambios evaluados que sacrifica una garantía real por velocidad. Con la advertencia de que la medida se tomó sobre el disco virtual de WSL2, donde el `fsync` atraviesa hasta el anfitrión Windows; en Linux nativo son décimas de milisegundo. Queda apuntado para volver a medirlo al contenerizar y decidir entonces si la escritura debe salir de la ruta de respuesta.
+
+#### La conexión que no se cerraba
+
+El punto que sí era real, aunque por un motivo distinto del que se le atribuía. En `sqlite3`, el `with` de una conexión gestiona la **transacción** —commit al salir bien, rollback si salta algo— y **no la cierra**. Se afirmaba que eso provocaría un agotamiento de descriptores y la caída del proceso; medido, no es así, pero tampoco es inocuo:
+
+| Escrituras | Descriptores tras la ráfaga | Tras `gc.collect()` |
+|---|---|---|
+| 500 | +75 | +0 |
+| 2 000 | +96 | +0 |
+| 8 000 | +99 | +0 |
+| 20 000 | +163 | +0 |
+| 20 000 **con `close()`** | **+0** | — |
+
+No es una fuga lineal —20 000 escrituras no dejan 20 000 descriptores— pero el atasco crece y `gc.collect()` lo devuelve siempre a cero: **son conexiones esperando al recolector de ciclos**, no al contador de referencias. El código era correcto por accidente, apoyado en un detalle de implementación de CPython que PyPy no comparte. `_conectar` pasa a ser un gestor de contexto propio que cierra en un `finally`, y el orden importa: el `with` interno sale antes, así que confirma y **luego** cierra — al revés se perdería la escritura, porque cerrar con una transacción pendiente la deshace.
+
+#### La ruta relativa y la segunda base de datos
+
+`history_db` es `var/history.db`, una ruta **relativa**, y una ruta relativa se resuelve contra el directorio desde el que se arrancó el proceso. Lanzar `uvicorn` desde `backend/` en lugar de desde la raíz crearía una segunda base de datos vacía — y como se crea sin quejarse, el síntoma no sería un error sino «se ha borrado el historial». Se ancla a la raíz del repo vía `__file__`, respetando las rutas absolutas, que son las que se configurarán en el contenedor.
+
+#### Validar en la firma, no recortar a mano
+
+`limit` y `offset` se declaran con `Query(ge=1, le=100)` en vez de acotarse dentro de la función. Así los topes salen publicados en el esquema OpenAPI —del que se genera el cliente Angular— y pedir de más devuelve un **422** diciendo cuál es el máximo, en lugar de servir otra cosa en silencio.
+
+El mínimo de 1 no es cosmético: **en SQLite un `LIMIT` negativo significa «sin límite»**. Sin ese borde, `?limit=-1` no daría error: traería la tabla entera a memoria y la serializaría a JSON. El caso peligroso no era `?limit=999999`, era el negativo.
+
+#### Los tests escribían en el historial de verdad
+
+Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa ruta en escritores del historial real: una corrida de la suite dejaba cuatro entradas «Un titular» en `var/history.db`. El aislamiento va en un fixture `autouse` de `tests/conftest.py` y no en el fichero que prueba el historial, porque **quien contamina no es quien lo prueba**: lo hace cualquier test que llame a un endpoint que registre, incluidos los que aún no existen.
+
+`tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
+
 ### Metadata de las tools: categoría y procedencia (#97, primera parte)
 
 El catálogo necesita saber, de cada herramienta, **qué tipo de trabajo hace** y **de dónde viene**. El objeto `Tool` del protocolo MCP trae nombre, descripción y esquema, pero ninguna de esas dos cosas. MCP sí permite adjuntar un `meta` libre por herramienta, y se comprobó que **viaja intacto hasta el cliente**, así que la información se declara en el origen en vez de en un mapa cableado en la API — que obligaría a editarla cada vez que se añade una fuente, justo lo que R1.9 prohíbe.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Version de Python: 3.12.3
 | Hito | Fecha | Contenido | Requisitos |
 |---|---|---|---|
 | **H1 · Diseño de interfaz** | ago–sep 2026 | Wireframes de pantallas y navegación, definición de funcionalidades, diseño de los endpoints REST | — |
-| **H2 · `v0.3` API REST** | octubre | FastAPI: exposición de las tools, catálogo con metadatos, historial de ejecución, OpenAPI, CORS, tests | **R4, R5** |
+| **H2 · `v0.3` API REST** | octubre | FastAPI: exposición de las tools, catálogo con metadatos, historial **persistente**, OpenAPI, CORS, tests | **R4, R5, R9** |
 | **H3 · `v0.4` SPA funcional** | noviembre | Angular: análisis de un titular → resultados con explicabilidad visual (cues resaltados, contraste de señales), catálogo de tools | **R6** |
-| **H4 · `v0.5` Docker + persistencia** | diciembre | Docker Compose (MCP + API / web), historial persistente, despliegue continuo | **R7, R8** |
+| **H4 · `v0.5` Docker** | diciembre | Docker Compose (MCP + API / web), **volumen** para el historial, despliegue continuo | **R7, R8** |
 | **H5 · `v1.0` Pulido y despliegue** | enero 2027 | Responsive, gestión de errores, pruebas E2E, despliegue | R6 |
 | **H6 · Memoria y defensa** | ene–feb 2027 | Redacción de la memoria y preparación de la defensa | — |
+
+_(Corrección de la tabla, 2026-08-11: **R9 —la persistencia— no figuraba en ninguna fila**. H2 pedía «historial de ejecución» y H4 «historial persistente», pero el requisito que los sostiene no estaba listado en ninguno de los dos. Se asigna a H2: hacer el historial en memoria ahora y persistirlo en diciembre sería construirlo dos veces y entregar una pantalla que pierde los datos al reiniciar. A H4 le queda lo que de verdad le corresponde — montar el volumen (R7.6) para que ese fichero sobreviva al contenedor.)_
 
 **Criterios de priorización:**
 

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -21,11 +21,13 @@ conectadas en runtime no se puede hacer importando módulos.
 """
 
 from contextlib import asynccontextmanager
+from typing import Annotated
 
 import structlog
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 
+from backend.api import history
 from backend.api.analyze import analyze
 from backend.api.catalog import fetch_catalog
 from backend.api.execute import InvalidArguments, ToolNotFound, execute_tool
@@ -35,6 +37,10 @@ from backend.api.schemas import (
     CatalogResponse,
     ExecuteRequest,
     ExecuteResponse,
+    HistoryEntry,
+    HistoryKind,
+    HistoryPage,
+    Origin,
 )
 from backend.config.settings import settings
 from backend.core.health import check_health
@@ -101,8 +107,22 @@ async def post_analyze(request: AnalyzeRequest) -> AnalyzeResponse:
     sería un error. Si el cuerpo de la noticia no se
     envía, la señal de incoherencia queda en `no_aplicable` y la dimensión de
     engaño no se puede evaluar.
+
+    Cada análisis queda registrado en el historial. Si esa escritura
+    falla, la respuesta se devuelve igual: perder un análisis correcto porque el
+    disco esté lleno sería peor que no guardarlo.
     """
-    return await analyze(request)
+    respuesta = await analyze(request)
+
+    await history.record(
+        kind=HistoryKind.ANALYSIS,
+        origin=Origin.API,
+        status="ok" if respuesta.has_any_result else "error",
+        payload=respuesta.model_dump(mode="json"),
+        headline=respuesta.headline,
+        verdict=respuesta.verdict.value,
+    )
+    return respuesta
 
 
 @app.get("/tools", response_model=CatalogResponse, tags=["catálogo"])
@@ -138,13 +158,64 @@ async def post_execute(name: str, request: ExecuteRequest) -> ExecuteResponse:
     falló: eso último no es un error HTTP, porque la petición era correcta.
     """
     try:
-        return await execute_tool(name, request.arguments)
+        respuesta = await execute_tool(name, request.arguments)
     except ToolNotFound:
         raise HTTPException(
             status_code=404, detail=f"No hay ninguna herramienta llamada '{name}'."
         ) from None
     except InvalidArguments as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from None
+
+    # Sólo se registra lo que llegó a ejecutarse. Una petición rechazada por 404
+    # o 422 no es una ejecución: ensuciaría el historial con intentos fallidos
+    # del formulario en vez de con análisis hechos.
+    #
+    # Las señales de análisis reciben el titular como argumento, así que se saca
+    # de ahí: la entrada se ve en la lista con su titular en vez de con un hueco.
+    # Las herramientas que no lo llevan (health_check, get_nyt_news) quedan a None.
+    titular = request.arguments.get("headline")
+    await history.record(
+        kind=HistoryKind.TOOL,
+        origin=Origin.API,
+        status=respuesta.status.value,
+        payload=respuesta.model_dump(mode="json"),
+        tool=name,
+        headline=titular if isinstance(titular, str) else None,
+    )
+    return respuesta
+
+
+@app.get("/history", response_model=HistoryPage, tags=["historial"])
+async def get_history(
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> HistoryPage:
+    """Análisis y ejecuciones anteriores, del más reciente al más antiguo.
+
+    Una entrada por **análisis**, no por herramienta invocada: un `/analyze`
+    ejecuta cinco señales y produce una sola línea, con su titular y su
+    veredicto. La traza de invocaciones vive en los logs, que es donde sirve.
+
+    Cada entrada trae la respuesta completa en `payload`, así que la interfaz
+    puede volver a mostrar el resultado sin reejecutar — que además de tardar
+    podría dar otro resultado, porque las señales remotas no son deterministas.
+
+    `limit` y `offset` se validan en la firma en vez de recortarse a mano dentro:
+    así los topes salen publicados en el esquema OpenAPI —del que se genera el
+    cliente Angular— y pedir de más devuelve un **422** diciendo cuál es el
+    máximo, en vez de servir otra cosa en silencio.
+
+    El mínimo de 1 no es cosmético: en SQLite un **LIMIT negativo significa «sin
+    límite»**, así que `?limit=-1` no daría error, traería la tabla ENTERA a
+    memoria y la serializaría. Es el borde que hay que tapar, no el `?limit=9999`.
+    """
+    filas, total = await history.query(limit, offset)
+    return HistoryPage(
+        items=[HistoryEntry(**fila) for fila in filas],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @app.get("/health", tags=["operación"])

--- a/backend/api/history.py
+++ b/backend/api/history.py
@@ -194,8 +194,23 @@ def _leer(
         total = conexion.execute("SELECT COUNT(*) FROM history").fetchone()[0]
         # fetchone() devuelve una tupla con un solo elemento, que es el resultado de la consulta COUNT(*). Se accede a ese elemento con [0] para obtener el número total de entradas en la tabla history.
         # Orden por id descendente: más estable que timestamp.
+        #
+        # Las columnas se nombran en vez de usar `SELECT *`, aunque suponga
+        # repetirlas por tercera vez en este fichero (ya están en `_ESQUEMA` y en
+        # `_INSERT`). Eso NO es acoplamiento: el acoplamiento es una propiedad de
+        # las fronteras entre módulos, y éste es justo el módulo cuyo trabajo es
+        # saberse el esquema. `SELECT *` no elimina ese conocimiento, lo DELEGA a
+        # quien consuma el resultado — que está al otro lado de la frontera.
+        #
+        # Consecuencia concreta: como `app.py` hace `HistoryEntry(**fila)`, con
+        # `SELECT *` la forma de la tabla decide la del contrato. Medido: añadir
+        # una columna se ignora en silencio, y RENOMBRAR una deja su campo a None
+        # también en silencio —titulares vacíos en la interfaz, sin un solo error
+        # en ningún log—. Nombrarlas convierte la salida de este módulo en una
+        # declaración deliberada, y mueve el fallo aquí dentro, que es su sitio.
         filas = conexion.execute(
-            "SELECT * FROM history ORDER BY id DESC LIMIT ? OFFSET ?",
+            "SELECT id, created_at, kind, origin, headline, tool, verdict, status, payload "
+            "FROM history ORDER BY id DESC LIMIT ? OFFSET ?",
             (limit, offset),
         ).fetchall()
 

--- a/backend/api/history.py
+++ b/backend/api/history.py
@@ -1,0 +1,229 @@
+"""Almacén del historial de análisis.
+
+**Qué se guarda: análisis, no invocaciones.** R9 habla de registrar cada
+ejecución de herramienta, pero un solo ``POST /analyze`` invoca cinco: guardarlas
+sueltas daría una pantalla llena de ``detect_clickbait_lexical`` en vez del
+titular que el usuario analizó. La traza de invocaciones ya existe —
+``log_tool_invocation`` la registra con parámetros y duración— y sirve para
+depurar, que es su sitio. Aquí se guarda lo que el usuario reconoce.
+
+Se guarda la respuesta **completa** porque el prototipo pide «acceso al
+resultado». Reejecutar en vez de guardar no valdría: costaría ~20 s y las
+señales remotas no son deterministas, así que el «resultado anterior» podría
+salir distinto — lo contrario de un historial.
+
+**SQLite detrás de tres funciones.** Lo que protege de un cambio de requisitos no
+es elegir el almacén más flexible, sino aislarlo: cambiar de motor es reescribir
+este fichero, sin tocar endpoints ni sus tests. Se elige SQLite porque tiene paginación, filtros y orden
+inverso: con JSONL cada consulta leería el fichero entero.
+"""
+
+import asyncio
+import json
+import sqlite3
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+# `HistoryKind` y `Origin` viven en `schemas.py`, no aquí, porque TODOS los enums
+# del contrato están allí y el cliente Angular se genera del esquema OpenAPI: un
+# enum publica el conjunto cerrado de valores, una cadena suelta no.
+from backend.api.schemas import HistoryKind, Origin
+from backend.config.settings import settings
+
+log = structlog.get_logger()
+
+# `__file__` es .../backend/api/history.py, así que dos niveles por encima está la
+# raíz del repo. Se ancla ahí porque `settings.history_db` es RELATIVA, y una ruta
+# relativa se resuelve contra el directorio desde el que se arrancó el proceso:
+# lanzar uvicorn desde `backend/` en vez de desde la raíz crearía una SEGUNDA base
+# de datos vacía. Y como `_conectar` la crea sin quejarse, el síntoma no sería un
+# error sino «se ha borrado el historial».
+_RAIZ = Path(__file__).resolve().parents[2]
+
+_ESQUEMA = """
+CREATE TABLE IF NOT EXISTS history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL,
+    kind       TEXT NOT NULL,
+    origin     TEXT NOT NULL,
+    headline   TEXT,
+    tool       TEXT,
+    verdict    TEXT,
+    status     TEXT NOT NULL,
+    payload    TEXT NOT NULL
+);
+"""
+
+
+def _ruta_db() -> Path:
+    """Ruta absoluta del fichero, ancle donde ancle la configuración.
+
+    Una ruta ABSOLUTA en `settings` se respeta tal cual: es lo que se pondrá en el
+    contenedor (`HISTORY_DB=/var/lib/clickbait/history.db`). Sólo las relativas se
+    anclan a la raíz del repo.
+    """
+    ruta = Path(settings.history_db)
+    return ruta if ruta.is_absolute() else _RAIZ / ruta
+
+
+@contextmanager
+def _conectar() -> Generator[sqlite3.Connection, None, None]:
+    """Abre la base de datos, creándola y creando el esquema si hace falta.
+
+    Una conexión por operación: sin pool ni estado compartido. A este volumen
+    —una escritura por análisis— la simplicidad gana, y evita tener que
+    responder si la conexión aguanta uso concurrente.
+
+    Es un gestor de contexto propio y no un `sqlite3.connect` pelado porque el
+    `with` de una conexión de sqlite3 **NO la cierra**: gestiona la TRANSACCIÓN
+    (commit al salir bien, rollback si salta una excepción). Sin el `close()`
+    explícito, cerrarla queda en manos del recolector de basura — medido: 20 000
+    escrituras dejaban hasta 163 descriptores abiertos, que un `gc.collect()`
+    devolvía a cero. No es una fuga lineal, pero el momento del cierre es
+    impredecible, y en un intérprete sin conteo de referencias (PyPy) sí crecería.
+    Con este `finally` el delta medido es 0 exacto.
+
+    El orden importa: el `with` interno sale ANTES que el `finally`, así que
+    primero confirma y luego cierra. Al revés se perdería la escritura, porque
+    cerrar una conexión con una transacción pendiente la deshace.
+
+    NO se activa `PRAGMA journal_mode=WAL`, aunque sea la recomendación habitual
+    para aplicaciones web. Medido con este patrón de acceso sale MÁS LENTO:
+    164 ms → 226 ms por escritura. Al cerrar la última conexión a una base en modo
+    WAL, SQLite ejecuta un checkpoint completo, y con una conexión por operación
+    eso pasa en cada escritura. WAL rinde cuando las conexiones se mantienen
+    abiertas, que es justo lo que este diseño no hace: son dos decisiones
+    acopladas, y quedarse con media de cada una es peor que con cualquiera entera.
+    """
+    ruta = _ruta_db()
+    ruta.parent.mkdir(
+        parents=True, exist_ok=True
+    )  # No se trae el repo /var de primeras, así que lo crea si no existe.
+
+    conexion = sqlite3.connect(ruta)
+    conexion.row_factory = sqlite3.Row  # Usar Row para poder acceder a las columnas por nombre en lugar de por índice. (fila["columna"] en lugar de fila[0])
+    conexion.execute(_ESQUEMA)
+    try:
+        with conexion:  # transacción: commit al salir bien, rollback si hay excepción
+            yield conexion
+    finally:
+        conexion.close()  # el `with` de arriba NO cierra, sólo transacciona
+
+
+# Las columnas `tool`, `verdict` y `status` existen ya aunque el filtrado sea
+# otro issue (#103): añadir una columna después obliga a migrar, y declararlas
+# ahora no cuesta nada.
+_INSERT = """
+INSERT INTO history (created_at, kind, origin, headline, tool, verdict, status, payload)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+# ? son placeholders que se sustituyen por los valores de la tupla en el segundo argumento de execute. Esto evita inyecciones SQL y problemas de comillas.
+
+
+def _guardar(
+    kind: HistoryKind,
+    origin: Origin,
+    status: str,
+    payload: dict[str, Any],
+    headline: str | None,
+    tool: str | None,
+    verdict: str | None,
+) -> int:
+    with _conectar() as conexion:
+        cursor = conexion.execute(
+            _INSERT,
+            (
+                datetime.now(timezone.utc).isoformat(),
+                kind.value,
+                origin.value,
+                headline,
+                tool,
+                verdict,
+                status,
+                json.dumps(payload, ensure_ascii=False),
+            ),
+        )
+        return cursor.lastrowid  # Devuelve el id de la fila insertada, que es útil para referenciarla después.
+
+
+async def record(
+    kind: HistoryKind,
+    origin: Origin,
+    status: str,
+    payload: dict[str, Any],
+    headline: str | None = None,
+    tool: str | None = None,
+    verdict: str | None = None,
+) -> int | None:
+    """Registra una entrada. Devuelve su id, o None si no se pudo guardar.
+
+    **Un fallo aquí no se propaga**, y conviene distinguirlo de tragarse un
+    error: lo que falla es un *efecto colateral*, no la respuesta. El análisis ya
+    se hizo y es correcto; perderlo porque el disco esté lleno sería peor que no
+    guardarlo. El motivo queda en el log.
+
+    (No es el caso de ``log_tool_invocation``, que devolvía una cadena en lugar
+    del resultado del que se le preguntaba: allí lo tragado ERA la respuesta.)
+    """
+    try:
+        # Guardar en un hilo aparte para no bloquear el bucle de eventos. SQLite es rápido, pero no instantáneo: si se bloquea el bucle de eventos, la API deja de responder y el usuario ve un timeout.
+        return await asyncio.to_thread(
+            _guardar, kind, origin, status, payload, headline, tool, verdict
+        )
+    except Exception as exc:
+        log.error("historial.escritura_fallida", motivo=f"{type(exc).__name__}: {exc}")
+        return None
+
+
+def _leer(
+    limit: int, offset: int
+) -> tuple[
+    list[dict[str, Any]], int
+]:  # Devuelve una página del historial y el total de entradas. El total lo necesita la interfaz para paginar («1-20 de 137»); sin él sólo puede saber si hay más página probando a pedirla.
+
+    # Tuple: Devuelve una tupla con dos elementos: una lista de diccionarios que representan las entradas del historial y un entero que indica el total de entradas en la base de datos.
+    # Dict[str, Any]: Cada diccionario tiene claves de tipo str y valores de cualquier tipo (Any), lo que permite almacenar información diversa sobre cada entrada del historial.
+
+    with _conectar() as conexion:
+        total = conexion.execute("SELECT COUNT(*) FROM history").fetchone()[0]
+        # fetchone() devuelve una tupla con un solo elemento, que es el resultado de la consulta COUNT(*). Se accede a ese elemento con [0] para obtener el número total de entradas en la tabla history.
+        # Orden por id descendente: más estable que timestamp.
+        filas = conexion.execute(
+            "SELECT * FROM history ORDER BY id DESC LIMIT ? OFFSET ?",
+            (limit, offset),
+        ).fetchall()
+
+        # LIMIT ? OFFSET ? es la paginación: "sáltate offset filas y dame las limit siguientes". Página 1: LIMIT 20 OFFSET 0; página 2 : LIMIT 20 OFFSET 20.
+
+    return [_desempaquetar(fila) for fila in filas], total
+
+
+def _desempaquetar(fila: sqlite3.Row) -> dict[str, Any]:
+    """Convierte una fila en un diccionario corriente, con el payload ya parseado.
+
+    Las dos conversiones existen por lo mismo: que nada de SQLite salga de este
+    módulo. Devolver un `sqlite3.Row` obligaría a quien llame a manejar un tipo de
+    la biblioteca de SQLite; devolver el payload como cadena le obligaría a saber
+    que aquí dentro se guarda serializado —y con Postgres y una columna `jsonb` el
+    driver ya devolvería el objeto construido, así que ese `json.loads` de fuera
+    reventaría con un TypeError. El aislamiento incluye el formato, no sólo el
+    motor: entra un diccionario, sale un diccionario.
+    """
+    entrada = dict(fila)
+    entrada["payload"] = json.loads(entrada["payload"])
+    return entrada
+
+
+async def query(limit: int, offset: int) -> tuple[list[dict[str, Any]], int]:
+    """Devuelve una página del historial y el total de entradas.
+
+    El total lo necesita la interfaz para paginar («1-20 de 137»); sin él sólo
+    puede saber si hay más página probando a pedirla.
+    """
+    return await asyncio.to_thread(_leer, limit, offset)

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -32,6 +32,7 @@ Tres principios lo gobiernan:
    simplemente no emite veredicto, igual que una señal que ha fallado.
 """
 
+from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any
 
@@ -327,3 +328,89 @@ class ExecuteResponse(BaseModel):
     detail: str | None = Field(
         default=None, description="Motivo legible cuando `status` es `error`."
     )
+
+
+# --------------------------------------------------------------------------
+# Historial — GET /history
+#
+# Se guardan ANÁLISIS, no invocaciones de herramienta: un `POST /analyze` es
+# UNA entrada, no cinco. La traza de invocaciones ya vive en los logs.
+# --------------------------------------------------------------------------
+
+
+class HistoryKind(
+    str, Enum
+):  # Añadir str es un MIXIN!!! (Herencia múltiple para obtener funciones como json.dumps, el cual no funciona con Enum puro)
+    """Define qué acción produjo la entrada en el historial."""
+
+    ANALYSIS = "analysis"  # Generado por POST /analyze (señales contrastadas)
+    TOOL = "tool"  # Generado por POST /tools/{name}/execute (herramienta suelta)
+
+
+class Origin(str, Enum):
+    """Desde dónde se pidió la entrada en el historial. El prototipo distingue chat y formulario."""
+
+    FORM = "form"
+    CHAT = "chat"  # aún no existe: llega con el agente
+    API = "api"  # llamada directa, sin interfaz
+
+
+class HistoryEntry(BaseModel):
+    """Una entrada del historial.
+
+    Sobre por qué unos campos son enums y otros cadenas sueltas: los enums
+    describen lo que se calcula AHORA, y publican en OpenAPI el conjunto cerrado
+    de valores para que el cliente pueda generar un tipo unión. Pero esto son
+    **datos leídos de disco, que pudo escribir otra versión del código**, y un
+    enum sobre eso es una bomba de relojería: el día que cambie un valor, las
+    filas antiguas dejan de validar y `GET /history` devuelve un 500 por una
+    entrada de hace seis meses.
+
+    De ahí el reparto: `kind` y `origin` son un conjunto minúsculo, estable y
+    bajo nuestro control (si cambiara, se migraría a mano) → enum. `verdict`
+    procede de ``OverallVerdict``, un vocabulario de dominio que va a CRECER
+    conforme se añadan tipos de clickbait → cadena. `status` se queda en cadena
+    porque su significado aún difiere entre tipos —en un análisis es «alguna
+    señal funcionó», en una herramienta es «no falló»— y eso se replantea al
+    llegar el filtrado (#103).
+    """
+
+    id: int
+    created_at: datetime
+    kind: HistoryKind
+    origin: Origin
+
+    headline: str | None = Field(
+        default=None, description="Titular analizado. Nulo en ejecuciones sueltas."
+    )
+    tool: str | None = Field(
+        default=None, description="Herramienta invocada. Nulo en análisis completos."
+    )
+    verdict: str | None = Field(
+        default=None, description="Veredicto global. Nulo en ejecuciones sueltas."
+    )
+    status: str
+
+    payload: dict[str, Any] = Field(
+        description=(
+            "La respuesta COMPLETA que se devolvió en su momento. Es lo que "
+            "permite volver a mostrar el resultado sin reejecutar — que además "
+            "de costar ~20 s podría dar otro resultado, porque las señales "
+            "remotas no son deterministas."
+        )
+    )
+
+
+class HistoryPage(BaseModel):
+    """Una página del historial, en orden cronológico inverso."""
+
+    items: list[HistoryEntry]
+    total: int = Field(
+        description=(
+            "Entradas totales, no las de esta página. La interfaz lo necesita "
+            "para paginar; sin él sólo puede saber si hay más pidiendo la "
+            "siguiente."
+        )
+    )
+    limit: int
+    offset: int

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -61,5 +61,16 @@ class Settings(BaseSettings):
     # timeout de descubrimiento, esa llamada moriría siempre en frío.
     mcp_execute_timeout: float = 60.0
 
+    # Fichero SQLite del historial.
+    #
+    # Va en `var/` y no en `data/` a propósito: `data/` está versionado —guarda
+    # los datasets y los splits congelados, que no deben cambiar nunca— y esto
+    # es estado mutable que cambia en cada petición. Juntarlos acabaría en un
+    # `git add data/` que commitea la base de datos.
+    #
+    # Este directorio es el que se monta como volumen luego para que el
+    # historial sobreviva al contenedor.
+    history_db: str = "var/history.db"
+
 
 settings = Settings()  # type: ignore #Activa la validación al importar

--- a/spikes/bench_historial_descriptores_y_wal.py
+++ b/spikes/bench_historial_descriptores_y_wal.py
@@ -1,0 +1,177 @@
+"""Dos preguntas que dejo abiertas el primer banco de pruebas.
+
+A) Los 20 descriptores de delta, .crecen sin limite (fuga) o son un atasco
+   acotado esperando al recolector de ciclos?
+B) WAL bajo de 193 ms a 119 ms. .Donde esta el resto? .Lo quita synchronous?
+
+Evidencia de las tablas de la seccion #102 del README.
+
+RESULTADOS (2026-08-13, WSL2 ext4 sobre VHD, Python 3.12.3 / SQLite 3.45.1)
+
+  A) descriptores abiertos, patron actual (sin close)
+       n=   500   delta= 75   tras gc.collect()= 0
+       n=  2000   delta= 96   tras gc.collect()= 0
+       n=  8000   delta= 99   tras gc.collect()= 0
+       n= 20000   delta=163   tras gc.collect()= 0
+       n= 20000 CON close()   delta=  0
+
+  B) coste de una escritura completa
+       journal=DELETE, synchronous=FULL  (por defecto)     164.17 ms
+       journal=WAL,    synchronous=FULL                    226.00 ms
+       journal=WAL,    synchronous=NORMAL                  250.66 ms
+       journal=WAL,    synchronous=OFF                       0.47 ms
+
+CONCLUSIONES
+
+A) No es una fuga lineal (20 000 escrituras no dejan 20 000 descriptores), pero
+   el atasco CRECE y gc.collect() lo devuelve siempre a cero: son conexiones
+   esperando al recolector de CICLOS, no al contador de referencias. El codigo
+   era correcto por accidente, apoyado en un detalle de CPython que PyPy no
+   comparte. Con close() explicito el delta es 0 exacto.
+
+B) WAL sale MAS LENTO, al reves de lo que dice el manual. Al cerrar la ULTIMA
+   conexion a una base en modo WAL, SQLite ejecuta un checkpoint completo, y con
+   'una conexion por operacion' eso pasa en cada escritura. WAL rinde cuando las
+   conexiones se mantienen abiertas: son dos decisiones acopladas, y quedarse
+   con media de cada una es peor que con cualquiera entera.
+
+   Los 0.47 ms de synchronous=OFF prueban que los ~164 ms son TODO fsync. No se
+   toca: es el unico cambio evaluado que sacrifica una garantia real. Ojo con
+   extrapolar la cifra: medida sobre el disco virtual de WSL2, donde el fsync
+   atraviesa hasta el anfitrion Windows. En Linux nativo son decimas de ms.
+   Volver a medirlo al contenerizar (H4).
+"""
+
+import gc
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ESQUEMA = """
+CREATE TABLE IF NOT EXISTS history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, created_at TEXT NOT NULL,
+    kind TEXT NOT NULL, origin TEXT NOT NULL, headline TEXT, tool TEXT,
+    verdict TEXT, status TEXT NOT NULL, payload TEXT NOT NULL);
+"""
+INSERT = """
+INSERT INTO history (created_at, kind, origin, headline, tool, verdict, status, payload)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+PAYLOAD = json.dumps({"signals": [{"name": f"s{i}", "detail": "x" * 400} for i in range(5)]})
+FILA = ("2026-08-13T12:00:00+00:00", "analysis", "api", "Titular", None, "clickbait", "ok", PAYLOAD)
+
+
+def fds():
+    return len(os.listdir(f"/proc/{os.getpid()}/fd"))
+
+
+def nueva_db(pragmas=()):
+    ruta = Path(tempfile.mkdtemp()) / "history.db"
+    c = sqlite3.connect(ruta)
+    for p in pragmas:
+        c.execute(p)
+    c.execute(ESQUEMA)
+    c.close()
+    return ruta
+
+
+print(f"Python: {sys.version.split()[0]}  |  SQLite: {sqlite3.sqlite_version}\n", flush=True)
+
+# ---------------------------------------------------------------- A
+print("=== A) .Fuga lineal o atasco acotado? ===", flush=True)
+print("   (synchronous=OFF solo para que corra rapido; no afecta al ciclo de vida)\n", flush=True)
+
+
+def escribir_sin_close(ruta):
+    """El patron ACTUAL: `with conexion:` sin close()."""
+    c = sqlite3.connect(ruta)
+    c.row_factory = sqlite3.Row
+    c.execute("PRAGMA synchronous=OFF")
+    c.execute(ESQUEMA)
+    with c:
+        c.execute(INSERT, FILA)
+
+
+for n in (500, 2000, 8000, 20000):
+    ruta = nueva_db(("PRAGMA journal_mode=WAL", "PRAGMA synchronous=OFF"))
+    gc.collect()
+    antes = fds()
+    for _ in range(n):
+        escribir_sin_close(ruta)
+    pico = fds()
+    gc.collect()
+    tras_gc = fds()
+    print(f"  n={n:>6}   antes={antes:>3}   despues={pico:>3}   "
+          f"delta={pico - antes:>3}   tras gc.collect()={tras_gc:>3}", flush=True)
+
+print("\n  -> si el delta NO crece con n, es un atasco acotado, no una fuga", flush=True)
+print("  -> si gc.collect() lo devuelve al inicio, estaban esperando al recolector", flush=True)
+
+# Y el patron PROPUESTO, para contrastar
+print("\n  Con close() explicito:", flush=True)
+
+
+def escribir_con_close(ruta):
+    c = sqlite3.connect(ruta)
+    c.row_factory = sqlite3.Row
+    c.execute("PRAGMA synchronous=OFF")
+    c.execute(ESQUEMA)
+    try:
+        with c:
+            c.execute(INSERT, FILA)
+    finally:
+        c.close()
+
+
+ruta = nueva_db(("PRAGMA journal_mode=WAL", "PRAGMA synchronous=OFF"))
+gc.collect()
+antes = fds()
+for _ in range(20000):
+    escribir_con_close(ruta)
+print(f"  n= 20000   antes={antes:>3}   despues={fds():>3}   delta={fds() - antes:>3}", flush=True)
+
+# ---------------------------------------------------------------- B
+print("\n=== B) .De donde salen los 119 ms que quedan? ===\n", flush=True)
+
+
+def bench_escritura(etiqueta, pragmas, n=200):
+    ruta = nueva_db(pragmas)
+
+    def escribir():
+        c = sqlite3.connect(ruta)
+        for p in pragmas:
+            c.execute(p)
+        c.execute(ESQUEMA)
+        try:
+            with c:
+                c.execute(INSERT, FILA)
+        finally:
+            c.close()
+
+    escribir()
+    t0 = time.perf_counter()
+    for _ in range(n):
+        escribir()
+    ms = (time.perf_counter() - t0) / n * 1e3
+    print(f"  {etiqueta:<48} {ms:9.2f} ms/op", flush=True)
+    return ms
+
+
+base = bench_escritura("journal=DELETE, synchronous=FULL  (por defecto)", ())
+wal = bench_escritura("journal=WAL,    synchronous=FULL", ("PRAGMA journal_mode=WAL",))
+wal_normal = bench_escritura(
+    "journal=WAL,    synchronous=NORMAL  <-- propuesta",
+    ("PRAGMA journal_mode=WAL", "PRAGMA synchronous=NORMAL"),
+)
+wal_off = bench_escritura(
+    "journal=WAL,    synchronous=OFF     (sin durabilidad)",
+    ("PRAGMA journal_mode=WAL", "PRAGMA synchronous=OFF"),
+)
+
+print(f"\n  WAL+FULL   frente al defecto : {base / wal:5.1f}x mas rapido", flush=True)
+print(f"  WAL+NORMAL frente al defecto : {base / wal_normal:5.1f}x mas rapido", flush=True)
+print(f"  WAL+OFF    frente al defecto : {base / wal_off:5.1f}x mas rapido", flush=True)

--- a/spikes/bench_historial_sqlite.py
+++ b/spikes/bench_historial_sqlite.py
@@ -1,0 +1,169 @@
+"""Mide el coste real de las 'ineficiencias' senaladas en history.py.
+
+Evidencia de las tablas de la seccion #102 del README. Una revision externa
+senalo cinco puntos de rendimiento; medirlos descarto tres y destapo uno que no
+estaba en la lista.
+
+No toca el repo: crea su propia base de datos en un temporal de WSL (ext4),
+no en /mnt/c, para que los numeros sean representativos del entorno real.
+
+RESULTADOS (2026-08-13, WSL2 ext4 sobre VHD, Python 3.12.3 / SQLite 3.45.1)
+
+    Path.mkdir(parents=True, exist_ok=True) [ya existe]        7.2 us
+    sqlite3.connect + close (sin esquema)                     35.1 us
+    sqlite3.connect + CREATE TABLE IF NOT EXISTS + close      97.4 us
+    CREATE TABLE IF NOT EXISTS solo (conexion ya abierta)      9.9 us
+    _conectar() + INSERT + commit [journal=delete]        193 791.9 us
+
+    => el esquema es el 0.005 % de una escritura completa
+    => el mkdir   es el 0.004 %
+
+    descriptores tras 2000 escrituras sin close()          delta +20
+    timeout por defecto de sqlite3.connect, medido          5.01 s
+
+CONCLUSIONES
+
+1. Ejecutar el esquema y el mkdir en cada conexion es ruido: se quedan, porque
+   hacen que el sistema funcione recien clonado el repo.
+2. El salto 35 -> 97 us NO es el coste del DDL: sqlite3.connect() es perezoso y
+   no abre el fichero hasta la primera sentencia, que aqui es el CREATE TABLE.
+   El coste marginal honesto es el aislado, 9.9 us.
+3. El timeout que se proponia anadir ya existia (5 s por defecto).
+4. Los 20 descriptores obligaron a un segundo banco:
+   ver bench_historial_descriptores_y_wal.py
+"""
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ESQUEMA = """
+CREATE TABLE IF NOT EXISTS history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL,
+    kind       TEXT NOT NULL,
+    origin     TEXT NOT NULL,
+    headline   TEXT,
+    tool       TEXT,
+    verdict    TEXT,
+    status     TEXT NOT NULL,
+    payload    TEXT NOT NULL
+);
+"""
+
+INSERT = """
+INSERT INTO history (created_at, kind, origin, headline, tool, verdict, status, payload)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+RAIZ = Path(tempfile.mkdtemp())
+DB = RAIZ / "var" / "history.db"
+DB.parent.mkdir(parents=True, exist_ok=True)
+
+# Un payload realista: la respuesta de /analyze con cinco senales ronda 2-4 KB.
+PAYLOAD = json.dumps({"signals": [{"name": f"s{i}", "detail": "x" * 400} for i in range(5)]})
+FILA = ("2026-08-13T12:00:00+00:00", "analysis", "api", "Titular", None, "clickbait", "ok", PAYLOAD)
+
+
+def bench(nombre, fn, n=2000):
+    fn()  # calentar
+    t0 = time.perf_counter()
+    for _ in range(n):
+        fn()
+    us = (time.perf_counter() - t0) / n * 1e6
+    print(f"  {nombre:<52} {us:9.1f} us/op   (n={n})", flush=True)
+    return us
+
+
+def descriptores():
+    return len(os.listdir(f"/proc/{os.getpid()}/fd"))
+
+
+con = sqlite3.connect(DB)
+con.execute(ESQUEMA)
+con.close()
+
+print(f"\nBase de datos: {DB}", flush=True)
+print(f"Python: {sys.version.split()[0]}  |  SQLite: {sqlite3.sqlite_version}", flush=True)
+
+print("\n--- Mejora 3: mkdir en cada conexion ---", flush=True)
+t_mkdir = bench("Path.mkdir(parents=True, exist_ok=True) [ya existe]",
+                lambda: DB.parent.mkdir(parents=True, exist_ok=True), n=20000)
+
+print("\n--- Mejora 1: DDL en cada conexion ---", flush=True)
+bench("sqlite3.connect + close (sin esquema)", lambda: sqlite3.connect(DB).close())
+
+
+def connect_con_esquema():
+    c = sqlite3.connect(DB)
+    c.execute(ESQUEMA)
+    c.close()
+
+
+bench("sqlite3.connect + CREATE TABLE IF NOT EXISTS + close", connect_con_esquema)
+
+abierta = sqlite3.connect(DB)
+t_ddl = bench("CREATE TABLE IF NOT EXISTS solo (conexion ya abierta)",
+              lambda: abierta.execute(ESQUEMA), n=20000)
+abierta.close()
+
+print("\n--- Referencia: el _conectar() + INSERT completo tal cual esta hoy ---", flush=True)
+
+
+def guardar_actual():
+    c = sqlite3.connect(DB)
+    c.row_factory = sqlite3.Row
+    c.execute(ESQUEMA)
+    with c:
+        c.execute(INSERT, FILA)
+
+
+modo = sqlite3.connect(DB).execute("PRAGMA journal_mode").fetchone()[0]
+t_total = bench(f"_conectar() + INSERT + commit  [journal_mode={modo}]", guardar_actual, n=200)
+
+print(f"\n  => el esquema es el {t_ddl / t_total * 100:.3f}% de una escritura completa", flush=True)
+print(f"  => el mkdir   es el {t_mkdir / t_total * 100:.3f}% de una escritura completa", flush=True)
+
+print("\n--- Mejora 4: la conexion sin close(), fuga o no ---", flush=True)
+antes = descriptores()
+for _ in range(2000):
+    guardar_actual()
+despues = descriptores()
+print(f"  descriptores abiertos antes de 2000 escrituras : {antes}", flush=True)
+print(f"  descriptores abiertos despues                  : {despues}", flush=True)
+print(f"  DELTA                                          : {despues - antes}", flush=True)
+
+print("\n--- Mejora 2a: journal_mode DELETE (por defecto) vs WAL ---", flush=True)
+c = sqlite3.connect(DB)
+c.execute("PRAGMA journal_mode=WAL")
+c.close()
+modo_wal = sqlite3.connect(DB).execute("PRAGMA journal_mode").fetchone()[0]
+print(f"  journal_mode tras el PRAGMA                    : {modo_wal}", flush=True)
+bench(f"_conectar() + INSERT + commit  [journal_mode={modo_wal}]", guardar_actual, n=200)
+
+c = sqlite3.connect(DB)
+print(f"  journal_mode en una conexion NUEVA             : "
+      f"{c.execute('PRAGMA journal_mode').fetchone()[0]}  <- persistente, no hay que repetirlo",
+      flush=True)
+c.close()
+print(f"  ficheros en var/                               : "
+      f"{sorted(p.name for p in DB.parent.iterdir())}", flush=True)
+
+print("\n--- Mejora 2b: el timeout por defecto, medido ---", flush=True)
+bloqueador = sqlite3.connect(DB)
+bloqueador.execute("BEGIN EXCLUSIVE")
+
+otro = sqlite3.connect(DB)  # sin pasar timeout: el que venga por defecto
+t0 = time.perf_counter()
+try:
+    otro.execute(INSERT, FILA)
+    print("  (no llego a bloquearse)", flush=True)
+except sqlite3.OperationalError as exc:
+    print(f"  espero {time.perf_counter() - t0:.2f} s antes de rendirse -> {exc}", flush=True)
+otro.close()
+bloqueador.rollback()
+bloqueador.close()

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -153,6 +153,7 @@ def test_openapi_documenta_las_rutas_y_el_contrato():
         "/analyze",
         "/tools",
         "/tools/{name}/execute",
+        "/history",
         "/health",
     }
     # Las descripciones de los Field llegan al esquema: son lo que ve quien

--- a/tests/api/test_history.py
+++ b/tests/api/test_history.py
@@ -1,0 +1,352 @@
+"""Tests del historial.
+
+Dos bloques, porque responden preguntas distintas:
+
+- **El almacén** (`backend.api.history`), llamando a sus funciones: si los datos
+  sobreviven, si salen en orden y si un fallo de escritura se queda donde debe.
+- **El endpoint** (`GET /history`), por HTTP: si la decisión de fondo —«una
+  entrada por análisis, no una por herramienta invocada»— se sostiene de verdad.
+
+Los tests del almacén usan `asyncio.run()` en vez del marcador de pytest-asyncio
+porque `pytest.ini` no declara `asyncio_mode = auto`: la alternativa sería
+marcar cada uno a mano para ganar lo mismo.
+
+La base de datos de cada test es un fichero nuevo bajo `tmp_path`, gracias al
+fixture `_historial_aislado` de `tests/conftest.py`. Ningún test hereda entradas
+de otro ni deja rastro en `var/`.
+"""
+
+import asyncio
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api import app as app_mod
+from backend.api import history
+from backend.api.app import app
+from backend.api.execute import ToolNotFound
+from backend.api.schemas import (
+    AnalyzeResponse,
+    Dimension,
+    DimensionVerdict,
+    ExecuteResponse,
+    ExecuteStatus,
+    HistoryKind,
+    Origin,
+    OverallVerdict,
+    SignalResult,
+    SignalStatus,
+    SignalType,
+)
+from backend.config.settings import settings
+
+client = TestClient(app)
+
+
+def _guardar(**cambios) -> int | None:
+    """`record` con los obligatorios ya puestos, para no repetirlos en cada test."""
+    argumentos = {
+        "kind": HistoryKind.ANALYSIS,
+        "origin": Origin.API,
+        "status": "ok",
+        "payload": {"verdict": "factual"},
+        **cambios,
+    }
+    return asyncio.run(history.record(**argumentos))
+
+
+def _leer(limit=20, offset=0):
+    return asyncio.run(history.query(limit, offset))
+
+
+# ---------------------------------------------------------------- el almacén
+
+
+def test_guarda_y_recupera():
+    identificador = _guardar(headline="Un titular", verdict="factual")
+    assert identificador == 1  # primera fila, AUTOINCREMENT empieza en 1
+
+    filas, total = _leer()
+    assert total == 1
+    assert filas[0]["headline"] == "Un titular"
+    assert filas[0]["verdict"] == "factual"
+    assert filas[0]["kind"] == "analysis"
+
+
+def test_el_payload_vuelve_como_diccionario():
+    """La garantía de aislamiento: entra un diccionario, sale un diccionario.
+
+    Si saliera como cadena, quien llame tendría que hacer `json.loads` — es decir,
+    tendría que saber que aquí dentro se guarda serializado. Con Postgres y una
+    columna `jsonb` ese `json.loads` de fuera reventaría.
+    """
+    _guardar(payload={"verdict": "enganoso", "signals": [{"name": "lexical"}]})
+
+    filas, _ = _leer()
+    assert filas[0]["payload"] == {
+        "verdict": "enganoso",
+        "signals": [{"name": "lexical"}],
+    }
+
+
+def test_crea_el_directorio_si_no_existe(tmp_path, monkeypatch):
+    """Recién clonado el repo, `var/` no existe: está en .gitignore."""
+    destino = tmp_path / "no" / "existe" / "todavia" / "history.db"
+    monkeypatch.setattr(settings, "history_db", str(destino))
+
+    assert _guardar() == 1
+    assert destino.exists()
+
+
+def test_una_ruta_relativa_se_ancla_a_la_raiz_del_repo(monkeypatch):
+    """Sin esto, arrancar uvicorn desde otro directorio crearía una segunda base
+    de datos vacía, y el síntoma sería «se ha borrado el historial»."""
+    monkeypatch.setattr(settings, "history_db", "var/history.db")
+
+    ruta = history._ruta_db()
+    assert ruta.is_absolute()
+    assert ruta == history._RAIZ / "var" / "history.db"
+
+
+def test_una_ruta_absoluta_se_respeta(monkeypatch, tmp_path):
+    """Es lo que se configurará en el contenedor con HISTORY_DB=/var/lib/..."""
+    destino = tmp_path / "en" / "otro" / "sitio.db"
+    monkeypatch.setattr(settings, "history_db", str(destino))
+
+    assert history._ruta_db() == destino
+
+
+def test_las_entradas_salen_de_la_mas_nueva_a_la_mas_vieja():
+    for titular in ("primero", "segundo", "tercero"):
+        _guardar(headline=titular)
+
+    filas, _ = _leer()
+    assert [f["headline"] for f in filas] == ["tercero", "segundo", "primero"]
+
+
+def test_la_paginacion_devuelve_el_total_completo():
+    for i in range(5):
+        _guardar(headline=f"titular {i}")
+
+    filas, total = _leer(limit=2, offset=2)
+    assert len(filas) == 2
+    # El total es de TODAS las entradas, no de la página: es lo que la interfaz
+    # necesita para pintar «3-4 de 5».
+    assert total == 5
+    assert [f["headline"] for f in filas] == ["titular 2", "titular 1"]
+
+
+def test_un_fallo_de_escritura_no_propaga(monkeypatch):
+    """El análisis ya se hizo y es correcto: perderlo porque el disco esté lleno
+    sería peor que no guardarlo. Devuelve None y deja el motivo en el log."""
+
+    def revienta(*args, **kwargs):
+        raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(history, "_guardar", revienta)
+
+    assert _guardar() is None
+
+
+def test_conectar_cierra_la_conexion_al_salir():
+    """El `with` de sqlite3 gestiona la TRANSACCIÓN, no el cierre.
+
+    Sin el `close()` explícito, cerrarla queda en manos del recolector: medido,
+    20 000 escrituras dejaban hasta 163 descriptores abiertos hasta el siguiente
+    `gc.collect()`. Operar sobre una conexión ya cerrada lanza ProgrammingError.
+    """
+    with history._conectar() as conexion:
+        conexion.execute("SELECT 1")
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        conexion.execute("SELECT 1")
+
+
+def test_una_excepcion_deshace_la_escritura():
+    """La otra mitad del gestor de contexto: rollback si algo revienta dentro.
+
+    Y prueba de paso que el orden es el correcto — confirmar ANTES de cerrar. Si
+    fuera al revés, cerrar con una transacción pendiente la desharía siempre.
+    """
+    with pytest.raises(RuntimeError):
+        with history._conectar() as conexion:
+            conexion.execute(
+                history._INSERT,
+                (
+                    "2026-01-01T00:00:00+00:00",
+                    "analysis",
+                    "api",
+                    "x",
+                    None,
+                    None,
+                    "ok",
+                    "{}",
+                ),
+            )
+            raise RuntimeError("boom")
+
+    _, total = _leer()
+    assert total == 0
+
+
+# ---------------------------------------------------------------- el endpoint
+
+
+def _respuesta_analisis(headline="Un titular"):
+    return AnalyzeResponse(
+        headline=headline,
+        content=None,
+        signals=[
+            SignalResult(
+                name="detect_clickbait_lexical",
+                status=SignalStatus.OK,
+                dimension=Dimension.FORMA,
+                type=SignalType.INTERPRETABLE,
+                is_clickbait=True,
+                data={"score": 2},
+            )
+        ],
+        dimensions=[
+            DimensionVerdict(
+                dimension=Dimension.FORMA,
+                is_clickbait=True,
+                contributing=["detect_clickbait_lexical"],
+            )
+        ],
+        verdict=OverallVerdict.CLICKBAIT_DE_FORMA,
+    )
+
+
+@pytest.fixture
+def analisis(monkeypatch):
+    async def falso_analyze(request):
+        return _respuesta_analisis(request.headline)
+
+    monkeypatch.setattr(app_mod, "analyze", falso_analyze)
+
+
+@pytest.fixture
+def ejecucion(monkeypatch):
+    async def falso_execute(name, arguments):
+        return ExecuteResponse(
+            tool=name,
+            server="http://127.0.0.1:8765/mcp",
+            status=ExecuteStatus.OK,
+            data={"score": 2},
+        )
+
+    monkeypatch.setattr(app_mod, "execute_tool", falso_execute)
+
+
+def test_historial_vacio():
+    cuerpo = client.get("/history").json()
+
+    assert cuerpo["items"] == []
+    assert cuerpo["total"] == 0
+    assert cuerpo["limit"] == 20
+
+
+def test_un_analyze_deja_UNA_entrada_y_no_una_por_senal(analisis):
+    """La decisión de fondo del historial.
+
+    Un `/analyze` invoca cinco herramientas. Guardarlas sueltas daría una lista
+    de `detect_clickbait_lexical` repetido en vez del titular que el usuario
+    analizó. La traza por invocación ya vive en los logs, que es su sitio.
+    """
+    client.post("/analyze", json={"headline": "Un titular"})
+
+    cuerpo = client.get("/history").json()
+    assert cuerpo["total"] == 1
+    assert cuerpo["items"][0]["kind"] == "analysis"
+    assert cuerpo["items"][0]["headline"] == "Un titular"
+    assert cuerpo["items"][0]["verdict"] == "clickbait_de_forma"
+
+
+def test_la_entrada_guarda_la_respuesta_completa(analisis):
+    """Es lo que permite volver a mostrar el resultado sin reejecutar — que
+    además de costar ~20 s podría dar otro resultado."""
+    client.post("/analyze", json={"headline": "Un titular"})
+
+    payload = client.get("/history").json()["items"][0]["payload"]
+    assert payload["verdict"] == "clickbait_de_forma"
+    assert payload["signals"][0]["name"] == "detect_clickbait_lexical"
+    assert payload["signals"][0]["data"] == {"score": 2}
+
+
+def test_una_ejecucion_suelta_guarda_su_titular(ejecucion):
+    """Las señales reciben el titular como argumento: sacarlo de ahí hace que la
+    entrada se vea en la lista con su titular en vez de con un hueco."""
+    client.post(
+        "/tools/detect_clickbait_lexical/execute",
+        json={"arguments": {"headline": "Otro titular"}},
+    )
+
+    entrada = client.get("/history").json()["items"][0]
+    assert entrada["kind"] == "tool"
+    assert entrada["tool"] == "detect_clickbait_lexical"
+    assert entrada["headline"] == "Otro titular"
+
+
+def test_una_herramienta_sin_titular_lo_deja_vacio(ejecucion):
+    client.post("/tools/health_check/execute", json={"arguments": {}})
+
+    entrada = client.get("/history").json()["items"][0]
+    assert entrada["tool"] == "health_check"
+    assert entrada["headline"] is None
+
+
+def test_una_peticion_rechazada_no_se_registra(monkeypatch):
+    """Un 404 no es una ejecución: ensuciaría el historial con intentos fallidos
+    del formulario en vez de con análisis hechos."""
+
+    async def no_existe(name, arguments):
+        raise ToolNotFound(name)
+
+    monkeypatch.setattr(app_mod, "execute_tool", no_existe)
+
+    assert (
+        client.post("/tools/inventada/execute", json={"arguments": {}}).status_code
+        == 404
+    )
+    assert client.get("/history").json()["total"] == 0
+
+
+def test_la_pagina_respeta_limit_y_offset(analisis):
+    for i in range(5):
+        client.post("/analyze", json={"headline": f"titular {i}"})
+
+    cuerpo = client.get("/history?limit=2&offset=1").json()
+    assert cuerpo["total"] == 5
+    assert cuerpo["limit"] == 2
+    assert cuerpo["offset"] == 1
+    assert [i["headline"] for i in cuerpo["items"]] == ["titular 3", "titular 2"]
+
+
+@pytest.mark.parametrize("limit", [0, -1, 101])
+def test_limit_fuera_de_rango_es_422(limit):
+    """El tope se valida en la firma, así que sale publicado en OpenAPI y pedir
+    de más devuelve 422 en vez de servir otra cosa en silencio.
+
+    El mínimo de 1 no es cosmético: en SQLite un LIMIT NEGATIVO significa «sin
+    límite», así que `?limit=-1` traería la tabla entera a memoria.
+    """
+    assert client.get(f"/history?limit={limit}").status_code == 422
+
+
+def test_offset_negativo_es_422():
+    assert client.get("/history?offset=-1").status_code == 422
+
+
+def test_los_topes_salen_en_el_esquema_openapi():
+    """Lo que justifica validar en la firma en vez de recortar a mano: el cliente
+    Angular se genera de aquí, y un tope no publicado se descubre a sorpresas."""
+    esquema = client.get("/openapi.json").json()
+    parametros = {
+        p["name"]: p["schema"]
+        for p in esquema["paths"]["/history"]["get"]["parameters"]
+    }
+
+    assert parametros["limit"]["maximum"] == 100
+    assert parametros["limit"]["minimum"] == 1
+    assert parametros["offset"]["minimum"] == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,25 @@ import pytest
 import structlog
 from mcp.server.fastmcp import FastMCP
 
+from backend.config.settings import settings
 from backend.core import health
 from backend.integrations.discovery import discover_and_register
+
+
+@pytest.fixture(autouse=True)
+def _historial_aislado(tmp_path, monkeypatch):
+    """Manda el historial a un fichero temporal, en TODOS los tests.
+
+    Desde que `/analyze` registra cada análisis, los tests de la capa HTTP
+    escriben en el historial de verdad: una sola corrida de la suite dejaba
+    cuatro entradas «Un titular» en `var/history.db`, el fichero del usuario.
+
+    Va aquí y con `autouse` —y no en el fichero que prueba el historial— porque
+    quien contamina no es quien lo prueba: lo hace cualquier test que llame a un
+    endpoint que registre, y eso incluye a los que aún no existen. Como
+    `_ruta_db()` lee `settings` en cada llamada, basta con mover el ajuste.
+    """
+    monkeypatch.setattr(settings, "history_db", str(tmp_path / "history.db"))
 
 
 @pytest.fixture


### PR DESCRIPTION
## #102 · Historial: persistir análisis y exponer `GET /history` con paginación

Closes #102

Hasta aquí la API era **sin estado**: cada petición se atendía con lo que traía
dentro y no dejaba rastro, así que reiniciar el proceso no perdía nada porque no
había nada que perder. R9 rompe eso —el usuario tiene que poder volver a ver un
análisis de ayer— y con ello aparece la primera escritura a disco del backend.

### Qué incluye

- **`backend/api/history.py`** (nuevo): el almacén, SQLite detrás de tres
  funciones (`record`, `query` y el gestor de conexión). Lo que protege de un
  cambio de requisitos no es elegir el almacén más flexible sino aislarlo:
  cambiar de motor es reescribir este fichero sin tocar endpoints ni sus tests.
- **`backend/api/app.py`**: registro tras `/analyze` y tras
  `/tools/{name}/execute`, y la ruta `GET /history`. Una petición rechazada por
  404 o 422 **no** se registra: no es una ejecución, y ensuciaría el historial
  con intentos fallidos del formulario.
- **`backend/api/schemas.py`**: `HistoryEntry`, `HistoryPage` y los enums
  `HistoryKind` / `Origin`, que viven aquí con el resto del contrato para que el
  conjunto cerrado de valores salga publicado en OpenAPI.
- **`backend/config/settings.py`** y **`.gitignore`**: `history_db` apunta a
  `var/` y no a `data/`. `data/` está versionado —datasets y splits congelados,
  que no deben cambiar nunca— y esto es estado que cambia en cada petición;
  juntarlos acaba en un `git add data/` que commitea la base de datos.
- **`tests/api/test_history.py`** (22 tests) y el aislamiento en
  **`tests/conftest.py`**.
- **`spikes/bench_historial_*.py`**: los dos bancos de prueba que sostienen las
  cifras de abajo, con sus resultados y conclusiones en la cabecera.

### La decisión de fondo: se guardan análisis, no invocaciones

Al pie de la letra, «registrar cada ejecución de herramienta» haría que un solo
`POST /analyze` dejara **cinco filas**, una por señal, y la pantalla resultante
sería una lista de `detect_clickbait_lexical` repetido sin el titular por ningún
sitio. Esa granularidad ya existe donde sirve: `log_tool_invocation` registra
cada invocación con parámetros y duración. Son dos registros con dos públicos.

Se guarda la respuesta **completa**, no sólo el veredicto: reejecutar al abrir la
entrada costaría ~20 s en frío y las señales remotas no son deterministas, así
que el «resultado anterior» podría salir distinto. Un historial que cambia lo que
dice no es un historial.

### Lo que salió de medir en vez de suponer

Una revisión externa señaló cinco puntos de rendimiento. Medirlos descartó tres,
corrigió uno y destapó otro que no estaba en la lista.

| Operación | Coste |
|---|---|
| `Path.mkdir(parents=True, exist_ok=True)` sobre directorio existente | 7,2 µs |
| `CREATE TABLE IF NOT EXISTS` sobre tabla existente | 9,9 µs |
| `_conectar()` + `INSERT` + `commit` | **193 792 µs** |

Ejecutar el esquema y el `mkdir` en cada conexión cuesta el **0,005 %** y el
**0,004 %** de lo que envuelven: se quedan, porque hacen que el sistema funcione
recién clonado el repo sin ningún paso de instalación, y cachearlos en una
variable de módulo rompería los tests con `tmp_path`. El **timeout** que se
proponía añadir ya existía: `sqlite3.connect` lo trae en 5 s por defecto, medido
en 5,01 s antes de `database is locked`.

**La conexión sin cerrar sí era real**, aunque no por el motivo que se le
atribuía. En `sqlite3`, el `with` de una conexión gestiona la *transacción* y no
la cierra:

| Escrituras | Descriptores tras la ráfaga | Tras `gc.collect()` |
|---|---|---|
| 2 000 | +96 | +0 |
| 20 000 | +163 | +0 |
| 20 000 **con `close()`** | **+0** | — |

No es la fuga lineal que llevaría a `Too many open files`, pero el atasco crece y
`gc.collect()` lo devuelve siempre a cero: son conexiones esperando al recolector
de **ciclos**. El código era correcto por accidente, apoyado en un detalle de
CPython que PyPy no comparte. `_conectar` pasa a gestor de contexto propio que
cierra en un `finally`, confirmando **antes** de cerrar — al revés se perdería la
escritura, porque cerrar con una transacción pendiente la deshace.

### WAL: la recomendación de manual, descartada por medición

| `journal_mode` | `synchronous` | ms/escritura |
|---|---|---|
| DELETE *(por defecto)* | FULL | 164 |
| WAL | FULL | 226 |
| WAL | NORMAL | 251 |
| WAL | OFF | 0,47 |

Al cerrar la **última** conexión a una base en modo WAL, SQLite ejecuta un
checkpoint completo; con «una conexión por operación» eso ocurre en cada
escritura. WAL rinde cuando las conexiones se mantienen abiertas, que es justo lo
que este diseño no hace: son dos decisiones acopladas, y quedarse con media de
cada una es peor que con cualquiera entera.

Los 0,47 ms de `synchronous=OFF` prueban que esos ~164 ms son **todo `fsync`**.
No se toca: un historial que se pierde al cortarse la luz no es un historial.

### Un fallo que sólo apareció mirando `var/`

Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa
ruta en escritores del historial real: una corrida de la suite dejaba cuatro
entradas «Un titular» en `var/history.db`. El aislamiento va en un fixture
`autouse` de `tests/conftest.py` y no en el fichero que prueba el historial,
porque quien contamina no es quien lo prueba: lo hace cualquier test que llame a
un endpoint que registre, incluidos los que aún no existen.

### Notas

- **Los filtros y la retención son #103.** Sin retención la tabla crece sin
  límite; las columnas `tool`, `verdict` y `status` ya existen para no tener que
  migrar cuando llegue.
- **`origin` es hoy siempre `api`**: `form` y `chat` están declarados porque el
  prototipo los distingue y añadir la columna después obligaría a migrar, pero no
  hay quien los emita hasta que existan la SPA y el agente.
- **`status` y `verdict` van como cadena y no como enum**, a propósito: son datos
  leídos de disco que pudo escribir otra versión del código, y un enum sobre eso
  hace que el día que cambie un valor las filas antiguas dejen de validar y
  `GET /history` devuelva un 500 por una entrada de hace meses. El significado de
  `status` además difiere entre tipos —en un análisis es «alguna señal funcionó»,
  en una herramienta es «no falló»— y se replantea en #103.
- **Los 164 ms de `fsync` se midieron sobre el disco virtual de WSL2**, donde
  atraviesa hasta el anfitrión Windows; en Linux nativo son décimas de ms. Queda
  apuntado para volver a medirlo al contenerizar (H4) y decidir entonces si la
  escritura debe salir de la ruta de respuesta.
- **`HistoryEntry(**fila)` sigue asumiendo que las claves del almacén casan con
  los campos del contrato.** El `SELECT` nombra las columnas para que la salida
  del módulo sea una declaración deliberada y no el reflejo de la tabla, pero
  cerrar el acoplamiento del todo exigiría construir el modelo campo a campo. La
  red hoy está en los tests, no en el código.
