### PR TITLE
feat(api): filtros y retención del historial (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,114 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### Historial: filtros y retención (#103)
+
+La otra mitad de R9. El issue anterior dejaba algo usable —historial paginado y en orden inverso— y éste añade dos refinamientos que traían decisiones propias, más un criterio que hubo que reinterpretar porque su premisa había cambiado.
+
+#### R9.4 se escribió para un historial que no existe
+
+«Filtrado por nombre de herramienta, intervalo de fechas y estado» se redactó pensando en el historial de **invocaciones**, que en #102 se descartó a favor de guardar análisis. Sobre lo que hay, dos de los tres criterios no encajan tal cual:
+
+**«Nombre de herramienta»** no aplica a un análisis, que invocó cinco señales y no tiene *una*. Se resuelve con dos parámetros en vez de uno: `kind` separa análisis de ejecuciones sueltas, y `tool` sólo casa con las segundas, que sí tienen una. Ambas columnas existían ya. Se descartó la lectura literal —guardar qué señales participaron en cada análisis— porque pide tabla nueva o columna de nombres y habilita una consulta de depuración, no de usuario.
+
+La UI es lo que hace que el desajuste no se note: las pestañas superiores son `kind`, y el desplegable de herramientas **sólo aparece dentro de «Herramientas»**. La restricción no se explica, se ve.
+
+**«Estado»** tampoco es una sola cosa. Un análisis puede tener tres señales bien y una caída, así que se desdobla: `verdict` es **qué concluyó** —`enganoso`, `factual`, `ambiguo`…— y es el que le interesa a quien mira sus análisis; `status` es **si funcionó la maquinaria**, y es operativo. En la pantalla sólo el primero merece sitio destacado. Es también el motivo por el que en #102 `status` quedó como cadena y no como enum.
+
+#### La poda: tres formulaciones y una que parecía correcta
+
+Podar al escribir estaba decidido de antemano; lo que no estaba era **cómo escribir el `DELETE`**, y ahí la intuición falló dos veces.
+
+| Formulación | desde 500 | desde 3000 | Coste |
+|---|---|---|---|
+| (a) `MIN` sobre subconsulta | → 700 | → 1000 | 801 µs |
+| (b) `OFFSET` sobre el índice | → 700 | → 1000 | 618 µs |
+| (c) borrar sólo la más vieja | **→ 500** | **→ 3000** | 14 µs |
+| **(d) corte por `MAX(id) - N`** | → 700 | → 1000 | **17,7 µs** |
+
+La (c) era 45 veces más barata que la ganadora y **está mal**: borra incondicionalmente, así que *mantiene* el tamaño de partida en vez de llevarlo al límite. Con 500 filas y techo de 1000 seguía borrando una por escritura — pérdida de datos silenciosa. Y el primer banco de pruebas no lo detectó porque arrancaba justo en el límite, así que su «quedan 1000 filas» salía por construcción y no porque funcionara.
+
+De ahí el criterio con el que se midieron: **convergencia desde ambos lados**, y las dos mitades significan cosas distintas. Desde abajo es **corrección**: borrar por debajo del techo destruye lo que la política dice conservar. Desde arriba es la **ruta de actualización**, y no es hipotética — el historial lleva creciendo sin techo desde #102, así que al desplegar la retención lo primero que se encuentra es una tabla por encima del límite. Que (d) reduzca de golpe —de 3000 a 1000 en *una* sentencia— es lo que evita tener que escribir una migración.
+
+#### Por qué `MAX(id) - N` es exacta, y dos veces que se afirmó mal
+
+La fórmula ganadora es la que *parece* ingenua, y restar del máximo sólo da «la N-ésima más nueva» si los ids son contiguos. Al justificarlo se dio dos veces una razón falsa antes de comprobarlo:
+
+1. «Los huecos vienen de la poda» — **falso**: la poda borra por la cola y deja un bloque contiguo.
+2. «Los huecos vienen de inserciones revertidas, porque `AUTOINCREMENT` quema el id» — **falso también**, y esta vez medido: tras una inserción revertida y una confirmada, la fila tiene el id 1. El contador se deshace con la transacción.
+
+Lo que `AUTOINCREMENT` garantiza es otra cosa: que un id **no se reutilice tras borrar**, para que el 40 podado no reaparezca señalando otro análisis. Que era justo para lo que se eligió en #102.
+
+Así que los ids son contiguos y la fórmula es exacta. Lo que la volvería aproximada es que algo borrara filas del *medio* —«fijar un análisis para que no se pierda», por ejemplo—: entonces el corte caería más arriba y se conservarían algo **menos** de N. Nunca más, así que el techo se respeta siempre y sólo el suelo se vuelve aproximado.
+
+#### El índice, y la pregunta que no se le hizo a WAL
+
+| | 1 000 filas | 10 000 | 50 000 |
+|---|---|---|---|
+| Poda por antigüedad **sin** índice | 2 374 µs | 11 113 µs | 54 595 µs |
+| Poda por antigüedad **con** índice | 0,99 µs | 1,02 µs | 0,97 µs |
+
+Unas 2.400 veces más rápida a 1.000 filas, y constante en vez de lineal. Y **no se paga al escribir**: 14,29 µs sin índice contra 13,91 µs con él, o sea que la diferencia está por debajo del ruido. Esa segunda medición es la que faltó en #102 al evaluar WAL — mirar sólo lo que una optimización acelera, sin mirar lo que encarece, es cómo se acaba adoptando algo que sale más lento.
+
+#### La retención no es sólo higiene de disco
+
+| `SELECT COUNT(*)` | 1 000 filas | 10 000 | 50 000 |
+|---|---|---|---|
+| | 886 µs | 10 215 µs | 50 465 µs |
+
+Perfectamente lineal, ~1 µs por fila, porque SQLite no cachea el conteo sino que recorre. Y `GET /history` lo ejecuta **en cada lectura** desde #102, para devolver el `total`. Sin techo, a 50.000 entradas cada petición gastaría 50 ms sólo en contar. La retención es lo que mantiene barata una lectura ya escrita.
+
+Los límites van a configuración (`history_max_entries`, `history_max_days`, `0` para desactivar) porque el criterio propone «1000 ejecuciones o 30 días» **como ejemplo, no como norma** — y porque en desarrollo interesa desactivarlos para no perder las pruebas propias. Se aplican los dos y manda el más estricto: uno acota el tamaño pero no el horizonte —mil análisis de golpe borran los de ayer— y el otro al revés.
+
+#### Un banco de pruebas que no midió lo que decía
+
+Conviene dejarlo escrito porque el error es fácil de repetir. El primer banco concluía que la poda por cantidad **escala con el tamaño de la tabla**:
+
+```
+1 615 µs (1k filas) → 11 990 µs (10k) → 61 860 µs (50k)
+```
+
+No lo demuestra: estaba escrito pasando `LIMIT = filas + 10`, es decir haciendo crecer **el límite** junto con la tabla. Medía el otro parámetro. En el sistema real el límite es fijo, así que el número que valía era el de la primera fila.
+
+Y el banco rehecho tampoco quedó fiable: con límite fijo sale plano a los tres tamaños, pero **también** al hacer crecer el límite hasta 50.010, lo que contradice al primero. No se explicó ese suelo de ~1 ms y no se construyó ninguna recomendación sobre esos números — la pregunta que importaba, el coste en régimen estacionario, la responde una medida directa.
+
+#### La poda va en la misma transacción, y qué cuesta eso
+
+Las dos sentencias se ejecutan dentro del `with` del `INSERT`, que es lo que hace que se cuelen en el `fsync` ya pagado: ninguna variante medida se acercó al doble de la referencia, así que el `DELETE` no añade sincronización propia.
+
+*(Esa medición sólo sirve para la lectura gruesa. Los deltas concretos eran ruido — podar salía «más rápido» que no podar, lo cual es imposible. La diferencia buscada, ~1,6 ms, es el 1 % de una escritura con `fsync` y no se resuelve contra un ruido del ±40 %.)*
+
+El precio de esa decisión: si la poda falla, **se deshace también el `INSERT`**, y como `record` se traga los errores el síntoma sería «el historial dejó de guardar» sin ruido. Separarlas en dos transacciones lo evitaría, pero perdería el ahorro que justifica podar al escribir. Se asume, cubierto con tests.
+
+#### Dos invariantes frágiles, reforzados sin que hubiera fallo
+
+Ninguno era un bug. Los dos eran código correcto **por razones que nadie había escrito**, que es una categoría distinta y que conviene tratar igual.
+
+**El `WHERE` compuesto.** Los filtros se acumulan en una lista de fragmentos que se unen con `AND`, y los valores viajan aparte por `?`. Era seguro, pero los cuatro filtros de igualdad se construían con `f"{columna} = ?"`: seguro **por dónde venía** esa variable —una tupla tres líneas más arriba—, no por cómo estaba escrita la línea. El día que alguien añada un filtro genérico por campo y pase el nombre desde la petición, esa misma línea se convierte en una inyección sin dar ninguna señal. Ahora el fragmento entero va en la tupla (`"kind = ?"`), y de paso el fichero queda coherente: los filtros de fecha ya eran literales.
+
+**El formato de las fechas.** `created_at` se compara entre cadenas, lo que sólo reproduce el orden cronológico si todo se escribe igual. Se comprobó que hoy acierta, incluso mezclando marcas con microsegundos y sin ellos: el carácter que sigue a los segundos es `.` (46) si los hay y `+` (43) si no, y 46 > 43, que es justo el orden correcto. Acierta por la tabla ASCII, no por diseño. Pero dependía de que **tres sitios** —el `INSERT`, el corte de la poda y los filtros— se acordaran de usar `isoformat()` en UTC. Un sufijo `Z` es el carácter 90 y ordena después de cualquier desfase: mezclarlo rompería las comparaciones en silencio. Todo pasa ahora por una única función.
+
+#### Detalles que costarían una tarde
+
+**El `+` de los desfases horarios.** En una cadena de consulta `+` significa espacio, así que `?since=2026-08-14T00:00:00+00:00` escrito a mano llega como `...00:00:00 00:00` y devuelve 422. No es un fallo de la API —cualquier cliente que codifique sus parámetros funciona— pero está avisado en la descripción del parámetro, que es donde lo verá quien genere el cliente Angular. La forma con sufijo `Z` no tiene el problema.
+
+**El `payload` corrupto.** Ninguna ruta del código puede producirlo: `_guardar` es el único sitio que escribe esa columna y siempre con `json.dumps`. Aun así, una sola fila rota dejaría ilegible el historial entero. Se descartó capturar el error y devolver `{}` —sustituye datos corruptos por datos falsos en silencio, y este sistema declara sus límites en vez de esconderlos— y se optó por que **siga fallando pero diciendo qué fila**: un `JSONDecodeError` pelado no identifica la entrada entre mil.
+
+#### Qué encontró revisar, frente a qué encontró medir
+
+Se aprovechó el issue para probar si una revisión automática sustituye al trabajo a mano. El resultado, con todas las cifras:
+
+| Origen | Resultado |
+|---|---|
+| Revisión multiagente en la nube (75 ficheros, 7.402 líneas) | **0 hallazgos** |
+| Revisión externa, primera tanda | 5 propuestas → 2 falsas, 2 insignificantes (0,005 % y 0,004 %), 1 buena |
+| Revisión externa, segunda tanda | 3 propuestas → 0 bugs, 2 invariantes frágiles que sí valía reforzar |
+| Medir a mano | la conexión sin cerrar, WAL descartado, el `COUNT(*)` lineal, la contaminación de tests, la convergencia de la poda, y cuatro afirmaciones propias desmentidas |
+
+La lectura: **lo que encontró cosas no fue revisar, fue medir.** Lo que aportaron las revisiones no fueron fallos sino la sospecha de que algo era correcto por accidente — y eso resultó ser un tipo de hallazgo útil, distinto del que se busca normalmente. Ninguna de las tres detectó un solo bug real.
+
+Se añade `ASYNC` al conjunto de reglas de ruff, que detecta llamadas bloqueantes dentro de funciones asíncronas. Con la advertencia de que **no conoce `sqlite3`**, así que el caso concreto de este issue se le habría escapado igual.
+
 ### Metadata de las tools: categoría y procedencia (#97, primera parte)
 
 El catálogo necesita saber, de cada herramienta, **qué tipo de trabajo hace** y **de dónde viene**. El objeto `Tool` del protocolo MCP trae nombre, descripción y esquema, pero ninguna de esas dos cosas. MCP sí permite adjuntar un `meta` libre por herramienta, y se comprobó que **viaja intacto hasta el cliente**, así que la información se declara en el origen en vez de en un mapa cableado en la API — que obligaría a editarla cada vez que se añade una fuente, justo lo que R1.9 prohíbe.

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -21,6 +21,7 @@ conectadas en runtime no se puede hacer importando módulos.
 """
 
 from contextlib import asynccontextmanager
+from datetime import datetime
 from typing import Annotated
 
 import structlog
@@ -41,6 +42,7 @@ from backend.api.schemas import (
     HistoryKind,
     HistoryPage,
     Origin,
+    RetentionPolicy,
 )
 from backend.config.settings import settings
 from backend.core.health import check_health
@@ -189,6 +191,48 @@ async def post_execute(name: str, request: ExecuteRequest) -> ExecuteResponse:
 async def get_history(
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
     offset: Annotated[int, Query(ge=0)] = 0,
+    kind: Annotated[
+        HistoryKind | None,
+        Query(description="`analysis` o `tool`. Las pestañas de la pantalla."),
+    ] = None,
+    tool: Annotated[
+        str | None,
+        Query(
+            max_length=100,
+            description=(
+                "Nombre de la herramienta. Sólo casa con ejecuciones sueltas: un "
+                "análisis invoca cinco señales y no tiene *una* herramienta."
+            ),
+        ),
+    ] = None,
+    verdict: Annotated[
+        str | None,
+        Query(
+            max_length=50,
+            description="Qué CONCLUYÓ el análisis: `enganoso`, `factual`, `ambiguo`…",
+        ),
+    ] = None,
+    status: Annotated[
+        str | None,
+        Query(
+            max_length=50,
+            description="Si funcionó la MAQUINARIA: `ok` o `error`. Filtro operativo.",
+        ),
+    ] = None,
+    since: Annotated[
+        datetime | None,
+        Query(
+            description=(
+                "Desde esta fecha, inclusive. Ojo: en una cadena de consulta `+` "
+                "significa ESPACIO, así que un desfase escrito a pelo "
+                "(`...T00:00:00+00:00`) llega roto y devuelve 422. Usa el sufijo "
+                "`Z` o codifica el parámetro."
+            )
+        ),
+    ] = None,
+    until: Annotated[
+        datetime | None, Query(description="Hasta esta fecha, inclusive.")
+    ] = None,
 ) -> HistoryPage:
     """Análisis y ejecuciones anteriores, del más reciente al más antiguo.
 
@@ -208,13 +252,38 @@ async def get_history(
     El mínimo de 1 no es cosmético: en SQLite un **LIMIT negativo significa «sin
     límite»**, así que `?limit=-1` no daría error, traería la tabla ENTERA a
     memoria y la serializaría. Es el borde que hay que tapar, no el `?limit=9999`.
+
+    Los filtros se acumulan con AND y el `total` se calcula **ya filtrado**, para
+    que la interfaz no pinte «1-3 de 500» sobre una lista de tres.
+
+    Hay dos parámetros donde el criterio hablaba de uno, y no es un descuido:
+    `verdict` es **qué concluyó el análisis** y es el que le importa a quien mira
+    sus análisis; `status` es **si funcionó la maquinaria** y es operativo. En la
+    pantalla sólo el primero merece sitio destacado.
+
+    La respuesta incluye `retention` para que la interfaz pueda explicar por qué
+    faltan los análisis viejos y acotar el selector de fechas sin cablear los
+    números.
     """
-    filas, total = await history.query(limit, offset)
+    filas, total = await history.query(
+        limit,
+        offset,
+        kind=kind,
+        tool=tool,
+        verdict=verdict,
+        status=status,
+        since=since,
+        until=until,
+    )
     return HistoryPage(
         items=[HistoryEntry(**fila) for fila in filas],
         total=total,
         limit=limit,
         offset=offset,
+        retention=RetentionPolicy(
+            max_entries=settings.history_max_entries,
+            max_days=settings.history_max_days,
+        ),
     )
 
 

--- a/backend/api/history.py
+++ b/backend/api/history.py
@@ -23,7 +23,7 @@ import json
 import sqlite3
 from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +58,20 @@ CREATE TABLE IF NOT EXISTS history (
     payload    TEXT NOT NULL
 );
 """
+
+# Va como sentencia aparte porque `execute` ejecuta UNA sola: pegarlo al final
+# de `_ESQUEMA` no lo crearía. (`executescript` sí acepta varias, pero emite un
+# COMMIT implícito antes, y eso dentro de una transacción es lo contrario de lo
+# que queremos.)
+#
+# Sin este índice, `created_at < ?` recorre y compara la tabla entera. Medido
+# sobre 1000 filas: 2374 µs sin índice frente a 0,99 µs con él, y la diferencia
+# CRECE con el tamaño (54 595 µs a 50 000 filas, frente a los mismos ~1 µs).
+# Y no se paga al insertar: 14,29 µs sin índice contra 13,91 µs con él, o sea
+# por debajo del ruido de medida.
+_INDICE_FECHA = (
+    "CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at)"
+)
 
 
 def _ruta_db() -> Path:
@@ -108,6 +122,7 @@ def _conectar() -> Generator[sqlite3.Connection, None, None]:
     conexion = sqlite3.connect(ruta)
     conexion.row_factory = sqlite3.Row  # Usar Row para poder acceder a las columnas por nombre en lugar de por índice. (fila["columna"] en lugar de fila[0])
     conexion.execute(_ESQUEMA)
+    conexion.execute(_INDICE_FECHA)
     try:
         with conexion:  # transacción: commit al salir bien, rollback si hay excepción
             yield conexion
@@ -124,6 +139,59 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 # ? son placeholders que se sustituyen por los valores de la tupla en el segundo argumento de execute. Esto evita inyecciones SQL y problemas de comillas.
+
+# Poda por cantidad. Parece la fórmula ingenua —«resta N al mayor id»— y hay que
+# explicar por qué aquí es EXACTA, porque a simple vista no lo parece.
+#
+# Restar del máximo sólo da «la N-ésima más nueva» si los ids son CONTIGUOS. Lo
+# son, y está comprobado: la poda borra siempre por la cola, así que deja un
+# bloque sin huecos; y `AUTOINCREMENT` NO quema el id al revertir una transacción
+# —el contador se deshace con ella—, así que una inserción fallida tampoco los
+# crea. Lo que `AUTOINCREMENT` garantiza es otra cosa: que un id no se REUTILICE
+# tras borrar, para que el 40 podado no reaparezca señalando otro análisis.
+#
+# Si algún día algo borrara filas del MEDIO (p. ej. «fijar un análisis para que
+# no se pierda»), aparecerían huecos, el corte caería más arriba y se conservarían
+# algo MENOS de N. Nunca más: el techo se respeta siempre, sólo el suelo se vuelve
+# aproximado.
+#
+# Se eligió frente a la subconsulta con MIN (801 µs) porque cuesta 17,7 µs y es
+# constante con el tamaño de la tabla: `MAX(id)` es el extremo derecho del índice
+# de la clave primaria, y `id <= corte` arranca por el izquierdo y para enseguida.
+# Se descartó «borrar sólo la más vieja» (14,4 µs) porque NO converge: mantiene el
+# tamaño de partida en vez de llevarlo al límite, así que con 500 filas y techo de
+# 1000 seguía borrando una por escritura. Barata e incorrecta.
+_PODA_CANTIDAD = "DELETE FROM history WHERE id <= (SELECT MAX(id) FROM history) - ?"
+
+# Poda por antigüedad. La comparación de cadenas basta porque las marcas se
+# guardan en ISO 8601, donde el orden alfabético coincide con el cronológico.
+_PODA_ANTIGUEDAD = "DELETE FROM history WHERE created_at < ?"
+
+
+def _podar(conexion: sqlite3.Connection) -> None:
+    """Recorta el historial a los límites configurados. `0` desactiva cada uno.
+
+    Se ejecuta AL ESCRIBIR, dentro de la transacción del `INSERT`. Es lo que hace
+    que salga prácticamente gratis: una escritura ya paga un `fsync`, y estas dos
+    sentencias viajan en ese mismo commit sin añadir otro (medido: ninguna
+    variante se acercó al doble de la referencia).
+
+    Las otras dos opciones se descartaron. **Programada** exige un proceso vivo y
+    un planificador para algo que aquí no lo necesita. **Al leer** es lo peor de
+    ambas: convierte una consulta en una operación destructiva.
+
+    Que la poda por cantidad reduzca —y no sólo mantenga— es lo que evita tener
+    que escribir una migración: al desplegar esto sobre una base que ya venía
+    creciendo sin techo, la primera escritura la deja en su sitio de una sola
+    sentencia. (Si nadie escribe, nadie poda: la tabla se queda como está, que es
+    inofensivo porque tampoco crece, y se corrige con el primer análisis.)
+    """
+    if settings.history_max_entries > 0:
+        conexion.execute(_PODA_CANTIDAD, (settings.history_max_entries,))
+
+    if settings.history_max_days > 0:
+        corte = datetime.now(timezone.utc) - timedelta(days=settings.history_max_days)
+        conexion.execute(_PODA_ANTIGUEDAD, (corte.isoformat(),))
 
 
 def _guardar(
@@ -149,7 +217,18 @@ def _guardar(
                 json.dumps(payload, ensure_ascii=False),
             ),
         )
-        return cursor.lastrowid  # Devuelve el id de la fila insertada, que es útil para referenciarla después.
+        identificador = cursor.lastrowid  # Devuelve el id de la fila insertada, que es útil para referenciarla después.
+
+        # Va DENTRO de la misma transacción, a propósito: es lo que hace que se
+        # cuele en el `fsync` que el INSERT ya estaba pagando.
+        #
+        # El precio de esa decisión: si la poda falla, se deshace también el
+        # INSERT, y como `record` se traga los errores el síntoma sería «el
+        # historial dejó de guardar» sin ruido. Separarlas en dos transacciones lo
+        # evitaría, pero perdería el ahorro que justifica podar al escribir.
+        _podar(conexion)
+
+        return identificador
 
 
 async def record(

--- a/backend/api/history.py
+++ b/backend/api/history.py
@@ -140,6 +140,41 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 
 # ? son placeholders que se sustituyen por los valores de la tupla en el segundo argumento de execute. Esto evita inyecciones SQL y problemas de comillas.
 
+
+def _marca(momento: datetime) -> str:
+    """Convierte una fecha en el texto que se guarda: ISO 8601 en UTC.
+
+    **Pasa por aquí TODO lo que toca `created_at`** —lo que se escribe, el corte
+    de la poda y los filtros—, y esa es la razón de que exista en vez de llamar a
+    `isoformat()` en cada sitio.
+
+    El motivo: `created_at` se compara **entre cadenas**, y eso sólo reproduce el
+    orden cronológico si todas están escritas igual. Comprobado que hoy lo están,
+    y que las comparaciones aciertan incluso mezclando marcas con microsegundos y
+    sin ellos —el carácter que sigue a los segundos es `.` (46) si los hay y `+`
+    (43) si no, y 46 > 43, que es justo el orden correcto—.
+
+    Pero era correcto **por un invariante que nada imponía**: que tres sitios
+    distintos se acordaran de usar `isoformat()` en UTC. La demostración de qué
+    pasaría si uno se despistara: un sufijo `Z` es el carácter 90, ordena después
+    de CUALQUIER desfase, y mezclarlo con `+00:00` sí rompe las comparaciones —en
+    silencio, descartando o colando filas sin ningún error. Centralizarlo aquí no
+    arregla un fallo: arregla que la corrección dependa de la memoria de quien
+    escriba el siguiente `INSERT`.
+
+    Una fecha sin huso se toma como UTC y no como hora local, para que el
+    resultado no dependa de la máquina donde corra el servidor.
+    """
+    if momento.tzinfo is None:
+        momento = momento.replace(tzinfo=timezone.utc)
+    return momento.astimezone(timezone.utc).isoformat()
+
+
+def _ahora() -> str:
+    """El instante actual, en el formato en que se guarda."""
+    return _marca(datetime.now(timezone.utc))
+
+
 # Poda por cantidad. Parece la fórmula ingenua —«resta N al mayor id»— y hay que
 # explicar por qué aquí es EXACTA, porque a simple vista no lo parece.
 #
@@ -191,7 +226,7 @@ def _podar(conexion: sqlite3.Connection) -> None:
 
     if settings.history_max_days > 0:
         corte = datetime.now(timezone.utc) - timedelta(days=settings.history_max_days)
-        conexion.execute(_PODA_ANTIGUEDAD, (corte.isoformat(),))
+        conexion.execute(_PODA_ANTIGUEDAD, (_marca(corte),))
 
 
 def _guardar(
@@ -207,7 +242,7 @@ def _guardar(
         cursor = conexion.execute(
             _INSERT,
             (
-                datetime.now(timezone.utc).isoformat(),
+                _ahora(),
                 kind.value,
                 origin.value,
                 headline,
@@ -260,8 +295,76 @@ async def record(
         return None
 
 
+def _condiciones(
+    kind: HistoryKind | None,
+    tool: str | None,
+    verdict: str | None,
+    status: str | None,
+    since: datetime | None,
+    until: datetime | None,
+) -> tuple[str, list[Any]]:
+    """Construye el `WHERE` con los filtros que vengan, y sus valores aparte.
+
+    Esto COMPONE una cadena SQL, que es el patrón que a primera vista parece una
+    inyección. La regla que hay que cumplir no es «el texto tiene que ser un
+    literal», sino algo más preciso: **ningún dato que venga de fuera puede
+    llegar al texto de la consulta**. Aquí lo que se acumula en `condiciones` son
+    fragmentos escritos en este fichero; los valores del usuario viajan aparte,
+    por `?`, en la lista de parámetros.
+
+    Los fragmentos van ENTEROS en la tupla (`"kind = ?"`) y no compuestos con un
+    f-string a partir del nombre de columna. Compuestos también serían seguros
+    —el nombre saldría igualmente de aquí— pero lo serían por DÓNDE viene esa
+    variable, no por cómo está escrita la línea: un invariante que vive a tres
+    líneas de distancia y que nada impone. El día que alguien añada un filtro
+    genérico por campo y pase el nombre desde la petición, esa misma línea se
+    convierte en una inyección sin dar ninguna señal. Un literal no puede
+    degradarse así.
+
+    Los filtros se combinan con AND: son restricciones acumulativas, que es lo
+    que espera quien va marcando casillas en una pantalla.
+    """
+    condiciones: list[str] = []
+    valores: list[Any] = []
+
+    # `tool` sólo tiene sentido sobre las ejecuciones sueltas: un análisis invocó
+    # CINCO herramientas, así que no hay una por la que filtrarlo. En la pantalla
+    # eso se resuelve mostrando el desplegable de herramientas únicamente dentro
+    # de la pestaña «Herramientas», de modo que la restricción no se explica: se
+    # ve. Aquí simplemente no casará con ninguna entrada de análisis, porque su
+    # columna `tool` es nula.
+    for condicion, valor in (
+        ("kind = ?", kind.value if kind else None),
+        ("tool = ?", tool),
+        ("verdict = ?", verdict),
+        ("status = ?", status),
+    ):
+        # `is not None` y no `if valor`: una cadena vacía o un 0 son valores
+        # legítimos, y con la comprobación por verdad se tratarían como «no vino».
+        if valor is not None:
+            condiciones.append(condicion)
+            valores.append(valor)
+
+    if since is not None:
+        condiciones.append("created_at >= ?")
+        valores.append(_marca(since))
+    if until is not None:
+        condiciones.append("created_at <= ?")
+        valores.append(_marca(until))
+
+    where = f" WHERE {' AND '.join(condiciones)}" if condiciones else ""
+    return where, valores
+
+
 def _leer(
-    limit: int, offset: int
+    limit: int,
+    offset: int,
+    kind: HistoryKind | None = None,
+    tool: str | None = None,
+    verdict: str | None = None,
+    status: str | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
 ) -> tuple[
     list[dict[str, Any]], int
 ]:  # Devuelve una página del historial y el total de entradas. El total lo necesita la interfaz para paginar («1-20 de 137»); sin él sólo puede saber si hay más página probando a pedirla.
@@ -269,8 +372,15 @@ def _leer(
     # Tuple: Devuelve una tupla con dos elementos: una lista de diccionarios que representan las entradas del historial y un entero que indica el total de entradas en la base de datos.
     # Dict[str, Any]: Cada diccionario tiene claves de tipo str y valores de cualquier tipo (Any), lo que permite almacenar información diversa sobre cada entrada del historial.
 
+    where, valores = _condiciones(kind, tool, verdict, status, since, until)
+
     with _conectar() as conexion:
-        total = conexion.execute("SELECT COUNT(*) FROM history").fetchone()[0]
+        # El COUNT lleva el MISMO `WHERE` que la consulta: el total tiene que ser
+        # el de las entradas que casan con el filtro, no el de la tabla entera, o
+        # la interfaz pintaría «1-3 de 500» sobre una lista de tres.
+        total = conexion.execute(
+            f"SELECT COUNT(*) FROM history{where}", valores
+        ).fetchone()[0]
         # fetchone() devuelve una tupla con un solo elemento, que es el resultado de la consulta COUNT(*). Se accede a ese elemento con [0] para obtener el número total de entradas en la tabla history.
         # Orden por id descendente: más estable que timestamp.
         #
@@ -289,8 +399,8 @@ def _leer(
         # declaración deliberada, y mueve el fallo aquí dentro, que es su sitio.
         filas = conexion.execute(
             "SELECT id, created_at, kind, origin, headline, tool, verdict, status, payload "
-            "FROM history ORDER BY id DESC LIMIT ? OFFSET ?",
-            (limit, offset),
+            f"FROM history{where} ORDER BY id DESC LIMIT ? OFFSET ?",
+            (*valores, limit, offset),
         ).fetchall()
 
         # LIMIT ? OFFSET ? es la paginación: "sáltate offset filas y dame las limit siguientes". Página 1: LIMIT 20 OFFSET 0; página 2 : LIMIT 20 OFFSET 20.
@@ -308,16 +418,51 @@ def _desempaquetar(fila: sqlite3.Row) -> dict[str, Any]:
     driver ya devolvería el objeto construido, así que ese `json.loads` de fuera
     reventaría con un TypeError. El aislamiento incluye el formato, no sólo el
     motor: entra un diccionario, sale un diccionario.
+
+    Si el JSON estuviera corrupto **falla, y dice qué fila**. Ninguna ruta del
+    código puede producirlo —`_guardar` es el único sitio que escribe `payload` y
+    siempre con `json.dumps`, y la columna es NOT NULL— así que esto sólo salta si
+    alguien ha editado la base a mano. Aun así se identifica la entrada, porque un
+    `JSONDecodeError` pelado no dice cuál de las mil está rota y obligaría a
+    buscarla a ojo.
+
+    Se descartó lo contrario —capturar y devolver `{}`— aunque evitaría que una
+    fila mala dejara ilegible el historial entero: sustituye datos corruptos por
+    datos falsos **en silencio**, y un sistema cuya tesis es declarar sus límites
+    en vez de esconderlos no debería inventarse un payload vacío y seguir.
     """
     entrada = dict(fila)
-    entrada["payload"] = json.loads(entrada["payload"])
+    try:
+        entrada["payload"] = json.loads(entrada["payload"])
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"El payload de la entrada {entrada['id']} no es JSON válido."
+        ) from exc
     return entrada
 
 
-async def query(limit: int, offset: int) -> tuple[list[dict[str, Any]], int]:
-    """Devuelve una página del historial y el total de entradas.
+async def query(
+    limit: int,
+    offset: int,
+    kind: HistoryKind | None = None,
+    tool: str | None = None,
+    verdict: str | None = None,
+    status: str | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+) -> tuple[list[dict[str, Any]], int]:
+    """Devuelve una página del historial y el total de entradas que casan.
 
     El total lo necesita la interfaz para paginar («1-20 de 137»); sin él sólo
-    puede saber si hay más página probando a pedirla.
+    puede saber si hay más página probando a pedirla. Con filtros aplicados es
+    el total de lo filtrado, no el de la tabla.
+
+    `verdict` y `status` responden preguntas distintas y por eso son dos y no
+    uno: el veredicto es **qué concluyó el análisis** (`enganoso`, `factual`…) y
+    es el que le interesa a quien mira sus análisis; el estado es **si funcionó
+    la maquinaria**, y es operativo. Meterlos en un solo parámetro «estado» era
+    lo que hacía que el criterio no encajara.
     """
-    return await asyncio.to_thread(_leer, limit, offset)
+    return await asyncio.to_thread(
+        _leer, limit, offset, kind, tool, verdict, status, since, until
+    )

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -401,16 +401,40 @@ class HistoryEntry(BaseModel):
     )
 
 
+class RetentionPolicy(BaseModel):
+    """Política de retención vigente, para que la interfaz no la cablee.
+
+    Va en la respuesta porque la pantalla la necesita para dos cosas, y las dos
+    son de usabilidad, no de adorno:
+
+    1. **Explicar por qué faltan análisis viejos.** La poda es invisible, y eso
+       es justo el problema: quien analizó algo hace cuarenta días y no lo
+       encuentra no piensa «se habrá podado», piensa que la aplicación ha perdido
+       sus datos. Un borrado silencioso se lee como un fallo.
+    2. **Acotar el selector de fechas.** Un calendario libre que permita pedir
+       «hace seis meses» y devuelva siempre vacío es una mala experiencia.
+
+    Y va aquí en vez de como constantes en Angular para que esos números salgan
+    de la configuración REAL: cableados, se desincronizarían el día que cambie
+    el `.env` y la pantalla seguiría prometiendo 30 días.
+    """
+
+    max_entries: int = Field(description="Entradas conservadas. 0 = sin límite.")
+    max_days: int = Field(description="Días conservados. 0 = sin límite.")
+
+
 class HistoryPage(BaseModel):
     """Una página del historial, en orden cronológico inverso."""
 
     items: list[HistoryEntry]
     total: int = Field(
         description=(
-            "Entradas totales, no las de esta página. La interfaz lo necesita "
-            "para paginar; sin él sólo puede saber si hay más pidiendo la "
-            "siguiente."
+            "Entradas totales que casan con el filtro, no las de esta página. La "
+            "interfaz lo necesita para paginar; sin él sólo puede saber si hay "
+            "más pidiendo la siguiente. Ojo con leerlo como «cuántos análisis he "
+            "hecho»: con retención activa es «cuántos se conservan»."
         )
     )
     limit: int
     offset: int
+    retention: RetentionPolicy

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -72,5 +72,23 @@ class Settings(BaseSettings):
     # historial sobreviva al contenedor.
     history_db: str = "var/history.db"
 
+    # Retención del historial. `0` desactiva cada límite por separado.
+    #
+    # Son configuración y no constantes porque el criterio propone «las últimas
+    # 1000 ejecuciones o 30 días» COMO EJEMPLO, no como norma. Y porque en
+    # desarrollo interesa desactivarlos (`HISTORY_MAX_ENTRIES=0`) para no perder
+    # las pruebas propias entre sesiones.
+    #
+    # Se aplican los dos: manda el más estricto. Uno acota el TAMAÑO pero no el
+    # horizonte temporal —mil análisis de golpe borran los de ayer— y el otro
+    # acota el horizonte pero no el tamaño —una ráfaga de 50 000 cabe entera en
+    # 30 días—. Cada uno tapa el punto ciego del otro.
+    #
+    # No es sólo higiene de disco: `GET /history` cuenta las filas en cada
+    # lectura y ese conteo es LINEAL (~1 µs por fila, medido). Sin techo, a
+    # 50 000 entradas cada petición gasta 50 ms sólo en contar.
+    history_max_entries: int = 1000
+    history_max_days: int = 30
+
 
 settings = Settings()  # type: ignore #Activa la validación al importar

--- a/docs/requisitos.md
+++ b/docs/requisitos.md
@@ -160,7 +160,7 @@ Este documento define los requisitos para un Trabajo de Fin de Grado (TFG) que i
 1. LA Backend_API DEBERÁ conservar los registros de ejecución de herramientas en una base de datos o un almacenamiento de archivos.
 2. CUANDO se ejecute una herramienta, LA Backend_API DEBERÁ almacenar el nombre de la herramienta, los parámetros, el resultado, la marca de tiempo y el estado de ejecución.
 3. LA Backend_API DEBERÁ proporcionar un endpoint para recuperar el historial de ejecución con paginación.
-4. LA Backend_API DEBERÁ admitir el filtrado del historial de ejecución por nombre de herramienta, intervalo de fechas y estado.
+4. LA Backend_API DEBERÁ admitir el filtrado del historial de ejecución por nombre de herramienta, intervalo de fechas y estado. _(Dos ajustes por el cambio de qué se guarda —análisis, no invocaciones—: «nombre de herramienta» se satisface sobre las **ejecuciones sueltas**, que sí tienen una, mientras que un análisis invoca cinco señales y se filtra por **tipo de entrada**; y «estado» se desdobla en **veredicto** —qué concluyó el análisis— y **estado de ejecución** —si funcionó la maquinaria—, porque un análisis puede tener tres señales bien y una caída. Ver memoria de cambios.)_
 5. LA Backend_API DEBERÁ limitar el almacenamiento del historial para evitar un crecimiento ilimitado (por ejemplo, conservar las últimas 1000 ejecuciones o 30 días).
 6. AL consultar el historial, LA Backend_API DEBERÁ devolver los resultados en orden cronológico inverso.
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -16,7 +16,17 @@ select = [
     "C4",  # comprehensions
     "DTZ", # datetimes sin zona horaria
     "RUF", # reglas propias de ruff
+    "ASYNC", # llamadas bloqueantes dentro de un `async def`
 ]
+
+# Sobre `ASYNC`: detecta `open()`, `time.sleep()`, `subprocess` y clientes HTTP
+# síncronos dentro de funciones asíncronas — la clase de error que consiste en
+# olvidar el `asyncio.to_thread` y congelar el bucle de eventos entero mientras
+# dura una operación de disco o de red.
+#
+# Con una limitación que conviene saber: NO conoce `sqlite3`, así que el caso
+# concreto del historial se le habría escapado. Se activa igualmente porque es
+# gratis y cubre la familia; pero no sustituye a mirar.
 
 # NO se selecciona `BLE` (blind-except) a propósito: capturar `Exception` en las
 # fronteras de integración es DELIBERADO, y es lo que sostiene el aislamiento de

--- a/spikes/bench_poda_convergencia.py
+++ b/spikes/bench_poda_convergencia.py
@@ -1,0 +1,181 @@
+"""Formulaciones de la poda por cantidad: .convergen, y cuanto cuestan?
+
+El banco anterior midio la variante (c) -borrar solo la mas vieja- empezando
+justo en el limite, asi que el '-> quedan 1000 filas' salio por construccion y
+no porque la poda funcione. (c) borra incondicionalmente: MANTIENE el tamano de
+partida, no converge al limite.
+
+Aqui se comprueba lo que de verdad importa de una poda: que desde CUALQUIER
+tamano inicial acabe en el limite. Y ademas cuanto cuesta hacerlo.
+
+RESULTADOS (2026-08-14, limite fijo en 1000)
+
+  0) AUTOINCREMENT y los huecos
+       tras 1 insercion REVERTIDA y 1 confirmada, el id de la fila es 1
+       -> NO quema el id al revertir: el contador se deshace con la transaccion
+
+  1) convergencia (200 escrituras con poda)
+                                     desde 500    desde 3000
+       (a) MIN sobre subconsulta       -> 700       -> 1000    OK
+       (c) mas vieja, SIN guarda       -> 500       -> 3000    NO CONVERGE
+       (d) corte por MAX(id) - N       -> 700       -> 1000    OK
+
+  2) coste en regimen estacionario (solo la poda, sin el INSERT)
+       (a) MIN sobre subconsulta       801.08 us
+       (c) mas vieja, SIN guarda        14.39 us
+       (d) corte por MAX(id) - N        17.71 us
+
+CONCLUSIONES
+
+Gana (d): converge desde ambos lados y es 45x mas barata que (a).
+
+(c) queda descartada aunque sea la mas rapida: NO converge. Borra
+incondicionalmente, asi que MANTIENE el tamano de partida — con 500 filas y techo
+de 1000 seguia borrando una por escritura, que es perdida de datos silenciosa.
+Barata e incorrecta, la peor combinacion.
+
+Las dos mitades del criterio significan cosas distintas:
+  - Desde ABAJO es CORRECCION: borrar por debajo del limite destruye datos que la
+    politica dice conservar.
+  - Desde ARRIBA es la RUTA DE ACTUALIZACION, y no es hipotetica: el historial
+    lleva creciendo sin techo desde #102, asi que al desplegar la retencion lo
+    primero que se encuentra es una tabla por encima del limite. Que (d) reduzca
+    de golpe —de 3000 a 1000 en UNA sentencia— es lo que evita una migracion.
+
+Sobre el punto 0: la prueba de huecos resulto VACUA. Se crearon 100 inserciones
+revertidas esperando huecos y no hay huecos que crear. Que (d) salga clavada en
+1000 es correcto, pero no por resistir huecos: por no haberlos. Los ids son
+contiguos en este diseno —la poda borra por la cola y el rollback no quema ids—,
+y eso es lo que convierte a (d) de aproximada en EXACTA.
+"""
+
+import json
+import sqlite3
+import sys
+import tempfile
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ESQUEMA = """
+CREATE TABLE IF NOT EXISTS history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, created_at TEXT NOT NULL,
+    kind TEXT NOT NULL, origin TEXT NOT NULL, headline TEXT, tool TEXT,
+    verdict TEXT, status TEXT NOT NULL, payload TEXT NOT NULL);
+"""
+INSERT = """
+INSERT INTO history (created_at, kind, origin, headline, tool, verdict, status, payload)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+PODA_A = ("(a) MIN sobre subconsulta",
+          "DELETE FROM history WHERE id < "
+          "(SELECT MIN(id) FROM (SELECT id FROM history ORDER BY id DESC LIMIT ?))")
+PODA_C = ("(c) mas vieja, SIN guarda",
+          "DELETE FROM history WHERE id = (SELECT MIN(id) FROM history)")
+PODA_D = ("(d) corte por MAX(id) - N",
+          "DELETE FROM history WHERE id <= (SELECT MAX(id) FROM history) - ?")
+
+PAYLOAD = json.dumps({"signals": [{"n": f"s{i}", "d": "x" * 400} for i in range(5)]})
+AHORA = datetime.now(timezone.utc)
+LIMITE = 1000
+
+
+def fila(dias=0):
+    return ((AHORA - timedelta(days=dias)).isoformat(), "analysis", "api",
+            "Un titular", None, "clickbait", "ok", PAYLOAD)
+
+
+def db(filas=0):
+    ruta = Path(tempfile.mkdtemp()) / "history.db"
+    con = sqlite3.connect(ruta)
+    con.execute("PRAGMA synchronous=OFF")
+    con.execute(ESQUEMA)
+    if filas:
+        with con:
+            con.executemany(INSERT, [fila() for _ in range(filas)])
+    return con
+
+
+def contar(con):
+    return con.execute("SELECT COUNT(*) FROM history").fetchone()[0]
+
+
+print(f"Python {sys.version.split()[0]} | SQLite {sqlite3.sqlite_version}")
+print(f"Limite = {LIMITE}\n")
+
+# ------------------------------------------------------------------ 0
+print("=== 0) .AUTOINCREMENT quema el id al revertir la transaccion? ===")
+print("    Es de donde vienen los huecos, y de lo que depende que (d) sea")
+print("    conservadora en vez de incorrecta.\n")
+
+con = db()
+con.execute("BEGIN")
+con.execute(INSERT, fila())
+con.execute("ROLLBACK")
+con.execute("BEGIN")
+con.execute(INSERT, fila())
+con.commit()
+primero = con.execute("SELECT MIN(id) FROM history").fetchone()[0]
+print(f"  tras 1 insercion REVERTIDA y 1 confirmada, el id de la fila es: {primero}")
+print(f"  -> {'SI quema el id (hay huecos)' if primero > 1 else 'NO quema el id (sin huecos)'}\n")
+con.close()
+
+# ------------------------------------------------------------------ 1
+print("=== 1) .Converge al limite desde cualquier tamano de partida? ===")
+print("    200 escrituras con poda. Desde 500 deberia CRECER hacia 700 (nada")
+print("    que podar). Desde 3000 deberia BAJAR a 1000.\n")
+
+for etiqueta, sql in (PODA_A, PODA_C, PODA_D):
+    parametros = () if sql == PODA_C[1] else (LIMITE,)
+    resultados = []
+    for inicial in (500, 3000):
+        con = db(inicial)
+        for _ in range(200):
+            with con:
+                con.execute(INSERT, fila())
+                con.execute(sql, parametros)
+        resultados.append((inicial, contar(con)))
+        con.close()
+    detalle = "   ".join(f"desde {i} -> {f}" for i, f in resultados)
+    ok = resultados[0][1] == 700 and resultados[1][1] == LIMITE
+    print(f"  {etiqueta:<32} {detalle:<34} {'OK' if ok else 'NO CONVERGE'}")
+
+# ------------------------------------------------------------------ 2
+print("\n=== 2) Coste en regimen estacionario (solo la poda, sin el INSERT) ===\n")
+
+for etiqueta, sql in (PODA_A, PODA_C, PODA_D):
+    parametros = () if sql == PODA_C[1] else (LIMITE,)
+    con = db(LIMITE)
+    tiempos = []
+    for _ in range(1000):
+        con.execute(INSERT, fila())
+        t0 = time.perf_counter()
+        con.execute(sql, parametros)
+        tiempos.append(time.perf_counter() - t0)
+    con.commit()
+    media = sum(tiempos) / len(tiempos) * 1e6
+    print(f"  {etiqueta:<32} {media:9.2f} us/op   -> quedan {contar(con)} filas")
+    con.close()
+
+# ------------------------------------------------------------------ 3
+print("\n=== 3) Con huecos, .cuanto por DEBAJO del limite se queda (d)? ===")
+print("    Un hueco hace que el corte caiga mas arriba: guarda algo menos de")
+print("    1000, nunca mas. La pregunta es cuanto menos.\n")
+
+for huecos in (0, 10, 100):
+    con = db(LIMITE)
+    for _ in range(huecos):  # inserciones revertidas: queman id, no dejan fila
+        try:
+            with con:
+                con.execute(INSERT, fila())
+                raise RuntimeError
+        except RuntimeError:
+            pass
+    for _ in range(200):
+        with con:
+            con.execute(INSERT, fila())
+            con.execute(PODA_D[1], (LIMITE,))
+    print(f"  {huecos:>3} inserciones revertidas -> la tabla se estabiliza en "
+          f"{contar(con)} filas  (techo {LIMITE})")
+    con.close()

--- a/spikes/bench_poda_coste_e_indice.py
+++ b/spikes/bench_poda_coste_e_indice.py
@@ -1,0 +1,216 @@
+"""Mide el coste de la poda antes de decidir donde se ejecuta (#103).
+
+Tres preguntas, en este orden:
+
+A) .Anade el DELETE un fsync? Si viaja en el commit que ya se estaba haciendo,
+   la escritura completa NO deberia cambiar de orden de magnitud. Si anadiera
+   una sincronizacion propia, se duplicaria (~164 -> ~328 ms) y se veria a
+   simple vista incluso con ruido.
+
+B) .Cuanto cuesta la CONSULTA de poda aislada, sin el fsync que la envuelve?
+
+C) .Escala con el tamano de la tabla? Es lo que decide si hace falta indice.
+
+Sobre el metodo de C: en regimen estacionario cada INSERT borra exactamente UNA
+fila, asi que el coste recurrente es 'buscar que borrar' (escala con el tamano)
+mas 'liberar una fila' (constante). Midiendo una poda que NO encuentra nada se
+aisla la parte que escala, y ademas no muta la tabla entre iteraciones.
+
+RESULTADOS (2026-08-14, WSL2 ext4 sobre VHD, Python 3.12.3 / SQLite 3.45.1)
+
+  A) escritura completa, synchronous por defecto
+       INSERT solo (referencia)                          241.5 ms
+       INSERT + poda cantidad [no borra nada]            229.0 ms
+       INSERT + poda cantidad [borra 1 por escritura]    163.8 ms
+       INSERT + poda antiguedad                          189.7 ms
+       INSERT + las dos podas                            202.1 ms
+
+  B/C) consulta aislada, sin fsync
+                                     1 000      10 000      50 000 filas
+       poda ANTIGUEDAD sin indice   2 374 us   11 113 us   54 595 us
+       poda ANTIGUEDAD con indice     0.99 us     1.02 us     0.97 us
+
+  D) coste del indice al INSERTAR
+       sin indice en created_at    14.29 us
+       con indice en created_at    13.91 us
+
+CONCLUSIONES
+
+A) NO SIRVE para medir el sobrecoste, y hay que decirlo: podar sale mas rapido
+   que no podar, lo cual es imposible como efecto real. El ruido del fsync en
+   WSL2 (+-40 %) se come la senal y con n=40 no se promedia. Insistir con mas
+   iteraciones tampoco valdria: la diferencia buscada (~1.6 ms) es el 1 % de una
+   escritura con fsync y nunca se resolveria contra ese ruido.
+
+   Lo unico que si sobrevive es la lectura gruesa, que era la pregunta: ninguna
+   variante se acerca al DOBLE, asi que el DELETE no anade un fsync propio y
+   viaja en el commit que el INSERT ya estaba pagando.
+
+B/C) El indice en created_at es el hallazgo: ~2400x mas rapido a 1000 filas, y
+   CONSTANTE en vez de lineal. Sin el, `created_at < ?` recorre la tabla entera.
+
+D) Y no se paga al escribir: la version CON indice sale mas rapida que la que no
+   lo tiene, o sea que la diferencia esta por debajo del ruido de medida. Es la
+   pregunta que no se le hizo a WAL en #102.
+
+OJO: la parte de 'poda por CANTIDAD' de este banco tiene un FALLO DE DISENO —se
+paso LIMIT = filas + 10, haciendo crecer el limite junto con la tabla— asi que
+sus numeros no miden lo que dicen. Rehecho en bench_poda_limite_fijo_y_count.py.
+"""
+
+import json
+import sqlite3
+import sys
+import tempfile
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ESQUEMA = """
+CREATE TABLE IF NOT EXISTS history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, created_at TEXT NOT NULL,
+    kind TEXT NOT NULL, origin TEXT NOT NULL, headline TEXT, tool TEXT,
+    verdict TEXT, status TEXT NOT NULL, payload TEXT NOT NULL);
+"""
+INSERT = """
+INSERT INTO history (created_at, kind, origin, headline, tool, verdict, status, payload)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+# Buscar el id de la N-esima mas nueva y borrar por debajo. NO vale
+# `MAX(id) - N`: en cuanto la poda ha borrado alguna vez los ids tienen huecos.
+DELETE_CANTIDAD = """
+DELETE FROM history
+WHERE id < (SELECT MIN(id) FROM (SELECT id FROM history ORDER BY id DESC LIMIT ?))
+"""
+DELETE_ANTIGUEDAD = "DELETE FROM history WHERE created_at < ?"
+
+PAYLOAD = json.dumps({"signals": [{"n": f"s{i}", "d": "x" * 400} for i in range(5)]})
+AHORA = datetime.now(timezone.utc)
+
+
+def fila(dias_atras=0):
+    marca = (AHORA - timedelta(days=dias_atras)).isoformat()
+    return (marca, "analysis", "api", "Un titular", None, "clickbait", "ok", PAYLOAD)
+
+
+def nueva_db(filas=0, dias_de_antiguedad=0, indice=False, rapida=True):
+    """Base recien creada, opcionalmente poblada y con indice en created_at."""
+    ruta = Path(tempfile.mkdtemp()) / "history.db"
+    con = sqlite3.connect(ruta)
+    if rapida:
+        con.execute("PRAGMA synchronous=OFF")
+    con.execute(ESQUEMA)
+    if indice:
+        con.execute("CREATE INDEX IF NOT EXISTS idx_created_at ON history(created_at)")
+    if filas:
+        # Repartidas en el tiempo, para que la poda por antiguedad tenga sentido.
+        with con:
+            con.executemany(
+                INSERT,
+                [fila(dias_atras=(i * dias_de_antiguedad) // max(filas, 1)) for i in range(filas)],
+            )
+    con.close()
+    return ruta
+
+
+def bench(etiqueta, fn, n, unidad="ms"):
+    fn()
+    t0 = time.perf_counter()
+    for _ in range(n):
+        fn()
+    por_op = (time.perf_counter() - t0) / n
+    valor = por_op * 1e3 if unidad == "ms" else por_op * 1e6
+    print(f"  {etiqueta:<56} {valor:10.3f} {unidad}/op   (n={n})", flush=True)
+    return valor
+
+
+print(f"Python {sys.version.split()[0]} | SQLite {sqlite3.sqlite_version}", flush=True)
+
+# ------------------------------------------------------------------ A
+print("\n=== A) .Anade el DELETE un fsync? (synchronous por defecto) ===", flush=True)
+print("    Si lo anadiera, se veria un salto de ~164 a ~328 ms.\n", flush=True)
+
+LIMITE = 1000
+N_A = 40
+
+
+def escritura(ruta, podar_cantidad=False, podar_antiguedad=False):
+    def hacer():
+        con = sqlite3.connect(ruta)
+        con.row_factory = sqlite3.Row
+        con.execute(ESQUEMA)
+        try:
+            with con:
+                con.execute(INSERT, fila())
+                if podar_cantidad:
+                    con.execute(DELETE_CANTIDAD, (LIMITE,))
+                if podar_antiguedad:
+                    con.execute(DELETE_ANTIGUEDAD, ((AHORA - timedelta(days=30)).isoformat(),))
+        finally:
+            con.close()
+
+    return hacer
+
+
+base = bench("INSERT solo (referencia)", escritura(nueva_db(rapida=False)), N_A)
+
+# Tabla por debajo del limite: la poda por cantidad no encuentra nada que borrar.
+r = nueva_db(filas=100, rapida=False)
+bench("INSERT + poda cantidad  [no borra nada]", escritura(r, podar_cantidad=True), N_A)
+
+# Regimen estacionario: la tabla esta en el limite, cada INSERT borra 1 fila.
+r = nueva_db(filas=LIMITE, rapida=False)
+estacionario = bench("INSERT + poda cantidad  [borra 1 por escritura]",
+                     escritura(r, podar_cantidad=True), N_A)
+
+r = nueva_db(filas=LIMITE, dias_de_antiguedad=60, rapida=False)
+bench("INSERT + poda antiguedad [borra las de +30 dias]",
+      escritura(r, podar_antiguedad=True), N_A)
+
+r = nueva_db(filas=LIMITE, dias_de_antiguedad=60, rapida=False)
+ambas = bench("INSERT + LAS DOS podas", escritura(r, podar_cantidad=True, podar_antiguedad=True), N_A)
+
+print(f"\n  => sobrecoste de la poda en regimen estacionario: "
+      f"{estacionario - base:+.1f} ms sobre {base:.1f} ms", flush=True)
+print(f"  => con las dos podas:                             "
+      f"{ambas - base:+.1f} ms", flush=True)
+print("  => si estos deltas son ruido y no ~164 ms, el DELETE NO anade fsync", flush=True)
+
+# ------------------------------------------------------------------ B y C
+print("\n=== B/C) Coste de la CONSULTA aislada, y como escala ===", flush=True)
+print("    Sin fsync. La poda no encuentra nada, para aislar la busqueda.\n", flush=True)
+
+VIEJO = (AHORA - timedelta(days=3650)).isoformat()
+
+for filas in (1_000, 10_000, 50_000):
+    print(f"  --- tabla de {filas:,} filas ---".replace(",", " "), flush=True)
+
+    ruta = nueva_db(filas=filas, dias_de_antiguedad=60)
+    con = sqlite3.connect(ruta)
+    con.execute("PRAGMA synchronous=OFF")
+    bench(f"poda por CANTIDAD (id + subconsulta)",
+          lambda: con.execute(DELETE_CANTIDAD, (filas + 10,)), 2000, unidad="us")
+    bench(f"poda por ANTIGUEDAD sin indice en created_at",
+          lambda: con.execute(DELETE_ANTIGUEDAD, (VIEJO,)), 200, unidad="us")
+    con.close()
+
+    ruta = nueva_db(filas=filas, dias_de_antiguedad=60, indice=True)
+    con = sqlite3.connect(ruta)
+    con.execute("PRAGMA synchronous=OFF")
+    bench(f"poda por ANTIGUEDAD CON indice en created_at",
+          lambda: con.execute(DELETE_ANTIGUEDAD, (VIEJO,)), 2000, unidad="us")
+    con.close()
+
+# ------------------------------------------------------------------ D
+print("\n=== D) .Y el coste del indice al ESCRIBIR? ===", flush=True)
+print("    Un indice acelera la lectura y encarece cada insercion: hay que ver", flush=True)
+print("    si lo que ahorra en C lo devuelve aqui.\n", flush=True)
+
+for indice in (False, True):
+    ruta = nueva_db(filas=1000, indice=indice)
+    con = sqlite3.connect(ruta)
+    con.execute("PRAGMA synchronous=OFF")
+    bench(f"INSERT con indice en created_at = {indice}",
+          lambda: con.execute(INSERT, fila()), 2000, unidad="us")
+    con.close()

--- a/spikes/bench_poda_limite_fijo_y_count.py
+++ b/spikes/bench_poda_limite_fijo_y_count.py
@@ -1,0 +1,155 @@
+"""Rehace la parte C del banco anterior, que tenia un fallo de diseno.
+
+El primero paso `LIMIT = filas + 10`, es decir hizo crecer el LIMITE junto con la
+tabla, asi que no midio lo que decia medir. En el sistema real el limite es FIJO
+(1000) sea cual sea el tamano de la tabla.
+
+Tres preguntas:
+
+A) Con limite fijo, .la poda por cantidad es constante o escala con la tabla?
+B) .Hay una forma mas barata de escribirla? Se comparan tres.
+C) SELECT COUNT(*) lo ejecuta GET /history en CADA lectura y en SQLite no esta
+   cacheado. .Cuanto cuesta segun crece la tabla? Esto afecta a lo ya mergeado.
+
+RESULTADOS (2026-08-14, limite fijo en 1000)
+
+  C) regimen estacionario: cada escritura borra UNA fila
+       (a) MIN sobre subconsulta        683.13 us   -> quedan 1000 filas
+       (b) OFFSET sobre el indice       617.86 us   -> quedan 1000 filas
+       (c) borrar solo la mas vieja      16.68 us   -> quedan 1000 filas
+
+  D) SELECT COUNT(*), que GET /history hace en CADA lectura
+       sobre  1 000 filas       886 us
+       sobre 10 000 filas    10 215 us
+       sobre 50 000 filas    50 465 us
+
+CONCLUSIONES
+
+D es el hallazgo, y toca codigo YA MERGEADO: el conteo es LINEAL, ~1 us por fila,
+porque SQLite no lo cachea sino que recorre. Con 50 000 entradas serian 50 ms por
+peticion solo para contar. Eso convierte la retencion en algo mas que higiene de
+disco: es lo que mantiene barata una lectura que ya estaba escrita.
+
+Sobre C: el '-> quedan 1000 filas' de la variante (c) NO prueba lo que parece.
+(c) borra incondicionalmente, y este banco arranco justo en 1000, asi que el
+resultado salio bonito por construccion. Se destapo en
+bench_poda_convergencia.py, que es el que decide.
+
+Y la parte A/B de este banco (no incluida arriba) resulto POCO FIABLE: con limite
+fijo la poda por cantidad sale plana (~1 ms) a los tres tamanos, pero TAMBIEN
+sale plana al hacer crecer el limite hasta 50 010, y eso contradice al banco
+anterior, que en ese mismo caso daba 62 ms. No se explica el suelo de ~1 ms y no
+se construyo ninguna recomendacion sobre esos numeros: la pregunta que importaba
+—el coste en regimen estacionario— la responde la medida directa de C.
+"""
+
+import json
+import sqlite3
+import sys
+import tempfile
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ESQUEMA = """
+CREATE TABLE IF NOT EXISTS history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, created_at TEXT NOT NULL,
+    kind TEXT NOT NULL, origin TEXT NOT NULL, headline TEXT, tool TEXT,
+    verdict TEXT, status TEXT NOT NULL, payload TEXT NOT NULL);
+"""
+INSERT = """
+INSERT INTO history (created_at, kind, origin, headline, tool, verdict, status, payload)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+# (a) la que propuse: subconsulta con MIN sobre las N mas nuevas
+PODA_A = """
+DELETE FROM history
+WHERE id < (SELECT MIN(id) FROM (SELECT id FROM history ORDER BY id DESC LIMIT ?))
+"""
+# (b) saltar N por el indice y quedarse con ese id
+PODA_B = """
+DELETE FROM history
+WHERE id <= (SELECT id FROM history ORDER BY id DESC LIMIT 1 OFFSET ?)
+"""
+# (c) borrar SOLO la mas vieja. Vale porque podamos en CADA escritura, asi que
+#     como mucho sobra una fila. MIN(id) sobre la clave primaria es inmediato.
+PODA_C = "DELETE FROM history WHERE id = (SELECT MIN(id) FROM history)"
+
+PAYLOAD = json.dumps({"signals": [{"n": f"s{i}", "d": "x" * 400} for i in range(5)]})
+AHORA = datetime.now(timezone.utc)
+LIMITE = 1000
+
+
+def fila(dias=0):
+    return ((AHORA - timedelta(days=dias)).isoformat(), "analysis", "api",
+            "Un titular", None, "clickbait", "ok", PAYLOAD)
+
+
+def db(filas):
+    ruta = Path(tempfile.mkdtemp()) / "history.db"
+    con = sqlite3.connect(ruta)
+    con.execute("PRAGMA synchronous=OFF")
+    con.execute(ESQUEMA)
+    if filas:
+        with con:
+            con.executemany(INSERT, [fila(dias=(i * 60) // filas) for i in range(filas)])
+    return con
+
+
+def bench(etiqueta, fn, n=2000):
+    fn()
+    t0 = time.perf_counter()
+    for _ in range(n):
+        fn()
+    us = (time.perf_counter() - t0) / n * 1e6
+    print(f"  {etiqueta:<50} {us:11.2f} us/op", flush=True)
+    return us
+
+
+print(f"Python {sys.version.split()[0]} | SQLite {sqlite3.sqlite_version}", flush=True)
+print(f"Limite FIJO en {LIMITE} filas, como en el sistema real.\n", flush=True)
+
+print("=== A/B) Poda por cantidad: .constante con el limite fijo? ===")
+print("    (la poda no encuentra nada que borrar: aisla el coste de BUSCAR)\n")
+
+for filas in (1_000, 10_000, 50_000):
+    print(f"  --- tabla de {filas} filas ---", flush=True)
+    con = db(filas)
+    # Limite por encima del total para que no borre nada y no mute la tabla.
+    tope = filas + 10
+    bench(f"(a) MIN sobre subconsulta   LIMIT {LIMITE}",
+          lambda: con.execute(PODA_A, (LIMITE,)))
+    bench(f"(a) MIN sobre subconsulta   LIMIT {tope} (no borra)",
+          lambda: con.execute(PODA_A, (tope,)))
+    bench(f"(b) OFFSET sobre el indice  OFFSET {tope} (no borra)",
+          lambda: con.execute(PODA_B, (tope,)))
+    con.close()
+
+print("\n=== C) Regimen estacionario: cada escritura borra UNA fila ===")
+print("    Se cronometra SOLO la poda, no el INSERT que la precede.\n")
+
+for etiqueta, sql, parametros in (
+    ("(a) MIN sobre subconsulta", PODA_A, (LIMITE,)),
+    ("(b) OFFSET sobre el indice", PODA_B, (LIMITE,)),
+    ("(c) borrar solo la mas vieja", PODA_C, ()),
+):
+    con = db(LIMITE)
+    tiempos = []
+    for _ in range(1000):
+        con.execute(INSERT, fila())
+        t0 = time.perf_counter()
+        con.execute(sql, parametros)
+        tiempos.append(time.perf_counter() - t0)
+    total = con.execute("SELECT COUNT(*) FROM history").fetchone()[0]
+    media = sum(tiempos) / len(tiempos) * 1e6
+    print(f"  {etiqueta:<50} {media:11.2f} us/op   -> quedan {total} filas", flush=True)
+    con.close()
+
+print("\n=== D) SELECT COUNT(*), que GET /history hace en CADA lectura ===\n")
+
+for filas in (1_000, 10_000, 50_000):
+    con = db(filas)
+    bench(f"SELECT COUNT(*) sobre {filas} filas",
+          lambda: con.execute("SELECT COUNT(*) FROM history").fetchone(), n=500)
+    con.close()

--- a/spikes/check_fechas_lexicograficas.py
+++ b/spikes/check_fechas_lexicograficas.py
@@ -1,0 +1,95 @@
+""".Falla la comparacion lexicografica de fechas por microsegundos o por 'Z'?
+
+Afirmacion a comprobar: que `2026-...T16:33:04.123456+00:00` (guardado, CON
+microsegundos) y `2026-...T16:33:04+00:00` (filtro, SIN ellos) se comparen mal
+como cadenas y descarten o incluyan registros equivocados.
+
+RESULTADO: la afirmacion es FALSA. Las seis combinaciones (>= y <= por tres
+formatos de filtro) coinciden con lo que dice Python comparando datetime de
+verdad.
+
+  sin microsegundos, +00:00   >=  ->  6 filas   OK
+  sin microsegundos, +00:00   <=  ->  6 filas   OK
+  con microsegundos,  +00:00  >=  ->  6 filas   OK
+  con microsegundos,  +00:00  <=  ->  6 filas   OK
+  desde otro huso (+05:00)    >=  ->  6 filas   OK
+  desde otro huso (+05:00)    <=  ->  6 filas   OK
+
+POR QUE FUNCIONA: el caracter que sigue a los segundos es '.' (46) si hay
+microsegundos y '+' (43) si no. Como 46 > 43, '...04.123456+00:00' ordena DESPUES
+de '...04+00:00', que es justo el orden cronologico correcto. Acierta por la
+tabla ASCII, no por diseno consciente.
+
+Y el sufijo 'Z' ya esta resuelto aguas arriba: `_marca` re-serializa siempre con
+isoformat(), asi que un ?since=...Z sale convertido a +00:00 antes de tocar SQL.
+
+PERO: 'Z' es el caracter 90 y ordena despues de CUALQUIER desfase, asi que
+mezclar los dos formatos SI romperia las comparaciones, en silencio. Nada impedia
+que un codigo futuro escribiera 'Z'. De ahi que, aunque no hubiera bug, se
+centralizara todo lo que toca `created_at` en `_marca`: la correccion dependia de
+que tres sitios se acordaran de hacer lo mismo.
+"""
+
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, "/home/ggarciac/TFG/2026-ClickBaitAnalysis")
+
+BASE = datetime(2026, 8, 14, 16, 33, 4, tzinfo=timezone.utc)
+
+print("=== .Que formatos produce isoformat() en cada sitio? ===\n")
+con_micros = BASE.replace(microsecond=123456)
+sin_micros = BASE.replace(microsecond=0)
+print(f"  _guardar con microsegundos : {con_micros.isoformat()}")
+print(f"  _guardar sin microsegundos : {sin_micros.isoformat()}   <- cuando cae en .000000")
+print(f"  _marca desde sufijo 'Z'    : {datetime.fromisoformat('2026-08-14T16:33:04Z').astimezone(timezone.utc).isoformat()}")
+print(f"  _marca desde +05:00        : {datetime.fromisoformat('2026-08-14T21:33:04+05:00').astimezone(timezone.utc).isoformat()}")
+
+print("\n=== .Coincide el orden ALFABETICO con el CRONOLOGICO? ===\n")
+print("  El caracter que sigue a los segundos es '.' (46) si hay microsegundos")
+print("  y '+' (43) si no. Como 46 > 43, '...04.123456+00:00' ordena DESPUES de")
+print(f"  '...04+00:00'. Y eso es cronologicamente correcto.\n")
+print(f"  ord('.') = {ord('.')}   ord('+') = {ord('+')}   ord('-') = {ord('-')}")
+print(f"  '{con_micros.isoformat()}' > '{sin_micros.isoformat()}' -> "
+      f"{con_micros.isoformat() > sin_micros.isoformat()}   (esperado True)")
+
+print("\n=== Prueba real contra SQLite ===\n")
+con = sqlite3.connect(":memory:")
+con.execute("CREATE TABLE t (created_at TEXT)")
+
+# Una fila por cada decima de segundo alrededor del instante base.
+instantes = [BASE + timedelta(microseconds=i * 100_000) for i in range(-5, 6)]
+con.executemany("INSERT INTO t VALUES (?)", [(m.isoformat(),) for m in instantes])
+con.commit()
+
+fallos = 0
+for etiqueta, filtro in (
+    ("sin microsegundos, +00:00", BASE.isoformat()),
+    ("con microsegundos,  +00:00", BASE.replace(microsecond=0).isoformat()),
+    ("desde otro huso (+05:00)  ", BASE.astimezone(timezone(timedelta(hours=5))).astimezone(timezone.utc).isoformat()),
+):
+    for operador, comparar in ((">=", lambda m: m >= BASE), ("<=", lambda m: m <= BASE)):
+        sql_dice = {
+            f[0] for f in con.execute(f"SELECT created_at FROM t WHERE created_at {operador} ?", (filtro,))
+        }
+        python_dice = {m.isoformat() for m in instantes if comparar(m)}
+        ok = sql_dice == python_dice
+        fallos += not ok
+        print(f"  {etiqueta}  {operador}  -> {len(sql_dice):>2} filas   "
+              f"{'OK' if ok else 'DISCREPA con Python'}")
+
+print(f"\n  {'TODO COINCIDE' if not fallos else f'{fallos} DISCREPANCIAS'}: la comparacion "
+      f"lexicografica {'reproduce' if not fallos else 'NO reproduce'} el orden cronologico.")
+
+print("\n=== .Y si alguien guardara con sufijo Z? (no ocurre hoy) ===\n")
+con.execute("INSERT INTO t VALUES (?)", ("2026-08-14T16:33:04Z",))
+con.commit()
+filtro = BASE.isoformat()
+con_z = con.execute("SELECT created_at FROM t WHERE created_at >= ?", (filtro,)).fetchall()
+print(f"  'Z' (90) frente a '+' (43): 'Z' ordena SIEMPRE despues de cualquier desfase.")
+print(f"  La fila con Z {'aparece' if any('Z' in f[0] for f in con_z) else 'NO aparece'} "
+      f"en un >= sobre su propio instante.")
+print("  -> mezclar los dos formatos SI romperia el orden. Hoy no se mezclan:")
+print("     todo lo que se escribe pasa por isoformat(), que produce '+00:00'.")
+con.close()

--- a/tests/api/test_history.py
+++ b/tests/api/test_history.py
@@ -436,3 +436,161 @@ def test_los_topes_salen_en_el_esquema_openapi():
     assert parametros["limit"]["maximum"] == 100
     assert parametros["limit"]["minimum"] == 1
     assert parametros["offset"]["minimum"] == 0
+
+
+# ---------------------------------------------------------------- los filtros
+
+
+def _poblar():
+    """Un historial variado: análisis con tres veredictos y dos herramientas."""
+    _guardar(headline="engañoso", verdict="enganoso", status="ok")
+    _guardar(headline="factual", verdict="factual", status="ok")
+    _guardar(headline="roto", verdict="sin_datos", status="error")
+    _guardar(kind=HistoryKind.TOOL, tool="analyze_sentiment", status="ok")
+    _guardar(kind=HistoryKind.TOOL, tool="health_check", status="error")
+
+
+def test_filtro_por_kind():
+    """La pestaña «Análisis» / «Herramientas» de la pantalla."""
+    _poblar()
+
+    cuerpo = client.get("/history?kind=analysis").json()
+    assert cuerpo["total"] == 3
+    assert {i["kind"] for i in cuerpo["items"]} == {"analysis"}
+
+
+def test_filtro_por_tool_solo_alcanza_ejecuciones_sueltas():
+    """El desajuste de R9.4, resuelto: un análisis invocó CINCO herramientas, así
+    que no hay una por la que filtrarlo y su columna `tool` es nula. La pantalla
+    lo hace evidente enseñando el desplegable sólo dentro de «Herramientas»."""
+    _poblar()
+
+    cuerpo = client.get("/history?tool=analyze_sentiment").json()
+    assert cuerpo["total"] == 1
+    assert cuerpo["items"][0]["kind"] == "tool"
+
+
+def test_filtro_por_verdict():
+    """Lo que CONCLUYÓ: es el filtro que quiere quien mira sus análisis."""
+    _poblar()
+
+    cuerpo = client.get("/history?verdict=enganoso").json()
+    assert cuerpo["total"] == 1
+    assert cuerpo["items"][0]["headline"] == "engañoso"
+
+
+def test_filtro_por_status_es_el_operativo():
+    """Si funcionó la MAQUINARIA. Cruza los dos tipos de entrada, y por eso no
+    podía ser el mismo parámetro que el veredicto."""
+    _poblar()
+
+    cuerpo = client.get("/history?status=error").json()
+    assert cuerpo["total"] == 2
+    assert {i["kind"] for i in cuerpo["items"]} == {"analysis", "tool"}
+
+
+def test_los_filtros_se_acumulan():
+    _poblar()
+
+    cuerpo = client.get("/history?kind=analysis&status=ok").json()
+    assert cuerpo["total"] == 2
+    assert {i["verdict"] for i in cuerpo["items"]} == {"enganoso", "factual"}
+
+
+def test_el_total_va_ya_filtrado():
+    """Sin esto la interfaz pintaría «1-1 de 5» sobre una lista de uno."""
+    _poblar()
+
+    cuerpo = client.get("/history?verdict=factual").json()
+    assert cuerpo["total"] == 1
+    assert len(cuerpo["items"]) == 1
+
+
+def test_filtro_por_fechas():
+    _sembrar(4, dias=60)
+    _guardar(headline="de hoy")
+
+    desde = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    cuerpo = client.get("/history", params={"since": desde}).json()
+
+    assert cuerpo["total"] == 1
+    assert cuerpo["items"][0]["headline"] == "de hoy"
+
+
+def test_las_fechas_se_normalizan_a_utc():
+    """`created_at` se compara entre CADENAS, y eso sólo ordena bien si todas
+    llevan el mismo huso: `10:00+02:00` es alfabéticamente menor que `09:00+00:00`
+    aunque sea el mismo instante. Sin normalizar, el filtro fallaría en silencio."""
+    _guardar(headline="de hoy")
+
+    # El MISMO instante expresado en dos husos distintos: mismo resultado.
+    hace_una_hora = datetime.now(timezone.utc) - timedelta(hours=1)
+    en_utc = hace_una_hora.isoformat()
+    en_otro_huso = hace_una_hora.astimezone(timezone(timedelta(hours=5))).isoformat()
+
+    assert client.get("/history", params={"since": en_utc}).json()["total"] == 1
+    assert client.get("/history", params={"since": en_otro_huso}).json()["total"] == 1
+
+
+def test_el_desfase_horario_hay_que_codificarlo_en_la_url():
+    """Documenta una trampa que no es de la API pero cuesta una tarde.
+
+    En una cadena de consulta, `+` significa ESPACIO. Así que un desfase escrito
+    a pelo (`...09:00:00+00:00`) llega como `...09:00:00 00:00` y no parsea. No
+    afecta a un cliente que codifique sus parámetros —Angular lo hace— pero sí a
+    quien teclee la URL. La forma con sufijo `Z` no tiene ese problema.
+    """
+    _guardar()
+
+    a_pelo = "/history?since=2020-01-01T00:00:00+00:00"
+    assert client.get(a_pelo).status_code == 422
+
+    assert client.get("/history?since=2020-01-01T00:00:00Z").status_code == 200
+    assert (
+        client.get(
+            "/history", params={"since": "2020-01-01T00:00:00+00:00"}
+        ).status_code
+        == 200
+    )
+
+
+def test_un_payload_corrupto_falla_diciendo_que_fila():
+    """Ninguna ruta del código puede producirlo: `_guardar` es el único sitio que
+    escribe `payload` y siempre con `json.dumps`. Sólo salta editando la base a
+    mano — y entonces conviene que diga CUÁL, porque un JSONDecodeError pelado no
+    identifica la entrada entre mil."""
+    _guardar()
+    with history._conectar() as conexion:
+        conexion.execute("UPDATE history SET payload = 'esto no es json'")
+
+    with pytest.raises(ValueError, match="entrada 1"):
+        _leer()
+
+
+def test_lo_escrito_y_lo_filtrado_usan_el_mismo_formato_de_fecha():
+    """La comparación de `created_at` es entre CADENAS, así que sólo reproduce el
+    orden cronológico si todo se escribe igual. Que pase por `_marca` es lo que
+    lo garantiza sin depender de que tres sitios se acuerden."""
+    _guardar()
+
+    filas, _ = _leer()
+    guardado = filas[0]["created_at"]
+
+    assert guardado.endswith("+00:00")  # nunca sufijo `Z`: ordena distinto
+    assert guardado == history._marca(datetime.fromisoformat(guardado))
+
+
+def test_un_kind_inventado_es_422():
+    """Al tiparlo como enum, FastAPI lo valida y publica los valores admitidos."""
+    assert client.get("/history?kind=inventado").status_code == 422
+
+
+def test_la_respuesta_declara_la_politica_de_retencion(monkeypatch):
+    """La pantalla la necesita para explicar por qué faltan los análisis viejos
+    —un borrado silencioso se lee como un fallo— y para acotar el selector de
+    fechas. Va en la respuesta para que salga de la configuración real."""
+    monkeypatch.setattr(settings, "history_max_entries", 250)
+    monkeypatch.setattr(settings, "history_max_days", 7)
+
+    retencion = client.get("/history").json()["retention"]
+    assert retencion == {"max_entries": 250, "max_days": 7}

--- a/tests/api/test_history.py
+++ b/tests/api/test_history.py
@@ -18,6 +18,7 @@ de otro ni deja rastro en `var/`.
 
 import asyncio
 import sqlite3
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -188,6 +189,91 @@ def test_una_excepcion_deshace_la_escritura():
 
     _, total = _leer()
     assert total == 0
+
+
+# ---------------------------------------------------------------- la retención
+
+
+def _sembrar(cuantas, dias=0):
+    """Escribe filas saltándose la poda, para preparar un estado de partida."""
+    marca = (datetime.now(timezone.utc) - timedelta(days=dias)).isoformat()
+    with history._conectar() as conexion:
+        conexion.executemany(
+            history._INSERT,
+            [
+                (marca, "analysis", "api", f"t{i}", None, "factual", "ok", "{}")
+                for i in range(cuantas)
+            ],
+        )
+
+
+def test_la_poda_por_cantidad_no_borra_si_no_sobra(monkeypatch):
+    """Desde ABAJO: con menos filas que el techo no sobra nada, así que no se
+    toca ni una. Es la mitad de corrección del criterio — una poda que borra por
+    debajo del límite destruye datos que la política dice conservar."""
+    monkeypatch.setattr(settings, "history_max_entries", 1000)
+    monkeypatch.setattr(settings, "history_max_days", 0)
+    _sembrar(500)
+
+    _guardar()
+
+    _, total = _leer()
+    assert total == 501
+
+
+def test_la_poda_por_cantidad_recorta_al_techo(monkeypatch):
+    """Desde ARRIBA, y en UNA sola escritura.
+
+    Es el escenario del despliegue, no un caso teórico: el historial lleva
+    creciendo sin techo desde que se añadió la persistencia, así que al activar
+    la retención lo primero que se encuentra es una tabla por encima del límite.
+    Que la poda reduzca —y no sólo mantenga— es lo que evita una migración.
+    """
+    monkeypatch.setattr(settings, "history_max_entries", 100)
+    monkeypatch.setattr(settings, "history_max_days", 0)
+    _sembrar(3000)
+
+    _guardar(headline="el que dispara la poda")
+
+    filas, total = _leer(limit=1)
+    assert total == 100
+    assert filas[0]["headline"] == "el que dispara la poda"
+
+
+def test_la_poda_por_antiguedad_respeta_lo_reciente(monkeypatch):
+    monkeypatch.setattr(settings, "history_max_entries", 0)
+    monkeypatch.setattr(settings, "history_max_days", 30)
+    _sembrar(10, dias=60)  # caducadas
+    _sembrar(5, dias=2)  # dentro del plazo
+
+    _guardar()
+
+    _, total = _leer()
+    assert total == 6  # las 5 recientes + la que acaba de entrar
+
+
+def test_cero_desactiva_la_retencion(monkeypatch):
+    """En desarrollo interesa no perder las pruebas propias entre sesiones."""
+    monkeypatch.setattr(settings, "history_max_entries", 0)
+    monkeypatch.setattr(settings, "history_max_days", 0)
+    _sembrar(50, dias=900)
+
+    _guardar()
+
+    _, total = _leer()
+    assert total == 51
+
+
+def test_el_indice_de_fecha_existe():
+    """Sin él, `created_at < ?` recorre la tabla entera: 2374 µs contra 0,99 µs
+    sobre 1000 filas, y la diferencia crece con el tamaño."""
+    with history._conectar() as conexion:
+        indices = {
+            fila["name"]
+            for fila in conexion.execute("PRAGMA index_list(history)").fetchall()
+        }
+
+    assert "idx_history_created_at" in indices
 
 
 # ---------------------------------------------------------------- el endpoint


### PR DESCRIPTION
## #103 · Historial: filtros y retención

Closes #103

La otra mitad de R9. El issue anterior dejaba algo usable —historial paginado y
en orden inverso— y éste añade los dos refinamientos que quedaban, más un
criterio que hubo que reinterpretar porque su premisa había cambiado.

Con esto se completa R9 y con él el hito **H2** → release `v0.3.0`.

### Qué incluye

- **`backend/config/settings.py`**: `history_max_entries` (1000) y
  `history_max_days` (30), con `0` para desactivar cada uno. Configuración y no
  constantes porque el criterio los propone *como ejemplo, no como norma*, y
  porque en desarrollo interesa desactivarlos para no perder las pruebas propias.
- **`backend/api/history.py`**: índice en `created_at`, la poda dentro de la
  transacción del `INSERT`, y el `WHERE` dinámico de los filtros.
- **`backend/api/app.py`** y **`schemas.py`**: seis parámetros de filtro
  validados en la firma —así salen publicados en OpenAPI— y un campo `retention`
  en la respuesta.
- **`docs/requisitos.md`**: ajuste de R9.4, justificado abajo.
- **`tests/api/test_history.py`**: 16 tests nuevos (5 de poda, 11 de filtros).
- **`spikes/`**: los cuatro bancos de prueba, con resultados y conclusiones en la
  cabecera — incluidos **los dos que salieron mal**, con la advertencia escrita.

### R9.4 se escribió para un historial que no existe

«Filtrado por nombre de herramienta, intervalo de fechas y estado» se redactó
pensando en el historial de **invocaciones**, que en #102 se descartó a favor de
guardar análisis. Dos de los tres criterios no encajan tal cual:

**«Nombre de herramienta»** no aplica a un análisis, que invocó cinco señales y
no tiene *una*. Se resuelve con dos parámetros: `kind` separa análisis de
ejecuciones sueltas y `tool` sólo casa con las segundas. Ambas columnas ya
existían. En la pantalla el desplegable de herramientas aparece únicamente dentro
de la pestaña «Herramientas», así que la restricción no se explica: se ve.

**«Estado»** tampoco es una sola cosa: un análisis puede tener tres señales bien
y una caída. Se desdobla en `verdict` —qué concluyó, y es el que interesa en
pantalla— y `status` —si funcionó la maquinaria, operativo—. Es también el motivo
por el que en #102 `status` quedó como cadena y no como enum.

Se descartó la lectura literal —guardar qué señales participaron en cada
análisis— porque pide tabla nueva y habilita una consulta de depuración, no de
usuario.

### La poda: la formulación barata era la incorrecta

| Formulación | desde 500 | desde 3000 | Coste |
|---|---|---|---|
| (a) `MIN` sobre subconsulta | → 700 | → 1000 | 801 µs |
| (b) `OFFSET` sobre el índice | → 700 | → 1000 | 618 µs |
| (c) borrar sólo la más vieja | **→ 500** | **→ 3000** | 14 µs |
| **(d) corte por `MAX(id) - N`** | → 700 | → 1000 | **17,7 µs** |

La (c) es 45 veces más barata que la ganadora y **está mal**: borra
incondicionalmente, así que *mantiene* el tamaño de partida en vez de llevarlo al
límite — con 500 filas y techo de 1000 seguía borrando una por escritura. El
primer banco no lo detectó porque arrancaba justo en el límite, así que su
«quedan 1000 filas» salía por construcción.

De ahí el criterio de **convergencia desde ambos lados**. Desde abajo es
corrección: borrar por debajo del techo destruye lo que la política dice
conservar. Desde arriba es la ruta de actualización, y no es hipotética — el
historial lleva creciendo sin techo desde #102, así que al desplegar esto lo
primero que se encuentra es una tabla por encima del límite. Que (d) reduzca de
golpe, de 3000 a 1000 en *una* sentencia, es lo que evita escribir una migración.

`MAX(id) - N` es exacta porque los ids son contiguos, y eso costó dos
afirmaciones falsas antes de comprobarlo: los huecos no vienen de la poda (borra
por la cola) ni de inserciones revertidas (**medido**: `AUTOINCREMENT` no quema
el id al revertir). Lo que garantiza es que un id no se reutilice tras borrar.

### El índice, y la pregunta que no se le hizo a WAL

| | 1 000 filas | 10 000 | 50 000 |
|---|---|---|---|
| Poda por antigüedad **sin** índice | 2 374 µs | 11 113 µs | 54 595 µs |
| Poda por antigüedad **con** índice | 0,99 µs | 1,02 µs | 0,97 µs |

Unas 2.400 veces más rápida a 1.000 filas, y constante en vez de lineal. Y **no
se paga al escribir**: 14,29 µs sin índice contra 13,91 µs con él, por debajo del
ruido. Esa segunda medición es la que faltó en #102 al evaluar WAL — mirar sólo
lo que una optimización acelera, sin mirar lo que encarece, es cómo se acaba
adoptando algo que sale más lento.

### La retención no es sólo higiene de disco

`SELECT COUNT(*)` cuesta **~1 µs por fila** y es lineal, porque SQLite no lo
cachea sino que recorre: 886 µs sobre 1.000 filas, 50 465 µs sobre 50.000. Y
`GET /history` lo ejecuta en cada lectura desde #102, para devolver el `total`.
La retención es lo que mantiene barata una lectura que ya estaba escrita.

### Dos invariantes frágiles, reforzados sin que hubiera fallo

Ninguno era un bug: eran código correcto **por razones que nadie había escrito**.

- **El `WHERE` compuesto** construía los filtros de igualdad con
  `f"{columna} = ?"`. Seguro por *dónde venía* esa variable, no por cómo estaba
  escrita la línea: el día que alguien pase un nombre de campo desde la petición,
  esa misma línea se convierte en una inyección sin dar señal. Ahora el fragmento
  entero va en la tupla.
- **El formato de fechas** dependía de que tres sitios se acordaran de usar
  `isoformat()` en UTC. Comprobado que hoy acierta —incluso mezclando marcas con
  microsegundos y sin ellos, porque `.` es 46 y `+` es 43— pero un sufijo `Z` es
  90 y ordena después de cualquier desfase: mezclarlo rompería las comparaciones
  en silencio. Todo pasa ahora por una única función.

### Qué encontró revisar, frente a qué encontró medir

| Origen | Resultado |
|---|---|
| Revisión multiagente en la nube (75 ficheros, 7.402 líneas) | **0 hallazgos** |
| Revisión externa, dos tandas | 8 propuestas → **0 bugs**; 2 falsas, 2 insignificantes (0,005 %), 2 invariantes que sí valía reforzar |
| Medir a mano | la convergencia de la poda, el `COUNT(*)` lineal, el coste del índice, y cuatro afirmaciones propias desmentidas |

Se añade `ASYNC` a ruff, que detecta llamadas bloqueantes dentro de funciones
asíncronas — con la advertencia de que **no conoce `sqlite3`**, así que el caso
concreto de este issue se le habría escapado igual.

### Notas

- **La poda va en la misma transacción que el `INSERT`**, que es lo que hace que
  se cuele en el `fsync` ya pagado. El precio: si la poda falla se deshace también
  el `INSERT`, y como `record` se traga los errores el síntoma sería «el historial
  dejó de guardar» sin ruido. Se asume, cubierto con tests.
- **`?since=...+00:00` escrito a mano devuelve 422**, porque en una cadena de
  consulta `+` significa espacio. No es un fallo de la API —cualquier cliente que
  codifique sus parámetros funciona— y está avisado en la descripción del
  parámetro, que es donde lo verá quien genere el cliente Angular.
- **La paginación sigue siendo por `offset`.** Es estable a este volumen y la
  retención le quita el problema de rendimiento, pero si la pantalla acaba siendo
  scroll infinito conviene migrar a cursor **antes** de generar el cliente: cambia
  el contrato.
- **Sin índices por `kind`, `verdict` o `status`.** Con techo de 1.000 filas un
  escaneo es ~1 ms; añadirlos sería optimizar sin medir.
- Los filtros por herramienta **no alcanzan a los análisis** por diseño, según el
  ajuste de R9.4 de arriba.
