### PR TITLE
docs: estructura del repositorio y validación E2E previa a v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,74 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### Validación E2E de la capa REST, y estructura del repositorio
+
+Antes de cerrar H2 se ejercitó el sistema **de punta a punta por primera vez desde que existe la API**: los 175 tests mockean la red y el protocolo, así que nada había probado la cadena real con el servidor MCP levantado por HTTP. Se corrió con los dos backends NLP, y el historial se apuntó a un fichero temporal para no ensuciar el real.
+
+Todo funcionó. Y aun así salieron tres cosas.
+
+| Paso | Resultado | En frío | En caliente |
+|---|---|---|---|
+| `GET /health` | `ok`, tres integraciones alcanzables | — | 0,43 s |
+| `GET /tools` | 11 herramientas, `degraded: false` | — | 0,068 s |
+| `execute` válido / 404 / 422 | los tres exactos | — | 0,66 s |
+| `POST /analyze` **local** | veredicto correcto | **105,6 s** | 0,363 s |
+| `POST /analyze` **remoto** | mismo veredicto | 38,9 s | 0,610 s |
+| `GET /history` + 10 filtros | todos correctos | — | 0,033 s |
+
+#### El timeout de ejecución no tiene arreglo por número
+
+`detect_clickbait` (BART-large-MNLI) contra un servidor MCP en frío tardó **51,6 s**, con un `mcp_execute_timeout` de **60**. Ocho segundos de margen, y **con el modelo ya descargado**: en una máquina limpia hay que sumar ~1,6 GB y se pasa.
+
+Lo importante es que **subir el número no lo arregla**. Con caché fría el tiempo depende del ancho de banda, así que no está acotado y no existe un valor correcto. La solución es que cargar el modelo no ocurra dentro de una petición: un **calentamiento explícito al arrancar**, que es inherentemente tarea de contenedores y por tanto de H4.
+
+Y la carga perezosa **se queda**: es lo que evita que importar un módulo arrastre 1,6 GB, y lo que permite que el CI corra sin torch. No se sustituye, se complementa con un disparo deliberado en el arranque — donde tardar 105 s es gratis porque hay sondas de *readiness* para eso.
+
+#### `NLP_BACKEND=remote` no hace remoto el sistema
+
+Sólo conmuta **dos de las cinco** señales:
+
+| Señal | Backend |
+|---|---|
+| `detect_clickbait`, `analyze_sentiment` | `remote` \| `local` |
+| `detect_clickbait_incoherence` | **siempre local** (MiniLM) |
+| `detect_clickbait_lexical` | **siempre local** (reglas) |
+| `detect_clickbait_linear` | **siempre local** (pesos en JSON) |
+
+Por eso el «remoto en frío» tardó 38,9 s: era MiniLM cargándose en local, no la red. **Consecuencia para H4: la imagen Docker necesita torch y sentence-transformers aunque se despliegue en modo remoto.** No se consigue una imagen ligera poniendo `remote`.
+
+*(Estaba declarado en las fichas de modelo desde E5-08; lo que no estaba era la consecuencia de despliegue.)*
+
+#### El caso estrella, en vivo — y lo que revela sobre el contraste
+
+El primer análisis reprodujo el listicle que se usa como ejemplo:
+
+```
+forma    -> None   (detect_clickbait=False · lexical=True · linear=True)
+engano   -> True   (incoherence)
+tono            —  (no vota)
+VEREDICTO: enganoso
+```
+
+La dimensión `forma` tenía **2 contra 1** y el sistema **se negó a resolverlo**: declaró la discrepancia en vez de votar. El tono no votó. Y la jerarquía hizo el resto — el engaño pesa más que la forma, así que el veredicto global salió `enganoso` pese a la ambigüedad.
+
+Pero conviene mirar **quiénes** coincidieron: `lexical` y `linear`, que son justo las dos que **comparten extracción de rasgos** — `featurize_cues()` llama a `lexical.detect()`. La que discrepó, `detect_clickbait`, es la única independiente de las tres.
+
+Así que ese «2 contra 1» es en realidad **un par acoplado contra una vista independiente**. Con agregación por mayoría, el sistema habría dictaminado `forma = clickbait` apoyándose en dos señales que ven exactamente lo mismo. **El diseño resultó más robusto ante la dependencia de lo que sabía ser.**
+
+Y de ahí sale la pregunta que sí importa, porque el caso observado fue el benigno:
+
+- Cuando las señales acopladas **discrepan** → se declara ambigüedad. Protegido.
+- Cuando las señales acopladas **coinciden** → cuenta como consenso. **Vulnerable.**
+
+Y dos señales que comparten rasgos coinciden casi siempre: eso es lo que significa estar acopladas. La situación de riesgo es la común. Medir el acuerdo real entre `lexical` y `linear` sobre el split de dev deja de ser tarea documental y pasa a decidir **si el contraste dentro de la dimensión `forma` significa algo**.
+
+#### `docs/estructura.md`: criterios de pertenencia, no descripciones
+
+Se añade un documento que dice qué contiene cada carpeta y, sobre todo, **qué cualifica a una pieza para vivir en ella**. La distinción no es retórica: una descripción se escribe mirando lo que ya hay dentro, así que por construcción lo legitima — «`api/` contiene endpoints, esquemas y la orquestación» habría dado por bueno que la lógica de veredictos viviera ahí. Un criterio en forma de pregunta sí/no («¿existiría esto si no hubiera HTTP?») se aplica a una pieza concreta y la delata.
+
+Escribirlo destapó cuatro tensiones y dos bugs sin ejecutar una línea. La primera tensión —la orquestación en `api/`— resultó tener consecuencia de diseño y se analiza aparte: el servidor MCP no expone ninguna herramienta que contraste señales, así que **el agente conversacional no puede reproducir el veredicto del formulario**.
+
 ### Historial: filtros y retención (#103)
 
 La otra mitad de R9. El issue anterior dejaba algo usable —historial paginado y en orden inverso— y éste añade dos refinamientos que traían decisiones propias, más un criterio que hubo que reinterpretar porque su premisa había cambiado.

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -56,9 +56,21 @@ class Settings(BaseSettings):
     mcp_timeout: float = 5.0
 
     # Ejecutar una herramienta necesita mucho más margen que descubrirla: un
-    # `list_tools` tarda milésimas, pero `detect_clickbait_incoherence` puede
-    # tardar ~20 s la primera vez porque carga el modelo de embeddings. Con el
-    # timeout de descubrimiento, esa llamada moriría siempre en frío.
+    # `list_tools` tarda milésimas, pero una señal NLP tiene que cargar su modelo
+    # la primera vez.
+    #
+    # ESTE VALOR SE QUEDA CORTO, y está medido: con `NLP_BACKEND=local`, ejecutar
+    # `detect_clickbait` (BART-large-MNLI) contra un servidor MCP en frío tardó
+    # 51,6 s — ocho segundos por debajo del corte, y con el modelo YA descargado
+    # en la caché de HuggingFace. En una máquina limpia hay que sumarle ~1,6 GB
+    # de descarga y se pasa.
+    #
+    # Subir el número no lo arregla: con caché fría el tiempo depende del ancho
+    # de banda, así que no está acotado y no existe un valor «correcto». La
+    # solución real es que cargar el modelo NO ocurra dentro de una petición —
+    # un calentamiento explícito al arrancar, que es inherentemente una tarea de
+    # contenedores (H4). Hasta entonces, el primer uso en frío de una señal
+    # pesada por `/tools/{name}/execute` puede fallar por timeout.
     mcp_execute_timeout: float = 60.0
 
     # Fichero SQLite del historial.

--- a/docs/estructura.md
+++ b/docs/estructura.md
@@ -1,0 +1,284 @@
+# Estructura del repositorio
+
+> Documento vivo. Dice **qué contiene cada carpeta** y, sobre todo, **qué
+> cualifica a una pieza para vivir en ella**. Para la arquitectura en ejecución
+> ver [`arquitectura.md`](arquitectura.md); para los criterios de aceptación,
+> [`requisitos.md`](requisitos.md).
+
+## Por qué criterios y no descripciones
+
+Una descripción se escribe mirando lo que ya hay dentro, así que **por
+construcción lo legitima**. «`api/` contiene endpoints, esquemas y la
+orquestación del análisis» es una descripción cierta que habría dado por bueno
+que la lógica de veredictos viviera ahí — y esa ubicación resultó tener una
+consecuencia seria (ver [tensión 1](#1--la-orquestación-del-análisis-en-api)).
+
+Un **criterio** es distinto: es una pregunta que se contesta sí o no sobre una
+pieza concreta, y puede delatar a algo que ya está dentro. Por eso cada carpeta
+declara tres cosas:
+
+1. **Contiene** — qué hay hoy.
+2. **Criterio** — la pregunta que decide si algo pertenece aquí.
+3. **No va aquí aunque lo parezca** — el caso concreto que se presta a confusión.
+
+---
+
+## `backend/api/`
+
+**Contiene** — la aplicación FastAPI: rutas, contrato y las piezas que sólo
+existen para servirlo.
+
+**Criterio** — *¿existiría esto si el sistema no expusiera HTTP?* Si la respuesta
+es **sí**, no va aquí.
+
+**No va aquí aunque lo parezca** — la lógica que decide **qué significa** un
+análisis. Que el veredicto se calcule al atender un `POST` es una coincidencia
+de historia, no una propiedad suya.
+
+| Fichero | Qué hace |
+|---|---|
+| `app.py` | La aplicación y sus cinco rutas. Segundo punto de entrada del backend, hermano de `main.py` y no capa sobre él |
+| `schemas.py` | El contrato: lo que entra y sale por HTTP, y los enums que lo acompañan |
+| `catalog.py` | Construye el catálogo agregando el `list_tools` de cada servidor MCP — `GET /tools` |
+| `execute.py` | Valida los argumentos contra el `inputSchema` e invoca — `POST /tools/{name}/execute` |
+| `mcp_session.py` | Abre sesiones MCP. Es donde la API actúa como **cliente**, no como servidor |
+| `analyze.py` | Orquestación de `POST /analyze` — ⚠️ [tensión 1](#1--la-orquestación-del-análisis-en-api) |
+| `history.py` | Almacén del historial sobre SQLite — ⚠️ [tensión 2](#2--el-almacén-del-historial-en-api) |
+
+## `backend/core/`
+
+**Contiene** — maquinaria compartida por varias capas.
+
+**Criterio** — *¿lo usa más de una capa **y** no sabe nada del dominio del
+clickbait?*
+
+**No va aquí aunque lo parezca** — nada que conozca titulares, señales,
+dimensiones o veredictos, por muy reutilizable que sea. Reutilizable no es lo
+mismo que genérico.
+
+| Fichero | Qué hace |
+|---|---|
+| `base_api.py` | `BaseAPI`: rate-limit, reintentos, cuota, autenticación y el log `api.call`. Lo heredan todos los clientes |
+| `models.py` | `ToolResult`, el modelo de retorno que viaja **dentro** del proceso (no por MCP) |
+| `logging.py` | `configure_logging()` — structlog, en consola o JSON |
+| `observability.py` | `log_tool_invocation`, el decorador que registra cada invocación con parámetros y duración |
+| `health.py` | `check_health()` y su registro como tool MCP — ⚠️ [tensión 4](#4--health-conoce-mcp-desde-core) |
+
+## `backend/integrations/`
+
+**Contiene** — un paquete por cada cosa externa que el sistema envuelve.
+
+**Criterio** — *¿envuelve algo **externo al proyecto**: una API, un modelo, un
+dataset?*
+
+**No va aquí aunque lo parezca** — la maquinaria que **descubre** o **describe**
+las integraciones. Esa opera *sobre* ellas, no *es* una.
+
+Cada integración repite el mismo patrón, y esa repetición es deliberada: hace la
+estructura predecible y es lo que permite el descubrimiento automático.
+
+| | |
+|---|---|
+| `<nombre>/client.py` | La lógica de la API. Hereda `BaseAPI` |
+| `<nombre>/tool.py` | Capa fina que declara la herramienta MCP y delega en el cliente |
+
+| Fichero | Qué hace |
+|---|---|
+| `discovery.py` | Recorre el paquete y registra lo que encuentra — ⚠️ [tensión 3](#3--discovery-y-metadata-no-envuelven-nada) |
+| `metadata.py` | La categoría y procedencia que cada tool declara, para el catálogo — ⚠️ [tensión 3](#3--discovery-y-metadata-no-envuelven-nada) |
+| `guardian/`, `nyt/` | Fuentes de noticias |
+| `weather/` | Fuente meteorológica. Sobrevive de la Épica 0 y sirve de contraste: es la única que no tiene nada que ver con el clickbait |
+
+### `backend/integrations/nlp/`
+
+El paquete más grande, porque contiene **las señales** — el núcleo del detector.
+
+| Fichero | Qué hace |
+|---|---|
+| `base.py` | `NLPBackend` (ABC): la interfaz que cumplen el backend remoto y el local |
+| `client.py` | `HFClient(BaseAPI, NLPBackend)`: backend remoto contra HuggingFace |
+| `local.py` | Backend local con `transformers`. Cachea los pipelines por `(tarea, modelo)` para no recargar, e **importa `transformers` de forma perezosa** — por eso el módulo se puede importar sin torch, que es lo que permite el CI ligero. Las inferencias van a un hilo aparte porque bloquean |
+| `factory.py` | `get_nlp_backend()`: elige uno según `settings`. Es lo que permitió cambiar de remoto a local sin tocar ninguna señal |
+| `lexical.py` | Señal **interpretable**. Busca tres tipos de pista —palabras, frases y patrones regex— y devuelve cada coincidencia **con su posición** (`span`), que es lo que permite resaltar los cues sobre el titular. Clickbait si el recuento llega a `THRESHOLD` |
+| `linear.py` | Señal **interpretable**: regresión logística sobre los cues, con los pesos visibles y las contribuciones de cada rasgo en la salida. Carga los pesos de `linear_clickbait.json` — ⚠️ [bug 1](#1--linearpy-lee-el-fichero-de-pesos-al-importar) · [bug 2](#2--dos-señales-de-forma-comparten-extracción-de-rasgos) |
+| `incoherence.py` | Señal **híbrida**: decisión transparente (umbral sobre la similitud) con rasgo opaco (embeddings). Codifica titular y cuerpo con `all-MiniLM-L6-v2` y los compara por **similitud coseno**: incoherente si baja de 0,3. El modelo se carga una sola vez y de forma perezosa, de ahí los ~20 s de la primera llamada |
+| `model_cards.py` | Ficha de cada señal: tipo, dimensión que mide y límites medidos |
+| `outputs.py` | Los `TypedDict` de retorno, para que MCP publique el `outputSchema` |
+| `tool.py` | Registra las señales como herramientas MCP |
+| `cues/` | Las listas de *cues* léxicos, en ficheros de datos |
+
+## `backend/config/`
+
+**Contiene** — `settings.py`, y sólo eso.
+
+**Criterio** — *¿es un valor que cambia entre entornos sin tocar código?*
+
+**No va aquí aunque lo parezca** — los umbrales de decisión de una señal. Ésos
+son parte del modelo y viven con él, aunque sean números configurables.
+
+## `backend/evaluation/`
+
+**Contiene** — los guiones de evaluación offline.
+
+**Criterio** — *¿se ejecuta **a mano** para producir una medición, y no forma
+parte de ningún servicio en marcha?*
+
+**No va aquí aunque lo parezca** — nada que se importe en tiempo de ejecución.
+Si un endpoint o una tool lo necesita, es que no era evaluación.
+
+| Fichero | Qué hace |
+|---|---|
+| `splits.py` | Split físico train/dev/test, congelado (#72) |
+| `eval_lexical.py` | Baseline del léxico: carga, puntúa, matriz de confusión, barrido de umbral |
+| `linear_model.py` | **Entrena** el modelo lineal y serializa los pesos a `linear_clickbait.json`, que es lo que consume la señal en ejecución; compara además contra el baseline de reglas. El nombre engaña: no contiene el modelo, lo produce — ver [renombrados](#renombrados-propuestos). Arrastra además un `featurize()` **sin ningún llamante** |
+| `eval_external.py` | Validación externa sobre Webis-17 (#76) — la que destapó el sesgo de fuente |
+
+## `backend/main.py`
+
+Punto de entrada del **servidor MCP**. Registra las integraciones descubiertas
+más el chequeo de salud, y arranca con el transporte configurado. No contiene
+lógica: si algo se le añadiera, pertenece a otro sitio.
+
+---
+
+## Fuera de `backend/`
+
+| Carpeta | Criterio |
+|---|---|
+| `tests/` | Espeja `backend/`: un fichero por módulo, misma ruta relativa |
+| `spikes/` | ¿Es código **desechable**, escrito para responder **una** pregunta? Lleva sus resultados en la cabecera y está excluido de ruff a propósito |
+| `docs/` | Documentación y sus fuentes (`.drawio`, `img/`) |
+| `data/` | **Versionado e inmutable**: datasets y splits congelados. Si algo cambia en ejecución, no va aquí |
+| `var/` | **Gitignored y mutable**: estado que cambia en cada petición. Es el directorio que se monta como volumen |
+| `docker/` | *(vacía)* — reservada para H4 |
+| `frontend/` | *(vacía)* — reservada para la SPA Angular |
+
+---
+
+## Tensiones detectadas
+
+Piezas que **no cumplen el criterio de la carpeta donde están**. Se documentan,
+no se resuelven aquí: convertir este fichero en un refactor encubierto es cómo se
+queda a medias.
+
+### 1 · La orquestación del análisis, en `api/`
+
+`backend/api/analyze.py` contrasta las señales, las agrupa por dimensión y deriva
+el veredicto. Eso **seguiría teniendo sentido en un sistema sólo-MCP**, así que
+incumple el criterio de `api/`.
+
+No es un problema estético: la consecuencia es que el servidor MCP **no expone
+ninguna herramienta que contraste señales**, y por tanto el agente conversacional
+de R13 no puede reproducir el veredicto del formulario. Analizado en **#107**.
+
+### 2 · El almacén del historial, en `api/`
+
+`backend/api/history.py` está ahí porque su consumidor es `GET /history` — que
+es exactamente el argumento que falló con `analyze.py`.
+
+¿Querría un servidor MCP guardar historial de lo que ejecutó? Probablemente sí.
+Si la respuesta es sí, el módulo incumple el criterio igual que el anterior, sólo
+que todavía sin consecuencia visible.
+
+### 3 · `discovery` y `metadata` no envuelven nada
+
+Ninguno de los dos envuelve una API, un modelo ni un dataset: son la maquinaria
+que **descubre** y **describe** las integraciones. Cumplen el criterio de `core/`
+—maquinaria compartida, sin dominio— mejor que el de `integrations/`.
+
+A favor de dejarlos donde están: operan sobre ese paquete y viven a su lado. En
+contra: por esa regla, cualquier cosa que opere sobre algo debería vivir dentro.
+
+### 4 · `health` conoce MCP desde `core/`
+
+`backend/core/health.py` es infraestructura —sondea APIs externas, no sabe nada
+de clickbait— pero además **se registra como herramienta MCP**, así que conoce
+FastMCP desde el núcleo.
+
+O el criterio de `core/` admite explícitamente «puede exponerse como
+herramienta», o esto es una excepción que hay que declarar. Conviene decidirlo
+porque marca si `core/` puede o no depender de la capa de protocolo.
+
+---
+
+## Bugs detectados
+
+Al leer los módulos para escribir las descripciones de arriba salieron dos cosas
+que sí hay que arreglar. **No son de la misma clase**, y conviene no meterlas en
+el mismo saco.
+
+### 1 · `linear.py` lee el fichero de pesos al importar
+
+```python
+JSON_FILE = Path(__file__).resolve().parent / "linear_clickbait.json"
+with open(JSON_FILE, encoding="utf-8") as f:  # ← nivel de módulo
+    JSON = json.load(f)
+```
+
+Es un efecto colateral en tiempo de import: **importar el módulo abre y parsea un
+fichero**, y falla si no está. Hoy funciona porque el JSON está commiteado, pero
+un import no debería tocar el disco — cualquier cosa que importe la señal, aunque
+sea para inspeccionarla, paga esa lectura y hereda ese modo de fallo.
+
+Arreglo: carga perezosa, como ya hacen `local.py` con `transformers` e
+`incoherence.py` con el modelo de embeddings. El patrón ya está en la casa.
+
+### 2 · Dos señales de **forma** comparten extracción de rasgos
+
+`featurize_cues()` en `linear.py` llama a `lexical.detect()` y reutiliza sus
+listas: la señal lineal está construida sobre la léxica.
+
+**Esto ya está declarado**, y conviene decirlo antes que nada. La ficha de
+`detect_clickbait_linear` lo recoge entre sus limitaciones:
+
+> *«No capta engaño semántico (usa las mismas pistas de superficie que el
+> léxico).»*
+
+Así que no es un descubrimiento: es una limitación conocida y publicada, que
+además viaja al frontend por `describe_models`. Lo que **no** está escrito es su
+consecuencia sobre el contraste:
+
+- Si una lista de cues tiene un hueco, **las dos señales lo tienen igual**; si un
+  cue salta por error, las dos lo ven. **Dos señales de forma de acuerdo no son
+  dos confirmaciones independientes.**
+- Lo que sí queda de contraste: pueden discrepar en *cuánto pesa* lo encontrado
+  —una cuenta plano contra umbral, la otra pondera con pesos aprendidos— pero no
+  en *qué se ha encontrado*.
+
+Y lo que **no** está afectado: `incoherence.py` parte de otra entrada —el cuerpo
+de la noticia— así que la dimensión de **engaño** es independiente de la de
+forma. La dependencia vive dentro de una sola dimensión, y el docstring de
+`model_cards.py` ya avisa de lo relacionado: *«tres señales de forma de acuerdo
+no significan que el titular engañe»*.
+
+No es un arreglo de código. Es **medirlo y añadir la consecuencia a la ficha**:
+la correlación entre las dos señales sobre el split de dev convierte «comparten
+rasgos» en un número, que es lo que el proyecto hace con el resto de sus límites.
+
+## Renombrados propuestos
+
+Criterio: **renombrar cuando el nombre hace una predicción falsa**, no cuando es
+escueto. `base.py` es escueto y predice bien; `linear_model.py` predice «aquí
+vive el modelo lineal» y es mentira.
+
+| Fichero | Propuesta | Por qué |
+|---|---|---|
+| `evaluation/linear_model.py` | `train_linear.py` | No contiene el modelo: lo **entrena**. El modelo vive en `nlp/linear.py` + el JSON. Y colisiona de un vistazo con `nlp/linear.py`, que sí es la señal. Encaja además con sus hermanos, ya verbo+objeto: `eval_lexical`, `eval_external` |
+| `nlp/client.py` | `remote.py` | El par actual `client.py` / `local.py` no dice que sean **dos implementaciones de la misma interfaz**; `remote.py` / `local.py` sí. Y en las demás integraciones `client.py` significa otra cosa —«el cliente de esta API»—, así que además es inconsistente entre paquetes |
+| `integrations/metadata.py` | `tool_metadata.py` | Menor: «metadata» de qué. El docstring ya lo cubre |
+
+No se renombran `base.py`, `models.py`, `outputs.py` ni `nlp/linear.py`: son
+escuetos pero no engañan, y al renombrar `linear_model.py` desaparece la única
+colisión real.
+
+## Deuda: 19 módulos sin docstring
+
+De los 30 módulos reales de `backend/`, **19 no declaran qué hacen**, y se
+concentran en el código de Fase A: todo `core/`, todos los `client.py` y casi
+todo `nlp/`. Lo escrito en Fase B sí está documentado.
+
+Las descripciones de las tablas de arriba se han sacado leyendo sus definiciones,
+no sus docstrings. **Lo correcto sería lo contrario**: que cada módulo declare su
+propósito y que este documento se limite a los criterios y las relaciones — una
+línea en un fichero central es lo primero que se queda obsoleto, un docstring
+está donde se edita el código.


### PR DESCRIPTION
## Estructura del repositorio y validación E2E previa a `v0.3.0`

Sin issue asociado: es documentación de trabajo ya hecho, no una unidad de
trabajo. Los hallazgos que sí requieren acción salieron de aquí y tienen su
propio sitio — **#107**, **#108** y **#109**.

Cierra los dos huecos que quedaban antes de tagear H2: el sistema nunca se había
ejercitado de punta a punta desde que existe la API REST, y no había ningún
documento que dijera **dónde debe vivir cada cosa**.

### Qué incluye

- **`docs/estructura.md`** (nuevo): qué contiene cada carpeta y, sobre todo, qué
  cualifica a una pieza para vivir en ella. Tabla por fichero dentro de
  `backend/`.
- **`README.md`**: la validación E2E con sus tres hallazgos y el caso estrella.
- **`backend/config/settings.py`**: el comentario de `mcp_execute_timeout`, que
  afirmaba «~20 s» cuando lo medido son 51,6. Único cambio en código, y **no
  altera comportamiento**.

### Criterios de pertenencia, no descripciones

La distinción no es retórica. Una descripción se escribe mirando lo que ya hay
dentro, así que **por construcción lo legitima**: «`api/` contiene endpoints,
esquemas y la orquestación del análisis» es cierta, y habría dado por bueno que
la lógica de veredictos viviera ahí.

Un criterio es una pregunta que se contesta sí o no sobre una pieza concreta, y
puede delatar a algo que ya está dentro:

| Carpeta | Criterio |
|---|---|
| `api/` | ¿existiría si no hubiera HTTP? |
| `core/` | ¿lo usa más de una capa **y** no sabe nada del dominio del clickbait? |
| `integrations/` | ¿envuelve algo **externo al proyecto**? |
| `config/` | ¿cambia entre entornos sin tocar código? |
| `evaluation/` | ¿se ejecuta **a mano** para producir una medición? |

Aplicarlos destapó **cuatro tensiones y dos bugs sin ejecutar una línea**. La
primera —la orquestación en `api/`— resultó tener consecuencia de diseño y se
analiza en #107: el servidor MCP no expone ninguna herramienta que contraste
señales, así que el agente conversacional no puede reproducir el veredicto del
formulario.

También se borró `backend/tools/`, resto de la estructura anterior al patrón
`integrations/*/tool.py`: contenía sólo un `__pycache__` y git no rastreaba nada.

### La validación E2E

Los 175 tests mockean la red y el protocolo, así que nada había probado la cadena
real con el servidor MCP levantado por HTTP. Se corrió con **los dos backends
NLP** y con el historial apuntado a un fichero temporal.

| Paso | Resultado | En frío | En caliente |
|---|---|---|---|
| `GET /health` | `ok`, tres integraciones | — | 0,43 s |
| `GET /tools` | 11 herramientas, `degraded: false` | — | 0,068 s |
| `execute` válido / 404 / 422 | los tres exactos | — | 0,66 s |
| `POST /analyze` **local** | veredicto correcto | **105,6 s** | 0,363 s |
| `POST /analyze` **remoto** | mismo veredicto | 38,9 s | 0,610 s |
| `GET /history` + 10 filtros | todos correctos | — | 0,033 s |

Todo funcionó. Y aun así salieron tres cosas.

**1 · El timeout de ejecución no tiene arreglo por número.** `detect_clickbait`
contra un servidor MCP en frío tardó **51,6 s** con un corte de **60**, y con el
modelo ya descargado. Subirlo no lo arregla: con caché fría el tiempo depende del
ancho de banda y no está acotado. La solución es que cargar no ocurra dentro de
una petición — calentamiento al arrancar, que es tarea de H4.

**2 · `NLP_BACKEND=remote` no hace remoto el sistema.** Sólo conmuta dos de las
cinco señales; incoherencia, léxico y lineal son **siempre locales**. Por eso el
«remoto en frío» tardó 38,9 s: era MiniLM cargándose en local, no la red.
**Consecuencia para H4: la imagen Docker necesita torch aunque se despliegue en
modo remoto.**

**3 · Los ~20 s del arranque en frío son ~105 s** con el backend local y las
cinco señales.

### El caso estrella, en vivo

El primer análisis reprodujo el listicle de ejemplo:

```
forma    -> None   (detect_clickbait=False · lexical=True · linear=True)
engano   -> True   (incoherence)
VEREDICTO: enganoso
```

La dimensión `forma` tenía **2 contra 1** y el sistema **se negó a resolverlo**:
declaró la discrepancia en vez de votar. El tono no votó. Y la jerarquía hizo el
resto.

Pero los dos que coincidieron son justo los que **comparten extracción de
rasgos**, y el que discrepó es el único independiente. Ese «2 contra 1» es **un
par acoplado contra una vista independiente**: con agregación por mayoría se
habría dictaminado `forma = clickbait` apoyándose en dos señales que ven lo
mismo.

El diseño resultó más robusto de lo que sabía ser — y por eso el caso observado
tranquiliza más de lo que debería: protege cuando las señales acopladas
**discrepan**, y es vulnerable cuando **coinciden**, que es lo que hacen casi
siempre. Abierto como **#109**.

### Notas

- **Ningún hallazgo rompe funcionalidad**: los tres son de configuración y
  documentación, y quedan declarados como límites conocidos de `v0.3.0`.
- **La carga perezosa se queda.** Es lo que evita que importar un módulo arrastre
  1,6 GB y lo que permite que el CI corra sin torch. No se sustituye: se
  complementa con un disparo deliberado en el arranque.
- **Las tensiones 2, 3 y 4 quedan documentadas sin resolver.** Convertir el
  documento en un refactor encubierto es cómo se queda a medias.
- Sin medir todavía: si parte de esos 51,6 s son consultas evitables al hub de
  HuggingFace (`HF_HUB_OFFLINE=1`). Es barato y va con H4.
