### PR TITLE
fix(api): un timeout de MCP corta la petición en vez de colgarla (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,74 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### Un timeout que no cortaba: la petición se colgaba en vez de fallar (#113)
+
+Al probar `analyze_headline` por el protocolo apareció algo que ningún test cubría: **una herramienta que tarda más que su timeout no producía un error, dejaba la petición colgada para siempre.**
+
+```
+servidor MCP   tool.invoke  duration_ms=151326  success=True
+API            sin respuesta · 6 min con la conexión abierta · 0 % de CPU
+cliente        ningún código HTTP
+```
+
+La tool **terminó bien** a los 151 s. El corte configurado eran 60. La API nunca devolvió nada.
+
+#### Por qué es peor que un timeout
+
+Un timeout que devuelve un error es manejable: la interfaz lo enseña, el usuario reintenta, el hueco de conexión se libera. Una petición que no vuelve deja el navegador esperando indefinidamente y ocupa un *worker*. Es un modo de fallo distinto — y era justo el que el ajuste pretendía evitar.
+
+Además afectaba al catálogo, cuyo comentario prometía literalmente lo que no cumplía: *«sin él, un servidor que acepta la conexión y no responde dejaría `/tools` colgado»*. Lo que sí funcionaba era el servidor **caído** —conexión rechazada, falla rápido, sale `unreachable`—; el servidor **lento** es otro caso y no estaba cubierto.
+
+#### La causa: dos timeouts que miden cosas distintas
+
+| | Qué mide |
+|---|---|
+| `timeout` de httpx *(el que había)* | **inactividad entre bytes** |
+| `asyncio.timeout` *(el que faltaba)* | **duración total** |
+
+Con una tool lenta que no envía nada mientras trabaja, el primero no salta. Reproducido sin modelos ni red, con una tool que duerme 10 s y un corte de 2: **25 s esperando** hasta que un vigilante externo lo mató. Con `asyncio.timeout`, corta a los **2,1 s**.
+
+Los dos se conservan: cubren fallos distintos y hacen falta ambos cortes.
+
+#### Se responde 504, no `status: error`
+
+Es una categoría nueva junto al 404 y el 422, y no un `ExecuteResponse` con estado de error. El motivo está medido: **al agotarse la espera la herramienta puede haber terminado bien** —de hecho terminó—. Decirle a quien mira que «el análisis falló» sería mentirle; un 504 dice que está tardando demasiado, que es lo que ocurre.
+
+#### `except*`, y por qué no vale un `except` normal
+
+Lo que sale de una sesión MCP viene envuelto **dos veces**, un task group de anyio por capa:
+
+```
+ExceptionGroup: 'unhandled errors in a TaskGroup'
+  ExceptionGroup: 'unhandled errors in a TaskGroup'
+    TimeoutError
+```
+
+Ese envoltorio **no se puede desactivar**: es la semántica de los task groups, donde pueden fallar varias tareas a la vez y no existe «la» excepción que devolver. *(anyio 3 desenvolvía cuando había una sola; anyio 4 envuelve siempre.)*
+
+Se usa **`except*`** (Python 3.11), que desmonta el grupo y compara por tipo **a cualquier profundidad** — así no depende de cuántas capas ponga la librería mañana. Un test lo fija con 0, 1, 2 y 3 niveles de anidamiento.
+
+Se descartó recorrer el árbol a mano, pero la alternativa queda escrita en el código: `except*` puede entrar en **varias ramas** —un grupo admite tipos distintos— así que un timeout acompañado de otro fallo saldría como 500 en vez de 504. Se asume; un timeout más un fallo independiente no es realmente «no respondió a tiempo».
+
+#### Dos tests, porque uno solo no basta
+
+El **rápido** sustituye la sesión por una que lanza el error ya fabricado: corre en milisegundos, entra en el CI y verifica **la traducción** a 504. Pero si `asyncio.timeout` no cortara, seguiría pasando igual.
+
+El **fiel** —marcado `integration`, fuera del CI— levanta un servidor MCP con una tool lenta y comprueba que la llamada **termina**. Ése prueba el mecanismo.
+
+#### El linter tenía la respuesta y le faltaba una línea
+
+Al declarar `target-version = "py312"` en ruff saltó esto:
+
+```
+ASYNC109  open_session(url, timeout: float)
+          help: Use `asyncio.timeout` instead
+```
+
+La regla `ASYNC` añadida en #103 **estaba señalando este mismo bug** y no podía decirlo: `asyncio.timeout()` existe desde 3.11, así que ruff no lo recomienda si no sabe a qué versión apuntas. Faltaba una línea de configuración para que el linter pudiera avisar de algo que costó una tarde encontrar a mano.
+
+Se queda con un `noqa` explicado —el parámetro es complemento y no sustituto— y en la línea, no en `ruff.toml`, para que la regla siga activa en el resto. Declarar la versión destapó además ocho enums que ruff quiere como `StrEnum`; eso **no** es cosmético —cambia lo que devuelve `str(Dimension.FORMA)`— y va a #108 con su repaso de puntos de uso.
+
 ### La orquestación sale de `api/`: las dos fachadas comparten veredicto (#107)
 
 Al dibujar el flujo de peticiones se comprobó que la orquestación del análisis

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -32,7 +32,12 @@ from backend.analysis.domain import AnalyzeRequest, AnalyzeResponse
 from backend.analysis.orchestrator import analyze
 from backend.api import history
 from backend.api.catalog import fetch_catalog
-from backend.api.execute import InvalidArguments, ToolNotFound, execute_tool
+from backend.api.execute import (
+    InvalidArguments,
+    ToolNotFound,
+    ToolTimeout,
+    execute_tool,
+)
 from backend.api.schemas import (
     CatalogResponse,
     ExecuteRequest,
@@ -157,6 +162,12 @@ async def post_execute(name: str, request: ExecuteRequest) -> ExecuteResponse:
     Devuelve **404** si la herramienta no existe, **422** si los argumentos no
     encajan, y **200 con `status` en `error`** si la herramienta se ejecutó y
     falló: eso último no es un error HTTP, porque la petición era correcta.
+
+    Y **504** si el servidor MCP tarda más de `mcp_execute_timeout`. Es una
+    categoría aparte del `status: error` a propósito: al agotarse la espera la
+    herramienta **puede haber terminado bien** —medido en #113, acabó con éxito a
+    los 151 s mientras la API ya había desistido—, así que decir que el análisis
+    falló sería falso. Lo que falló es la espera.
     """
     try:
         respuesta = await execute_tool(name, request.arguments)
@@ -166,6 +177,14 @@ async def post_execute(name: str, request: ExecuteRequest) -> ExecuteResponse:
         ) from None
     except InvalidArguments as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from None
+    except ToolTimeout:
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                f"'{name}' no respondió en {settings.mcp_execute_timeout:.0f} s. "
+                "Puede que siga ejecutándose; vuelve a consultarlo en un momento."
+            ),
+        ) from None
 
     # Sólo se registra lo que llegó a ejecutarse. Una petición rechazada por 404
     # o 422 no es una ejecución: ensuciaría el historial con intentos fallidos

--- a/backend/api/catalog.py
+++ b/backend/api/catalog.py
@@ -78,8 +78,25 @@ async def fetch_catalog() -> CatalogResponse:
 
 
 async def _consultar(url: str) -> tuple[ServerInfo, list[ToolInfo]]:
-    """Abre una sesión MCP, se presenta y pide el catálogo de ese servidor."""
-    async with open_session(url, settings.mcp_timeout) as (session, inicializacion):
+    """Abre una sesión MCP, se presenta y pide el catálogo de ese servidor.
+
+    El ``asyncio.timeout`` es el que hace verdad la promesa de ``mcp_timeout``:
+    que un servidor lento salga como ``unreachable`` en vez de dejar ``/tools``
+    colgado. El ``timeout`` de httpx no basta —mide inactividad entre bytes, no
+    duración— y sin esto un servidor que acepta la conexión y tarda en responder
+    cuelga la petición para siempre.
+
+    Lo que sí cubría httpx, y sigue cubriendo, es el servidor **caído**: ahí la
+    conexión se rechaza y falla rápido.
+
+    Al agotarse, la excepción sube al ``gather(return_exceptions=True)`` de
+    ``fetch_catalog`` como cualquier otro fallo, así que este servidor sale
+    degradado y los demás se sirven igual. No hace falta tratarla aquí.
+    """
+    async with (
+        asyncio.timeout(settings.mcp_timeout),
+        open_session(url, settings.mcp_timeout) as (session, inicializacion),
+    ):
         listado = await session.list_tools()
 
     nombre = inicializacion.serverInfo.name

--- a/backend/api/execute.py
+++ b/backend/api/execute.py
@@ -19,7 +19,10 @@ responder 422 y decir qué campo falla.
   petición era correcta y el servidor la atendió; lo que falló es el análisis.
   Mismo criterio que en ``/analyze``, donde una señal caída no tumba la
   respuesta.
+- El servidor tarda más de la cuenta → **504**. Ver ``ToolTimeout``.
 """
+
+import asyncio
 
 import structlog
 from jsonschema import Draft7Validator
@@ -40,6 +43,19 @@ class InvalidArguments(Exception):
     """Los argumentos no encajan en el esquema que publica la herramienta."""
 
 
+class ToolTimeout(Exception):
+    """El servidor MCP no respondió dentro de ``mcp_execute_timeout``.
+
+    Es su **propia** categoría y no un ``ExecuteResponse`` con ``status`` en
+    ``error``, porque no son lo mismo: aquel significa «la herramienta se ejecutó
+    y falló», y aquí puede haber salido perfectamente.
+
+    Lo que ha fallado es la espera, no el análisis. Decirle a quien mira que «el
+    análisis falló» sería mentirle; un 504 le dice que está tardando demasiado,
+    que es lo que pasa de verdad.
+    """
+
+
 async def execute_tool(name: str, arguments: dict) -> ExecuteResponse:
     """Localiza la herramienta, valida los argumentos y la invoca.
 
@@ -50,7 +66,49 @@ async def execute_tool(name: str, arguments: dict) -> ExecuteResponse:
     ha pasado y es aquí, ya fuera, donde se decide qué excepción sale.
     """
     for url in settings.mcp_servers:
-        intento = await _intentar(url, name, arguments)
+        try:
+            intento = await _intentar(url, name, arguments)
+
+        # `except*` y no `except`: lo que sale de la sesión viene envuelto DOS
+        # veces —un task group de anyio por capa, `streamable_http_client` y
+        # `ClientSession`— y un `except TimeoutError` no casa con un grupo:
+        #
+        #     ExceptionGroup: 'unhandled errors in a TaskGroup'
+        #       ExceptionGroup: 'unhandled errors in a TaskGroup'
+        #         TimeoutError          <- lo que de verdad pasó
+        #
+        # Ese envoltorio no se puede desactivar: es la semántica de los task
+        # groups, donde pueden fallar VARIAS tareas a la vez y no existe «la»
+        # excepción que devolver.
+        #
+        # `except*` (Python 3.11+) desmonta el grupo y compara por tipo a
+        # CUALQUIER profundidad, así que cubre también el caso sin envolver y no
+        # depende de cuántas capas ponga la librería el día de mañana.
+        #
+        # Diferencia con un `except` normal, comprobada: `except*` puede entrar
+        # en VARIAS ramas, porque un grupo admite fallos de tipos distintos. Si
+        # llegara un timeout JUNTO A otro fallo, saldría un grupo con el
+        # `ToolTimeout` dentro y la ruta respondería 500 en lugar de 504. Se
+        # asume: un timeout más un fallo independiente no es realmente «no
+        # respondió a tiempo».
+        #
+        # Si esa robustez llegara a hacer falta, la alternativa —descartada por
+        # ser maquinaria a mano donde el lenguaje ya trae herramienta— era
+        # recorrer el árbol y quedarse con el 504 siempre:
+        #
+        #     def _hay_timeout(exc: BaseException) -> bool:
+        #         if isinstance(exc, BaseExceptionGroup):
+        #             return any(_hay_timeout(hija) for hija in exc.exceptions)
+        #         return isinstance(exc, TimeoutError)
+        #
+        #     except BaseExceptionGroup as grupo:
+        #         if not _hay_timeout(grupo):
+        #             raise
+        #         raise ToolTimeout(name) from grupo
+        except* TimeoutError:
+            log.warning("tool.execute.timeout", tool=name, url=url)
+            raise ToolTimeout(name) from None
+
         if intento is None:
             continue  # esta herramienta no está en este servidor
 
@@ -70,10 +128,24 @@ async def _intentar(
     Devuelve ``None`` si no la tiene. Si la tiene, ``(problemas, resultado,
     servidor)``: con ``problemas`` los argumentos no pasaron la validación y no
     se llegó a invocar nada.
+
+    El ``asyncio.timeout`` acota **la operación entera** —handshake, catálogo y
+    llamada— y no sólo ``call_tool``, para que un servidor lento en presentarse
+    tampoco deje la petición sin techo.
+
+    Es el que de verdad corta. El ``timeout`` de httpx que se le pasa a
+    ``open_session`` mide **inactividad entre bytes**, no duración: con una tool
+    que tarda más de la cuenta no salta, y la petición se queda colgada para
+    siempre en vez de fallar (#113, reproducido — 25 s de espera con un corte
+    pedido de 2). Se conserva igualmente porque sí cubre lo suyo: un servidor que
+    acepta la conexión y deja de enviar.
     """
-    async with open_session(url, settings.mcp_execute_timeout) as (
-        session,
-        inicializacion,
+    async with (
+        asyncio.timeout(settings.mcp_execute_timeout),
+        open_session(url, settings.mcp_execute_timeout) as (
+            session,
+            inicializacion,
+        ),
     ):
         tools = {t.name: t for t in (await session.list_tools()).tools}
         if name not in tools:

--- a/backend/api/history.py
+++ b/backend/api/history.py
@@ -23,7 +23,7 @@ import json
 import sqlite3
 from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -166,13 +166,13 @@ def _marca(momento: datetime) -> str:
     resultado no dependa de la máquina donde corra el servidor.
     """
     if momento.tzinfo is None:
-        momento = momento.replace(tzinfo=timezone.utc)
-    return momento.astimezone(timezone.utc).isoformat()
+        momento = momento.replace(tzinfo=UTC)
+    return momento.astimezone(UTC).isoformat()
 
 
 def _ahora() -> str:
     """El instante actual, en el formato en que se guarda."""
-    return _marca(datetime.now(timezone.utc))
+    return _marca(datetime.now(UTC))
 
 
 # Poda por cantidad. Parece la fórmula ingenua —«resta N al mayor id»— y hay que
@@ -225,7 +225,7 @@ def _podar(conexion: sqlite3.Connection) -> None:
         conexion.execute(_PODA_CANTIDAD, (settings.history_max_entries,))
 
     if settings.history_max_days > 0:
-        corte = datetime.now(timezone.utc) - timedelta(days=settings.history_max_days)
+        corte = datetime.now(UTC) - timedelta(days=settings.history_max_days)
         conexion.execute(_PODA_ANTIGUEDAD, (_marca(corte),))
 
 

--- a/backend/api/mcp_session.py
+++ b/backend/api/mcp_session.py
@@ -35,9 +35,19 @@ def _http_client(timeout: float) -> httpx.AsyncClient:
 
 @asynccontextmanager
 async def open_session(
-    url: str, timeout: float
+    url: str,
+    timeout: float,  # noqa: ASYNC109
 ) -> AsyncGenerator[tuple[ClientSession, InitializeResult]]:
     """Abre una sesión MCP ya inicializada contra ``url``.
+
+    Sobre el ``noqa``: ruff señala el parámetro ``timeout`` y recomienda
+    ``asyncio.timeout``, y **tenía razón** — así se descubrió #113, donde una
+    herramienta lenta colgaba la petición para siempre porque este timeout no
+    cortaba. Pero la solución no fue quitarlo sino **sumarle** el otro: quien
+    llama envuelve la operación en ``asyncio.timeout`` para acotar la DURACIÓN, y
+    éste se conserva porque cubre algo distinto que aquél no ve — un servidor que
+    acepta la conexión y deja de enviar bytes. Son dos fallos diferentes y hacen
+    falta los dos cortes.
 
     Devuelve también el resultado del *handshake*, porque de ahí sale el nombre
     que **declara el propio servidor** (``serverInfo.name``) — no el que figure

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -72,15 +72,20 @@ class Settings(BaseSettings):
     # un calentamiento explícito al arrancar, que es inherentemente una tarea de
     # contenedores (H4).
     #
-    # PERO OJO, Y ESTO ES PEOR: al superarse el corte la petición **no falla,
-    # se CUELGA**. Medido — la tool terminó en el servidor MCP a los 151 s con
-    # `success=True` y la API nunca devolvió nada: seis minutos con la conexión
-    # abierta y 0 % de CPU. Un timeout que devuelve error es manejable; una
-    # petición que no vuelve deja al navegador esperando para siempre.
+    # Y ojo con QUIÉN corta, porque este número solo no lo hacía: hasta #113, al
+    # superarse el corte la petición **no fallaba, se colgaba** — la tool terminó
+    # en el servidor a los 151 s con `success=True` y la API nunca devolvió nada,
+    # seis minutos con la conexión abierta y 0 % de CPU.
     #
-    # El motivo probable —sin verificar— es que el timeout de httpx es POR
-    # LECTURA y no por duración total. Abierto como #113: el arreglo
-    # pasa por acotar la llamada entera, no por ajustar este número.
+    # El motivo: el `timeout` de httpx mide **inactividad entre bytes**, no
+    # duración. Quien de verdad acota la llamada es el `asyncio.timeout` de
+    # `execute.py`, que usa este mismo valor. Los dos se conservan porque cubren
+    # fallos distintos —duración excesiva frente a un servidor que enmudece— y
+    # hacen falta los dos cortes.
+    #
+    # Al agotarse, la respuesta es un **504**, no un `status: error`: el trabajo
+    # puede haber salido bien al otro lado, así que decir «el análisis falló»
+    # sería falso. Lo que falló es la espera.
     mcp_execute_timeout: float = 60.0
 
     # Fichero SQLite del historial.

--- a/backend/core/health.py
+++ b/backend/core/health.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Literal, TypedDict
 
 import httpx
@@ -78,7 +78,7 @@ async def check_health() -> Salud:
     integrations = dict(zip(PROBES, results, strict=True))
     return {
         "status": _aggregate_status(integrations),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
         "integrations": integrations,
     }
 

--- a/backend/integrations/guardian/client.py
+++ b/backend/integrations/guardian/client.py
@@ -1,5 +1,5 @@
 # Constants
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from backend.config.settings import settings
 from backend.core.base_api import BaseAPI
@@ -47,7 +47,7 @@ class GuardianAPI(BaseAPI):
         # UTC explícito, no la zona de la máquina: en Docker el contenedor va en
         # UTC y el equipo de desarrollo no, así que `date.today()` desplazaría la
         # ventana de búsqueda un día cerca de medianoche según dónde se ejecute.
-        today = datetime.now(timezone.utc).date()
+        today = datetime.now(UTC).date()
         new_date = today - timedelta(days=days)
         params = {"from-date": new_date, "show-fields": "trailText"}
         if topic:  # Usa buscador de tags

--- a/backend/integrations/nyt/client.py
+++ b/backend/integrations/nyt/client.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from backend.config.settings import settings
 from backend.core.base_api import BaseAPI
@@ -51,7 +51,7 @@ class NYTAPI(BaseAPI):
         # UTC explícito, no la zona de la máquina: en Docker el contenedor va en
         # UTC y el equipo de desarrollo no, así que `date.today()` desplazaría la
         # ventana de búsqueda un día cerca de medianoche según dónde se ejecute.
-        today = datetime.now(timezone.utc).date()
+        today = datetime.now(UTC).date()
         new_date = (today - timedelta(days=days)).strftime("%Y%m%d")  # Formato YYYYMMDD
         params = {"begin_date": new_date, "sort": "relevance" if topic else "newest"}
         if topic:

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,6 +6,13 @@
 
 exclude = ["spikes", ".venv", "data"]
 
+# Sin esto ruff supone una versión antigua y da por indefinidos incorporados que
+# sí existen: `ExceptionGroup` y `BaseExceptionGroup` llegaron en 3.11, y el
+# código usa además `except*` y `asyncio.timeout()`. Se declara aquí porque el
+# proyecto no tiene `pyproject.toml` —de donde ruff leería `requires-python`— y
+# el venv corre 3.12.
+target-version = "py312"
+
 [lint]
 select = [
     "E",   # pycodestyle: errores
@@ -47,6 +54,17 @@ ignore = [
     "RUF001",
     "RUF002",
     "RUF003",
+
+    # Sugiere cambiar `class X(str, Enum)` por `enum.StrEnum` en los ocho enums
+    # del contrato. NO es un cambio cosmético: con el mixin `str, Enum`,
+    # `str(Dimension.FORMA)` devuelve `'Dimension.FORMA'`, y con `StrEnum`
+    # devuelve `'forma'`. Cualquier sitio que interpole el enum en una cadena
+    # cambiaría de salida en silencio.
+    #
+    # Se silencia AQUÍ y no se aplica al vuelo porque exige repasar los puntos de
+    # uso —serialización, logs, f-strings— y eso es una tarea con su propio
+    # riesgo, no un arreglo de paso. Va con la limpieza de #108.
+    "UP042",
 ]
 
 [lint.per-file-ignores]

--- a/tests/api/test_history.py
+++ b/tests/api/test_history.py
@@ -18,7 +18,7 @@ de otro ni deja rastro en `var/`.
 
 import asyncio
 import sqlite3
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -198,7 +198,7 @@ def test_una_excepcion_deshace_la_escritura():
 
 def _sembrar(cuantas, dias=0):
     """Escribe filas saltándose la poda, para preparar un estado de partida."""
-    marca = (datetime.now(timezone.utc) - timedelta(days=dias)).isoformat()
+    marca = (datetime.now(UTC) - timedelta(days=dias)).isoformat()
     with history._conectar() as conexion:
         conexion.executemany(
             history._INSERT,
@@ -512,7 +512,7 @@ def test_filtro_por_fechas():
     _sembrar(4, dias=60)
     _guardar(headline="de hoy")
 
-    desde = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    desde = (datetime.now(UTC) - timedelta(days=1)).isoformat()
     cuerpo = client.get("/history", params={"since": desde}).json()
 
     assert cuerpo["total"] == 1
@@ -526,7 +526,7 @@ def test_las_fechas_se_normalizan_a_utc():
     _guardar(headline="de hoy")
 
     # El MISMO instante expresado en dos husos distintos: mismo resultado.
-    hace_una_hora = datetime.now(timezone.utc) - timedelta(hours=1)
+    hace_una_hora = datetime.now(UTC) - timedelta(hours=1)
     en_utc = hace_una_hora.isoformat()
     en_otro_huso = hace_una_hora.astimezone(timezone(timedelta(hours=5))).isoformat()
 

--- a/tests/api/test_timeout.py
+++ b/tests/api/test_timeout.py
@@ -1,0 +1,135 @@
+"""Que un servidor MCP lento no cuelgue la petición.
+
+Antes de esto, una herramienta que tardaba más que su timeout **no fallaba: se
+colgaba para siempre**. Medido — la tool terminó en el servidor con éxito a los
+151 s mientras la API llevaba seis minutos con la conexión abierta y 0 % de CPU.
+
+Hay dos ficheros de test y prueban cosas distintas a propósito:
+
+- **Éste**, rápido: sustituye la sesión por una que duerme, así que corre en
+  milisegundos y entra en el CI. Prueba **la traducción** — que un timeout acaba
+  en un 504 y no en un 500 ni en un `status: error`.
+- **`tests/integration/test_timeout_real.py`**, marcado `integration`: levanta un
+  servidor MCP de verdad con una tool lenta. Prueba **el mecanismo** — que
+  `asyncio.timeout` corta donde el timeout de httpx no cortaba.
+
+El rápido no vale por sí solo: si sustituyes la sesión, ya no estás probando la
+capa que tenía el fallo. Y el fiel no puede ir en el CI porque tarda segundos por
+escenario. Cada uno cubre lo que el otro no.
+"""
+
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api import app as app_mod
+from backend.api import execute as execute_mod
+from backend.api.app import app
+from backend.api.execute import ToolTimeout, execute_tool
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def sesion_lenta(monkeypatch):
+    """Una sesión MCP que tarda más de la cuenta, sin levantar nada.
+
+    Reproduce la forma en que el fallo llega de verdad: el `TimeoutError` sale
+    **envuelto en dos ExceptionGroup**, uno por cada task group de anyio
+    (`streamable_http_client` y `ClientSession`). Es lo que hace que un
+    `except TimeoutError` normal no lo capture.
+    """
+
+    def instalar(anidamiento: int = 2):
+        async def falso_intentar(url, name, arguments):
+            exc: BaseException = TimeoutError()
+            for _ in range(anidamiento):
+                exc = ExceptionGroup("unhandled errors in a TaskGroup", [exc])
+            raise exc
+
+        monkeypatch.setattr(execute_mod, "_intentar", falso_intentar)
+
+    return instalar
+
+
+# ----- la traducción a HTTP -----
+
+
+def test_un_timeout_devuelve_504(sesion_lenta):
+    """504 y no 500: la petición era correcta, lo que falló fue la espera."""
+    sesion_lenta()
+
+    response = client.post("/tools/detect_clickbait/execute", json={"arguments": {}})
+
+    assert response.status_code == 504
+
+
+def test_el_504_dice_que_puede_seguir_ejecutandose(sesion_lenta):
+    """El detalle importa porque el trabajo PUEDE haber salido bien: al agotarse
+    la espera la herramienta sigue corriendo al otro lado. Decir «el análisis
+    falló» sería mentir."""
+    sesion_lenta()
+
+    detalle = client.post(
+        "/tools/detect_clickbait/execute", json={"arguments": {}}
+    ).json()["detail"]
+
+    assert "detect_clickbait" in detalle
+    assert "ejecutándose" in detalle
+
+
+def test_no_se_confunde_con_una_herramienta_que_falla(sesion_lenta):
+    """Un timeout NO es un `status: error`. Aquel significa «se ejecutó y falló»
+    y sale con 200; éste significa «dejamos de esperar» y sale con 504."""
+    sesion_lenta()
+
+    response = client.post("/tools/detect_clickbait/execute", json={"arguments": {}})
+
+    assert response.status_code != 200
+    assert "status" not in response.json()
+
+
+# ----- el desenvuelto del ExceptionGroup -----
+
+
+@pytest.mark.parametrize("capas", [0, 1, 2, 3])
+def test_se_reconoce_a_cualquier_profundidad(sesion_lenta, capas):
+    """`except*` compara por tipo a cualquier nivel del árbol, así que da igual
+    cuántos task groups anidados ponga la librería. Hoy son dos; el test fija que
+    seguirá funcionando si mañana son tres — o ninguno."""
+    sesion_lenta(anidamiento=capas)
+
+    with pytest.raises(ToolTimeout):
+        asyncio.run(execute_tool("detect_clickbait", {}))
+
+
+def test_otros_fallos_siguen_su_camino(monkeypatch):
+    """El desenvuelto no puede tragarse cualquier cosa: un fallo que no sea de
+    tiempo tiene que seguir subiendo tal cual."""
+
+    async def revienta(url, name, arguments):
+        raise ExceptionGroup(
+            "unhandled errors in a TaskGroup", [ValueError("otra cosa")]
+        )
+
+    monkeypatch.setattr(execute_mod, "_intentar", revienta)
+
+    with pytest.raises(BaseExceptionGroup):
+        asyncio.run(execute_tool("detect_clickbait", {}))
+
+
+# ----- que no se rompió lo de antes -----
+
+
+def test_las_otras_categorias_no_cambian(monkeypatch):
+    """404 y 422 seguían funcionando; el 504 se añade, no sustituye."""
+
+    async def no_existe(name, arguments):
+        raise execute_mod.ToolNotFound(name)
+
+    monkeypatch.setattr(app_mod, "execute_tool", no_existe)
+    assert (
+        client.post("/tools/inventada/execute", json={"arguments": {}}).status_code
+        == 404
+    )

--- a/tests/integration/test_timeout_real.py
+++ b/tests/integration/test_timeout_real.py
@@ -1,0 +1,132 @@
+"""El corte por timeout, contra un servidor MCP de verdad.
+
+Marcado `integration` porque **levanta un servidor y espera de verdad**: cada
+escenario tarda segundos, así que no entra en el CI. Se lanza a mano:
+
+    .venv/bin/python -m pytest tests/integration/test_timeout_real.py -m integration -v
+
+Prueba lo que `tests/api/test_timeout.py` NO puede probar. Aquel sustituye la
+sesión por una que lanza el error ya fabricado, así que verifica la traducción a
+504 pero **no el mecanismo**: si `asyncio.timeout` no cortara, el test rápido
+seguiría pasando igual.
+
+Aquí no se fabrica nada. La tool duerme más que el timeout y se comprueba que la
+llamada TERMINA, que era exactamente lo que no ocurría: el `timeout` de httpx
+mide inactividad entre bytes y no duración, así que con una tool lenta no saltaba
+y la petición se quedaba colgada para siempre.
+"""
+
+import asyncio
+import sys
+import time
+from typing import TypedDict
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from backend.api.execute import ToolTimeout, execute_tool
+from backend.config.settings import settings
+
+pytestmark = pytest.mark.integration
+
+PUERTO = 8799
+URL = f"http://127.0.0.1:{PUERTO}/mcp"
+
+TIMEOUT = 2.0  # lo que se le concede al cliente
+DORMIR = 10.0  # lo que tarda la tool: cinco veces más
+GUARDIA = 25.0  # si se pasa de aquí, es que sigue colgándose
+
+
+class Tardanza(TypedDict):
+    dormidos: float
+
+
+def _construir_servidor() -> FastMCP:
+    mcp = FastMCP("test-lento")
+    mcp.settings.host = "127.0.0.1"
+    mcp.settings.port = PUERTO
+
+    @mcp.tool()
+    async def dormir(segundos: float) -> Tardanza:
+        """Duerme sin bloquear el bucle de eventos del servidor."""
+        await asyncio.sleep(segundos)
+        return {"dormidos": segundos}
+
+    return mcp
+
+
+@pytest.fixture(scope="module")
+def servidor_lento():
+    """Levanta el servidor en un proceso aparte y espera a que escuche.
+
+    En un proceso y no en un hilo porque `mcp.run()` monta su propio bucle de
+    eventos, y compartirlo con el del test es pedir problemas.
+    """
+    import subprocess
+
+    guion = (
+        "import sys; sys.path.insert(0, '.'); "
+        "from tests.integration.test_timeout_real import _construir_servidor; "
+        "_construir_servidor().run(transport='streamable-http')"
+    )
+    proceso = subprocess.Popen(
+        [sys.executable, "-c", guion],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    limite = time.time() + 30
+    while time.time() < limite:
+        import socket
+
+        with socket.socket() as s:
+            if s.connect_ex(("127.0.0.1", PUERTO)) == 0:
+                break
+        time.sleep(0.3)
+    else:
+        proceso.kill()
+        pytest.fail("el servidor de prueba no llegó a escuchar")
+
+    yield
+    proceso.kill()
+    proceso.wait(timeout=10)
+
+
+@pytest.fixture
+def apuntando_al_lento(monkeypatch, servidor_lento):
+    monkeypatch.setattr(settings, "mcp_servers", [URL])
+    monkeypatch.setattr(settings, "mcp_execute_timeout", TIMEOUT)
+    monkeypatch.setattr(settings, "mcp_timeout", TIMEOUT)
+
+
+def test_una_tool_lenta_corta_en_vez_de_colgarse(apuntando_al_lento):
+    """EL test de este issue. Antes del arreglo, esta llamada no volvía nunca.
+
+    La cota es generosa a propósito: al agotarse el corte, cerrar la sesión aún
+    necesita que el servidor conteste, así que el total supera el timeout pedido
+    —medido: 2,1 s con el bucle del servidor libre, 4,0 s con él bloqueado—. Lo
+    que importa es que esté ACOTADO, no que sea exacto.
+    """
+
+    async def llamar():
+        return await execute_tool("dormir", {"segundos": DORMIR})
+
+    t0 = time.perf_counter()
+    with pytest.raises(ToolTimeout):
+        asyncio.run(asyncio.wait_for(llamar(), timeout=GUARDIA))
+    transcurrido = time.perf_counter() - t0
+
+    assert transcurrido < GUARDIA - 1, "siguió colgándose hasta el vigilante"
+    assert transcurrido >= TIMEOUT, "cortó antes de tiempo"
+
+
+def test_una_tool_rapida_sigue_respondiendo(apuntando_al_lento):
+    """El corte no puede haberse llevado por delante el camino normal."""
+
+    async def llamar():
+        return await execute_tool("dormir", {"segundos": 0.1})
+
+    respuesta = asyncio.run(asyncio.wait_for(llamar(), timeout=GUARDIA))
+
+    assert respuesta.status.value == "ok"
+    assert respuesta.data == {"dormidos": 0.1}


### PR DESCRIPTION
## #113 · Un timeout de MCP colgaba la petición en vez de fallar

Closes #113

Descubierto al validar #107 por el protocolo: **una herramienta que tarda más que
su timeout no producía un error, dejaba la petición colgada para siempre.**

```
servidor MCP   tool.invoke  duration_ms=151326  success=True
API            sin respuesta · 6 min con la conexión abierta · 0 % de CPU
cliente        ningún código HTTP
```

La tool **terminó bien** a los 151 s. El corte configurado eran 60. La API nunca
devolvió nada.

### Por qué es peor que un timeout

Un error se enseña, el usuario reintenta y el hueco de conexión se libera. Una
petición que no vuelve deja el navegador esperando indefinidamente y ocupa un
*worker*. Es un modo de fallo distinto — y era justo el que el ajuste pretendía
evitar.

Afectaba también al catálogo, cuyo comentario prometía lo que no cumplía: *«sin
él, un servidor que acepta la conexión y no responde dejaría `/tools` colgado»*.
Lo que sí funcionaba era el servidor **caído** —conexión rechazada, falla
rápido—; el **lento** es otro caso y no estaba cubierto.

### La causa

| | Qué mide |
|---|---|
| `timeout` de httpx *(el que había)* | **inactividad entre bytes** |
| `asyncio.timeout` *(el que faltaba)* | **duración total** |

Con una tool lenta que no envía nada mientras trabaja, el primero no salta.
Reproducido sin modelos ni red, con una tool que duerme 10 s y un corte de 2:
**25 s esperando** hasta que un vigilante externo lo mató. Con `asyncio.timeout`,
corta a los **2,1 s**.

Los dos se conservan: cubren fallos distintos y hacen falta los dos cortes.

### Qué incluye

- **`execute.py`**: `asyncio.timeout` acotando la operación entera —handshake,
  catálogo y llamada— más `ToolTimeout` como categoría propia.
- **`app.py`**: traducción a **504**.
- **`catalog.py`**: el mismo corte, para que un servidor lento salga
  `unreachable` con `degraded: true` en vez de colgar `/tools`.
- **`mcp_session.py`**: `noqa` del `ASYNC109` con su razón.
- **`ruff.toml`**: `target-version = "py312"` y el silenciado de `UP042`.
- **`tests/api/test_timeout.py`** (9 tests, CI) y
  **`tests/integration/test_timeout_real.py`** (2, a mano).

### 504 y no `status: error`

Categoría nueva junto al 404 y el 422, y no un `ExecuteResponse` con estado de
error. El motivo está medido: **al agotarse la espera la herramienta puede haber
terminado bien** — de hecho terminó. Decir que «el análisis falló» sería mentir;
un 504 dice que está tardando demasiado, que es lo que ocurre.

### `except*`, y por qué no vale un `except` normal

Lo que sale de una sesión MCP viene envuelto **dos veces**, un task group de anyio
por capa:

```
ExceptionGroup: 'unhandled errors in a TaskGroup'
  ExceptionGroup: 'unhandled errors in a TaskGroup'
    TimeoutError
```

Ese envoltorio **no se puede desactivar**: es la semántica de los task groups,
donde pueden fallar varias tareas a la vez y no existe «la» excepción que
devolver. Se usa `except*` (Python 3.11), que compara por tipo **a cualquier
profundidad**, así que no depende de cuántas capas ponga la librería mañana — un
test lo fija con 0, 1, 2 y 3 niveles.

Se descartó recorrer el árbol a mano, y la alternativa queda escrita en el código:
`except*` puede entrar en **varias ramas**, así que un timeout acompañado de otro
fallo saldría como 500 en vez de 504. Se asume.

### Dos tests, porque uno solo no basta

El **rápido** sustituye la sesión por una que lanza el error ya fabricado: corre
en milisegundos, entra en el CI y verifica **la traducción**. Pero si
`asyncio.timeout` no cortara, seguiría pasando igual.

El **fiel** —`integration`, fuera del CI— levanta un servidor MCP con una tool
lenta y comprueba que la llamada **termina**. Ése prueba el mecanismo.

### El linter tenía la respuesta y le faltaba una línea

Al declarar `target-version = "py312"` saltó esto:

```
ASYNC109  open_session(url, timeout: float)
          help: Use `asyncio.timeout` instead
```

La regla `ASYNC` añadida en #103 **señalaba este mismo bug** y no podía decirlo:
`asyncio.timeout()` existe desde 3.11, así que ruff no lo recomienda si no sabe a
qué versión apuntas. Una línea de configuración separaba al proyecto de un aviso
automático de algo que costó una tarde encontrar a mano.

### Notas

- **El corte está acotado pero no es exacto**: 2,1 s con el bucle del servidor
  libre, 4,0 s con él bloqueado, para un presupuesto de 2. Al agotarse, cerrar la
  sesión aún necesita que el servidor conteste. Lo que importa es que esté
  acotado; el test fija una cota superior, no un número clavado.
- **Sigue apareciendo `Session termination failed`** al cortar: el `DELETE /mcp`
  de despedida no llega a completarse. No cuelga, pero deja la sesión sin cerrar
  limpiamente en el servidor. No se persigue aquí.
- **`UP042` queda silenciado**, no resuelto: cambiar los ocho enums a `StrEnum`
  altera lo que devuelve `str(Dimension.FORMA)` y exige repasar los puntos de
  uso. Va a #108.
- **La lentitud de fondo sigue siendo de H4**: esto hace que el sistema responda
  cuando se supera el límite, no que deje de superarse. Para eso está el
  calentamiento al arrancar.
