### PR TITLE
chore(nlp): los ids de modelo viven en un solo sitio (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,89 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### Un campo que servía a tres amos: los ids de modelo (#116)
+
+Tres modelos, **ocho declaraciones de su identificador** repartidas por el
+backend. Cambiar el modelo de una señal en un sitio y no en los otros dejaba las
+dos fachadas —REST y MCP— respondiendo con **modelos distintos al mismo
+titular**, y sin que nada fallara: los dos caminos seguían devolviendo una
+etiqueta válida y bien formada.
+
+Salió al preparar #115, que es precisamente un cambio de modelo.
+
+#### Por qué no se había arreglado antes
+
+El `TODO` que lo registraba explicaba también el obstáculo:
+
+> *«Unificar leyéndolos de `MODEL_CARDS["name"]` exige antes normalizar ese
+> campo, que hoy mezcla ids de HuggingFace con descripciones en prosa.»*
+
+Y era exacto. `name` valía `"facebook/bart-large-mnli"` en tres fichas y
+`"Léxico por reglas (listas de cues de Chakraborty et al. 2016)"` en dos. Un solo
+campo intentando ser a la vez identificador de máquina y etiqueta para personas,
+que son cosas que no se parecen en nada: una tiene que coincidir carácter a
+carácter con lo que espera un tercero, la otra tiene que leerse bien en una
+tarjeta de la interfaz. Cuando un campo sirve a dos amos, hay que elegir a cuál
+servir mal.
+
+#### La separación
+
+| Campo | Quién lo consume | Ejemplo |
+|---|---|---|
+| `signal` | `/analyze`, para buscar la ficha de cada resultado | `detect_clickbait` |
+| `model_id` | el orquestador y la tool, para construir la llamada | `facebook/bart-large-mnli` |
+| `name` | la interfaz | `BART-large MNLI (zero-shot por inferencia)` |
+
+`model_id` es **`None`** en el léxico y el lineal. No es un hueco: dice que esa
+señal no es un modelo descargable —una son regex y listas de cues, la otra un
+JSON de pesos del propio repo—, y esa distinción se consulta desde fuera.
+
+El campo entra también en `FichaModelo`, el `TypedDict` que MCP publica como
+`outputSchema` de `describe_models`. Si sólo estuviera en el diccionario, el
+contrato publicado y la realidad divergirían — que es el mismo error, una capa
+más arriba.
+
+#### Una divergencia que ya estaba ahí
+
+Al recorrer los ocho sitios apareció uno que no era duplicación sino
+**discrepancia**: `IncoherenceDetector.MODEL` decía `"all-MiniLM-L6-v2"` mientras
+su ficha decía `"sentence-transformers/all-MiniLM-L6-v2"`.
+
+Dos cadenas distintas para el mismo modelo. Resolvían igual —`sentence-transformers`
+busca los nombres desnudos en su propia organización—, así que **no rompía nada**
+y podía durar indefinidamente con la divulgación diciendo una cosa y el código
+cargando otra. Es el caso que mejor ilustra la issue: el daño de la duplicación
+no es que falle, es que **no falla**.
+
+#### Unificar no basta
+
+Poner el id en un sitio no impide que vuelva a salir de ahí; sólo lo hace menos
+probable. Lo que lo impide es un test que capture **con qué modelo se llama de
+verdad** por cada camino: se sustituye el backend por un espía, se invocan las
+tools por el protocolo y las señales por el orquestador, y se compara lo
+capturado contra la ficha.
+
+Y como un test de regresión que nunca se ha visto fallar no demuestra nada, se
+comprobó introduciendo cada divergencia posible y verificando que la caza:
+
+```
+tool MCP con otro id                                       lo caza
+orquestador REST con otro id                               lo caza
+detector con el nombre desnudo (la divergencia que HABÍA)  lo caza
+```
+
+#### Lo que sigue duplicado, a propósito
+
+Las etiquetas candidatas `["clickbait", "factual news"]` continúan escritas en
+`orchestrator.py` y en `tool.py`. No se mueven a la ficha por dos razones: una
+ficha **divulga qué es una señal, no cómo se la invoca**, y meterle parámetros de
+llamada la convierte en configuración; y #115 sustituye ese modelo por un
+clasificador, que no lleva etiquetas candidatas — sería trabajo para borrarlo en
+la PR siguiente.
+
+O sea que #116 unifica **el identificador**, no toda la invocación. Queda anotado
+en el código como decisión, no como olvido.
+
 ### Tres señales de forma, pero una opinión y media (#109)
 
 La dimensión `forma` contrasta tres señales —léxico, lineal y zero-shot— y es la

--- a/backend/analysis/orchestrator.py
+++ b/backend/analysis/orchestrator.py
@@ -62,12 +62,18 @@ _detector = IncoherenceDetector()
 # test_model_cards_signals_match_registered_tools.
 _CARDS = cards_by_signal()
 
-# TODO(deuda): estos ids están duplicados en integrations/nlp/tool.py. Unificar
-# leyéndolos de MODEL_CARDS["name"] exige antes normalizar ese campo, que hoy
-# mezcla ids de HuggingFace con descripciones en prosa.
-_ZERO_SHOT_MODEL = "facebook/bart-large-mnli"
+# Los ids salen de la ficha (#116). Antes estaban cableados aquí y otra vez en
+# integrations/nlp/tool.py, así que cambiar el modelo en un sitio dejaba las dos
+# fachadas —REST y MCP— respondiendo con modelos distintos al mismo titular, y
+# sin que nada fallara: los dos caminos seguían devolviendo una etiqueta válida.
+_ZERO_SHOT_MODEL = _CARDS["detect_clickbait"]["model_id"]
+_SENTIMENT_MODEL = _CARDS["analyze_sentiment"]["model_id"]
+
+# Las etiquetas candidatas SIGUEN duplicadas en tool.py, y es deliberado: una
+# ficha divulga qué es cada señal, no cómo se la invoca. Además #115 sustituye
+# este modelo por un clasificador, que no lleva etiquetas candidatas — meterlas
+# ahora en la ficha sería trabajo para borrarlo en la siguiente PR.
 _ZERO_SHOT_LABELS = ["clickbait", "factual news"]
-_SENTIMENT_MODEL = "cardiffnlp/twitter-roberta-base-sentiment-latest"
 
 
 @dataclass(frozen=True)

--- a/backend/evaluation/eval_candidatos.py
+++ b/backend/evaluation/eval_candidatos.py
@@ -1,0 +1,273 @@
+"""¿Quién ocupa la tercera plaza de `forma`? (issue #115)
+
+`detect_clickbait` usa `facebook/bart-large-mnli`, elegido en E3-02 **por
+eliminación**: era lo único que el serverless de HuggingFace servía para esto. La
+condición del aplazamiento —«si llega la infra»— se cumplió en la Épica 5 con
+`LocalNLPClient`, y nadie volvió a la nota. #109 midió el coste: 63,7 % de
+acierto, la señal más floja de la dimensión.
+
+Esto compara candidatos para sustituirlo. **No basta con que acierten más.**
+
+LOS TRES CRITERIOS, y por qué son tres
+
+1. **Acierto fuera de dominio**, contra la clase mayoritaria y no en absoluto. Con
+   Webis al 69 % de negativos, responder «no» a todo ya da 69 %.
+
+2. **Independencia del par acoplado.** Un candidato preciso que coincida con
+   léxico+lineal no aporta nada: la plaza no necesita otra confirmación, necesita
+   una señal capaz de discrepar con fundamento. Sin este criterio se elegiría el
+   más exacto, que puede ser justamente el más redundante.
+
+3. **Ausencia de memorización.** `elozano/bert-base-cased-clickbait-news` sacó un
+   99,7 % en Chakraborty y un F1 de 0,185 en Webis: había memorizado el corpus con
+   el que lo medíamos. De ahí el campo ``entrenado_en``, que no es documentación
+   sino **lo que decide en qué corpus se le evalúa**: a cada candidato se le juzga
+   por el material que NO vio. Para los que no declaran su dataset, el patrón
+   —alto en uno, desplome en el otro— sigue delatándolo.
+
+Los dos corpus miden cosas distintas y por eso se conservan los dos: Chakraborty
+etiqueta **por fuente** (BuzzFeed = clickbait) y Webis por **juicio humano**
+(`truthMean`). Un modelo entrenado en el primero puede lucir sin haber aprendido
+clickbait; ninguno entrenado en el segundo puede evaluarse honestamente en él.
+
+    NLP_BACKEND=local python -m backend.evaluation.eval_candidatos
+"""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+# Se importan los MÓDULOS y no sus funciones porque ambos exportan una
+# `muestra_estratificada` distinta —una estratifica pares, la otra ternas con
+# `truthMean`— y con el prefijo delante se ve cuál es cuál en el punto de uso.
+from backend.evaluation import eval_acoplamiento as acopl
+from backend.evaluation import eval_transferencia as transf
+from backend.evaluation.eval_external import load_external
+from backend.evaluation.splits import load_split
+
+_RAIZ = Path(__file__).resolve().parents[2]
+
+SEMILLA = 24
+N_CHAKRABORTY = 300  # la misma muestra de #109, para que el kappa sea comparable
+N_WEBIS = 600
+
+# Sonda para fijar el mapeo de etiquetas de los clasificadores: las convenciones
+# no están normalizadas entre modelos y cablear el positivo al revés invertiría
+# el resultado sin que ninguna excepción avisara.
+SONDA_CLICKBAIT = "17 Things Nobody Tells You About Working From Home"
+SONDA_FACTUAL = "Federal Reserve raises interest rates by 0.25 percent"
+
+ETIQUETAS_ZS = ["clickbait", "factual news"]
+
+
+@dataclass(frozen=True)
+class Candidato:
+    """Un modelo a evaluar, con lo que hace falta para juzgarlo con justicia.
+
+    ``entrenado_en`` es el campo que gobierna la comparación: nombra el corpus que
+    el modelo YA VIO, y por tanto aquel en el que su puntuación no significa nada.
+    ``None`` significa que no vio ninguno de los dos —el caso de los NLI
+    genéricos—, y entonces ambos corpus son test honesto.
+    """
+
+    alias: str
+    modelo: str
+    modo: str  # "zero-shot" | "clasificacion"
+    entrenado_en: str | None
+    nota: str = ""
+
+    def honesto(self, corpus: str) -> bool:
+        return self.entrenado_en != corpus
+
+
+CANDIDATOS: tuple[Candidato, ...] = (
+    Candidato(
+        alias="INCUMBENTE bart-large-mnli",
+        modelo="facebook/bart-large-mnli",
+        modo="zero-shot",
+        entrenado_en=None,
+        nota="elegido en E3-02 por eliminación; línea base a batir",
+    ),
+    Candidato(
+        alias="Stremie roberta-base",
+        modelo="Stremie/roberta-base-clickbait",
+        modo="clasificacion",
+        entrenado_en="webis",
+        nota="declara Webis-Clickbait-17: entrenado con ETIQUETA HUMANA, no por fuente",
+    ),
+    Candidato(
+        alias="DeBERTa-v3-base NLI",
+        modelo="MoritzLaurer/DeBERTa-v3-base-mnli-fever-anli",
+        modo="zero-shot",
+        entrenado_en=None,
+        nota="NLI más fuerte que BART; conserva la inmunidad al sesgo de fuente",
+    ),
+)
+
+
+def _clave_cache(cand: Candidato, corpus: str, n: int) -> str:
+    """Nombre del fichero de caché.
+
+    El incumbente reutiliza las claves que ya escribieron #109 y
+    `eval_transferencia`: son las mismas predicciones sobre las mismas muestras,
+    y recalcularlas serían minutos de BART tirados.
+    """
+    if cand.modelo == "facebook/bart-large-mnli":
+        legado = {
+            "chakraborty": f"zero_shot_dev_{n}_{SEMILLA}",
+            "webis": f"zero_shot_webis_{n}_{SEMILLA}",
+        }
+        return legado[corpus]
+    slug = cand.modelo.replace("/", "_")
+    return f"cand_{slug}_{corpus}_{n}_{SEMILLA}"
+
+
+def _cacheado(clave: str, headlines: list[str], calcular) -> list[int]:
+    """Caché en disco con verificación de que corresponde a ESTA muestra.
+
+    Se comparan los titulares y no sólo el nombre del fichero: una clave que
+    coincidiera por casualidad daría un resultado equivocado en silencio, que es
+    peor que no tener caché.
+    """
+    fichero = _RAIZ / "var" / f"{clave}.json"
+    if fichero.exists():
+        guardado = json.loads(fichero.read_text(encoding="utf-8"))
+        if guardado["headlines"] == headlines:
+            print(f"      (reusando {fichero.name})")
+            return guardado["veredictos"]
+        print(f"      ({fichero.name} no corresponde a esta muestra: recalculando)")
+
+    veredictos = calcular()
+    fichero.parent.mkdir(parents=True, exist_ok=True)
+    fichero.write_text(
+        json.dumps({"headlines": headlines, "veredictos": veredictos}), encoding="utf-8"
+    )
+    return veredictos
+
+
+def predecir(cand: Candidato, headlines: list[str], corpus: str) -> list[int]:
+    """Veredictos 0/1 del candidato, con caché."""
+
+    def calcular() -> list[int]:
+        from transformers import pipeline
+
+        if cand.modo == "zero-shot":
+            pipe = pipeline("zero-shot-classification", model=cand.modelo)
+            salida = pipe(headlines, candidate_labels=ETIQUETAS_ZS)
+            return [int(s["labels"][0] == "clickbait") for s in salida]
+
+        pipe = pipeline("text-classification", model=cand.modelo)
+        sonda = pipe([SONDA_CLICKBAIT, SONDA_FACTUAL])
+        if sonda[0]["label"] == sonda[1]["label"]:
+            raise RuntimeError(
+                f"{cand.modelo}: la sonda no separa los dos casos ({sonda}); "
+                "el mapeo de etiquetas no se puede fijar automáticamente"
+            )
+        positiva = sonda[0]["label"]
+        print(f"      etiqueta positiva: «{positiva}»")
+        return [int(s["label"] == positiva) for s in pipe(headlines)]
+
+    print(f"    {cand.alias} sobre {corpus} ({len(headlines)})...", flush=True)
+    return _cacheado(_clave_cache(cand, corpus, len(headlines)), headlines, calcular)
+
+
+def _pct(x: float) -> str:
+    return f"{x * 100:.1f} %"
+
+
+if __name__ == "__main__":
+    # --- las dos muestras, con las mismas semillas que #109 ---
+    dev = acopl.muestra_estratificada(load_split("dev"), N_CHAKRABORTY, semilla=SEMILLA)
+    webis = transf.muestra_estratificada(load_external(), N_WEBIS, semilla=SEMILLA)
+
+    corpus = {
+        "chakraborty": {
+            "headlines": [p[0] for p in dev],
+            "y": [p[1] for p in dev],
+            "truth": None,
+            "etiqueta": "por FUENTE (BuzzFeed = clickbait)",
+        },
+        "webis": {
+            "headlines": [d[0] for d in webis],
+            "y": [d[1] for d in webis],
+            "truth": [d[2] for d in webis],
+            "etiqueta": "por JUICIO HUMANO (truthMean)",
+        },
+    }
+
+    print("LAS DOS MUESTRAS")
+    for nombre, c in corpus.items():
+        base = transf.clase_mayoritaria(c["y"])
+        print(
+            f"  {nombre:12} n={len(c['y']):>4}  positivos {_pct(sum(c['y']) / len(c['y']))}"
+            f"  ·  mayoritaria {_pct(base)}  ·  etiqueta {c['etiqueta']}"
+        )
+
+    # El par acoplado, para medir independencia. Se calcula una vez por corpus.
+    for c in corpus.values():
+        c["lex"], c["lin"] = acopl.predicciones(c["headlines"])
+
+    print("\n\nEVALUACIÓN")
+    resumen = []
+    for cand in CANDIDATOS:
+        print(f"\n{'=' * 78}\n{cand.alias}  ·  {cand.modelo}")
+        if cand.nota:
+            print(f"  {cand.nota}")
+        visto = cand.entrenado_en or "ninguno de los dos"
+        print(f"  entrenado en: {visto}")
+        print(f"{'=' * 78}")
+
+        print(f"\n  {'corpus':26} {'acierto':>8} {'prec':>7} {'rec':>7} {'F1':>7}")
+        for nombre, c in corpus.items():
+            pred = predecir(cand, c["headlines"], nombre)
+            m = transf.metricas(c["y"], pred)
+            marca = "" if cand.honesto(nombre) else "  <- CONTAMINADO (lo vio)"
+            print(
+                f"  {nombre:26} {_pct(m['acierto']):>8} {m['precision']:>7.3f} "
+                f"{m['recall']:>7.3f} {m['f1']:>7.3f}{marca}"
+            )
+            c[cand.alias] = pred
+            if cand.honesto(nombre):
+                resumen.append((cand.alias, nombre, m))
+
+        # --- criterio 2: ¿discrepa del par acoplado, o lo confirma? ---
+        print("\n  INDEPENDENCIA en el test honesto (kappa contra el par acoplado)")
+        for nombre, c in corpus.items():
+            if not cand.honesto(nombre):
+                continue
+            for otra in ("lex", "lin"):
+                a = acopl.acuerdo(c[cand.alias], c[otra])
+                nombre_otra = "lexical" if otra == "lex" else "linear"
+                print(
+                    f"    {nombre:12} vs {nombre_otra:8} acuerdo {_pct(a['observado']):>8}"
+                    f"   kappa {a['kappa']:>6.3f}"
+                )
+
+    # --- criterio 3 aplicado: respuesta a la intensidad, donde Webis es honesto ---
+    print(
+        f"\n\n{'=' * 78}\nRESPUESTA A LA INTENSIDAD (tercios de `truthMean`, solo positivos)"
+    )
+    print(f"{'=' * 78}")
+    c = corpus["webis"]
+    honestos = {
+        cand.alias: c[cand.alias] for cand in CANDIDATOS if cand.honesto("webis")
+    }
+    honestos["lexical"] = c["lex"]
+    filas = transf.recall_por_intensidad(c["y"], c["truth"], honestos)
+
+    cabecera = f"  {'tramo':12} {'n':>4} {'truthMean':>10}"
+    for nombre in honestos:
+        cabecera += f" {nombre[:13]:>14}"
+    print(cabecera)
+    for etiqueta, fila in zip(("tibios", "medios", "flagrantes"), filas, strict=True):
+        linea = f"  {etiqueta:12} {fila['n']:>4} {fila['truth_medio']:>10.2f}"
+        for nombre in honestos:
+            linea += f" {_pct(fila[nombre]):>14}"
+        print(linea)
+
+    print("\n\nRESUMEN · sólo tests honestos")
+    print(f"  {'candidato':28} {'corpus':14} {'F1':>7} {'acierto':>9}")
+    for alias, nombre, m in resumen:
+        print(f"  {alias:28} {nombre:14} {m['f1']:>7.3f} {_pct(m['acierto']):>9}")
+    print("\n  Recuerda los tres criterios: acierto fuera de dominio, INDEPENDENCIA")
+    print("  del par acoplado, y ausencia del patrón de memorización.")

--- a/backend/integrations/nlp/incoherence.py
+++ b/backend/integrations/nlp/incoherence.py
@@ -1,10 +1,17 @@
 import asyncio
 
 from backend.core.models import ToolResult
+from backend.integrations.nlp.model_cards import cards_by_signal
 
 
 class IncoherenceDetector:
-    MODEL = "all-MiniLM-L6-v2"
+    # El id sale de la ficha (#116). Antes estaba aquí como "all-MiniLM-L6-v2",
+    # SIN el prefijo `sentence-transformers/` que sí llevaba la ficha: dos
+    # cadenas distintas para el mismo modelo. Resolvían igual —la librería busca
+    # los nombres desnudos en su propia organización—, así que la divergencia no
+    # rompía nada y podía sobrevivir indefinidamente mientras la divulgación
+    # decía una cosa y el código cargaba otra. Es el caso exacto que motiva #116.
+    MODEL = cards_by_signal()["detect_clickbait_incoherence"]["model_id"]
     THRESHOLD = 0.3  # Lower es clickbait #TODO: Parametrizable
 
     def __init__(self) -> None:

--- a/backend/integrations/nlp/model_cards.py
+++ b/backend/integrations/nlp/model_cards.py
@@ -8,12 +8,24 @@ marca qué señales son white-box (``interpretable``) frente a caja negra
 La otra mitad de R3.9 (intercambiar modelos por configuración) la cubre la
 factoría ``get_nlp_backend`` vía el setting ``nlp_backend`` (remote/local).
 
-El campo ``signal`` es la **clave de máquina**: debe coincidir EXACTAMENTE con el
-nombre de la tool MCP que produce esa señal, porque ``/analyze`` lo usa para
-buscar la ficha de cada resultado. No es una etiqueta legible —para eso están
-``name`` y ``task``— y meterle anotaciones («detect_clickbait (zero-shot)»)
-rompe la búsqueda en silencio: no lanza excepción, simplemente no encuentra la
-ficha. ``test_model_cards_signals_match_registered_tools`` lo vigila.
+TRES CAMPOS QUE PARECEN LO MISMO Y NO LO SON
+
+- ``signal`` — **clave de máquina**: coincide EXACTAMENTE con el nombre de la
+  tool MCP que produce esa señal, porque ``/analyze`` la usa para buscar la ficha
+  de cada resultado. Meterle anotaciones («detect_clickbait (zero-shot)») rompe
+  la búsqueda en silencio: no lanza excepción, simplemente no encuentra la ficha.
+  ``test_model_cards_signals_match_registered_tools`` lo vigila.
+- ``model_id`` — **identificador en HuggingFace**, y la fuente ÚNICA desde la que
+  el orquestador y la tool construyen su llamada. Es ``None`` en las señales que
+  no son un modelo descargable (léxico y lineal), y ese ``None`` es información.
+- ``name`` — **etiqueta para personas**, la que se pinta en la interfaz.
+
+Estaban fundidos en ``name``, que era un id crudo en tres fichas y prosa en dos,
+así que el id acabó cableado en cinco sitios y las dos fachadas —REST y MCP—
+podían quedarse con modelos distintos sin que nada fallara (#116). Separarlos es
+lo que permite que el id viva en un solo lugar; ``test_los_ids_de_las_fichas_son_los_que_se_usan``
+comprueba que la llamada real usa el de la ficha, que es lo único que impide que
+vuelvan a separarse.
 
 El campo ``dimension`` indica QUÉ mide cada señal, no cómo de transparente es:
 
@@ -42,7 +54,8 @@ def cards_by_signal() -> dict[str, dict]:
 MODEL_CARDS = [
     {
         "signal": "detect_clickbait",
-        "name": "facebook/bart-large-mnli",
+        "model_id": "facebook/bart-large-mnli",
+        "name": "BART-large MNLI (zero-shot por inferencia)",
         "task": "Clasifica el titular como clickbait vs factual por inferencia natural (NLI, zero-shot).",
         "type": "opaco",
         "dimension": "forma",
@@ -58,7 +71,8 @@ MODEL_CARDS = [
     },
     {
         "signal": "analyze_sentiment",
-        "name": "cardiffnlp/twitter-roberta-base-sentiment-latest",
+        "model_id": "cardiffnlp/twitter-roberta-base-sentiment-latest",
+        "name": "RoBERTa afinado en tuits (3 clases)",
         "task": "Análisis de sentimiento en 3 clases (positivo / neutral / negativo).",
         "type": "opaco",
         "dimension": "tono",
@@ -72,7 +86,8 @@ MODEL_CARDS = [
     {
         "signal": "detect_clickbait_incoherence",
         "dimension": "engano",
-        "name": "sentence-transformers/all-MiniLM-L6-v2",
+        "model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        "name": "MiniLM-L6-v2 (embeddings de frase)",
         "task": "Similitud coseno titular↔contenido; una similitud baja indica posible clickbait por incoherencia.",
         "type": "híbrido",
         "limitations": [
@@ -86,6 +101,8 @@ MODEL_CARDS = [
     {
         "signal": "detect_clickbait_lexical",
         "dimension": "forma",
+        # Sin `model_id`: no hay nada que descargar. Son regex y listas de cues.
+        "model_id": None,
         "name": "Léxico por reglas (listas de cues de Chakraborty et al. 2016)",
         "task": "Detecta pistas léxicas/estructurales de clickbait y devuelve qué cues dispararon y dónde.",
         "type": "interpretable",
@@ -103,6 +120,8 @@ MODEL_CARDS = [
     {
         "signal": "detect_clickbait_linear",
         "dimension": "forma",
+        # Sin `model_id`: los pesos son un JSON del repo, no un modelo de la Hub.
+        "model_id": None,
         "name": "Regresión logística sobre features léxicas (entrenada en Chakraborty)",
         "task": "Clickbait ponderado: aprende el peso de cada pista y devuelve los cues que más contribuyeron al veredicto.",
         "type": "interpretable",

--- a/backend/integrations/nlp/outputs.py
+++ b/backend/integrations/nlp/outputs.py
@@ -69,9 +69,20 @@ class SalidaIncoherencia(TypedDict):
 
 
 class FichaModelo(TypedDict):
-    """Una entrada de la divulgación de modelos."""
+    """Una entrada de la divulgación de modelos.
+
+    Tres campos parecen lo mismo y no lo son, así que conviene fijarlos aquí:
+    ``signal`` es el nombre de la tool MCP, ``model_id`` el identificador en
+    HuggingFace y ``name`` la etiqueta que lee una persona. Cada uno lo consume
+    alguien distinto —el orquestador, la llamada al backend y la interfaz—, y
+    cuando eran un solo campo había que elegir a quién servir mal (#116).
+
+    ``model_id`` es ``None`` en las señales que no son un modelo descargable —el
+    léxico y el lineal—, y ese ``None`` es información, no un hueco.
+    """
 
     signal: str
+    model_id: str | None
     name: str
     task: str
     type: str

--- a/backend/integrations/nlp/tool.py
+++ b/backend/integrations/nlp/tool.py
@@ -30,6 +30,11 @@ def register(mcp: FastMCP):
     api = get_nlp_backend()
     detector = IncoherenceDetector()
 
+    # Los ids de modelo salen de las fichas (#116), no cableados aquí. Se
+    # resuelven una vez al registrar y no en cada llamada: MODEL_CARDS es una
+    # constante de módulo, así que releerla por invocación sería trabajo inútil.
+    _ficha = model_cards.cards_by_signal()
+
     @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
     async def detect_clickbait(headline: str) -> Etiqueta:
@@ -51,8 +56,7 @@ def register(mcp: FastMCP):
         """
         response = await api.zero_shot(
             headline,
-            "facebook/bart-large-mnli",
-            # modelo Zero-SHot para MVP
+            _ficha["detect_clickbait"]["model_id"],
             ["clickbait", "factual news"],
             # Labels para crear y descartar hipotesis. FIJOS para no confundir LLM.
         )
@@ -78,9 +82,7 @@ def register(mcp: FastMCP):
         Raises:
             Si la llamada al modelo falla (timeout o caída del proveedor).
         """
-        response = await api.classify(
-            text, "cardiffnlp/twitter-roberta-base-sentiment-latest"
-        )
+        response = await api.classify(text, _ficha["analyze_sentiment"]["model_id"])
         if not response.has_content():
             raise ToolError(response.error or "Error al analizar el sentimiento")
         return response.data

--- a/tests/integrations/test_nlp.py
+++ b/tests/integrations/test_nlp.py
@@ -464,6 +464,7 @@ def test_linear_detector_no_headline():
 def test_model_cards_wellformed():
     required = {
         "signal",
+        "model_id",
         "name",
         "task",
         "type",
@@ -479,6 +480,77 @@ def test_model_cards_wellformed():
         assert card["type"] in valid_types
         assert card["dimension"] in valid_dimensions
         assert isinstance(card["limitations"], list) and card["limitations"]
+
+
+def test_model_id_es_id_de_maquina_o_None():
+    # `model_id` es lo que se le pasa al backend, así que o es un identificador
+    # de la Hub («org/modelo») o es None. Una etiqueta legible colada aquí
+    # rompería la carga del modelo, no la divulgación.
+    for card in model_cards.MODEL_CARDS:
+        model_id = card["model_id"]
+        if model_id is None:
+            continue  # léxico y lineal: no hay nada que descargar
+        assert isinstance(model_id, str) and model_id.strip()
+        assert "/" in model_id, f"{card['signal']}: «{model_id}» no parece un id"
+        assert model_id == model_id.strip()
+
+
+@pytest.mark.asyncio
+async def test_las_dos_fachadas_usan_el_id_de_la_ficha(monkeypatch):
+    """El test que justifica #116: unificar los ids no impide que vuelvan a separarse.
+
+    El id vivía cableado en la tool MCP, en el orquestador REST y en el detector
+    de incoherencia, además de en la ficha. Cambiarlo en un sitio dejaba las dos
+    fachadas respondiendo con modelos distintos al mismo titular **sin que nada
+    fallara**: los dos caminos seguían devolviendo una etiqueta válida.
+
+    Por eso no basta con comprobar que las constantes existen: hay que capturar
+    con qué modelo se llama DE VERDAD por cada camino.
+    """
+    from backend.analysis import orchestrator
+    from backend.core.models import ToolResult
+
+    fichas = model_cards.cards_by_signal()
+
+    class _Espia:
+        def __init__(self):
+            self.modelos = {}
+
+        async def zero_shot(self, text, model, labels):
+            self.modelos["zero_shot"] = model
+            return ToolResult.ok({"label": "clickbait", "score": 0.9})
+
+        async def classify(self, text, model):
+            self.modelos["classify"] = model
+            return ToolResult.ok({"label": "neutral", "score": 0.8})
+
+    # --- fachada MCP ---
+    espia_mcp = _Espia()
+    monkeypatch.setattr(nlp_tool, "get_nlp_backend", lambda: espia_mcp)
+    mcp = FastMCP("test")
+    nlp_tool.register(mcp)
+    await mcp.call_tool("detect_clickbait", {"headline": "Un titular"})
+    await mcp.call_tool("analyze_sentiment", {"text": "Un texto"})
+
+    # --- fachada REST ---
+    espia_rest = _Espia()
+    monkeypatch.setattr(orchestrator, "_api", espia_rest)
+    await orchestrator._run_signals("Un titular", None)
+
+    esperado = {
+        "zero_shot": fichas["detect_clickbait"]["model_id"],
+        "classify": fichas["analyze_sentiment"]["model_id"],
+    }
+    assert espia_mcp.modelos == esperado, "la tool MCP no usa el id de la ficha"
+    assert espia_rest.modelos == esperado, "el orquestador no usa el id de la ficha"
+
+    # El tercero no pasa por el backend NLP: carga su modelo él mismo. Antes
+    # decía "all-MiniLM-L6-v2" mientras la ficha decía la ruta completa — dos
+    # cadenas distintas que resolvían al mismo sitio, así que la divergencia no
+    # rompía nada y podía durar para siempre.
+    assert (
+        IncoherenceDetector.MODEL == fichas["detect_clickbait_incoherence"]["model_id"]
+    )
 
 
 def test_model_cards_serializable_and_cover_signals():


### PR DESCRIPTION
Cierra #116.

Tres modelos, **ocho declaraciones de su identificador** repartidas por el
backend. Cambiar el modelo de una señal en un sitio y no en los otros dejaba las
dos fachadas —REST y MCP— respondiendo con **modelos distintos al mismo titular**,
y sin que nada fallara: los dos caminos seguían devolviendo una etiqueta válida.

Salió al preparar #115, que es precisamente un cambio de modelo.

## Por qué no se había hecho antes

El `TODO` que lo registraba nombraba también el obstáculo: unificar leyendo de
`MODEL_CARDS["name"]` exigía normalizar antes ese campo, que valía
`"facebook/bart-large-mnli"` en tres fichas y `"Léxico por reglas (…)"` en dos.
Un solo campo intentando ser identificador de máquina y etiqueta para personas.

## La separación

| Campo | Quién lo consume | Ejemplo |
|---|---|---|
| `signal` | `/analyze`, para buscar la ficha de cada resultado | `detect_clickbait` |
| `model_id` | el orquestador y la tool, para construir la llamada | `facebook/bart-large-mnli` |
| `name` | la interfaz | `BART-large MNLI (zero-shot por inferencia)` |

`model_id` es `None` en el léxico y el lineal: no son modelos descargables, y esa
distinción se consulta desde fuera. El campo entra también en `FichaModelo`, el
`TypedDict` que MCP publica como `outputSchema` de `describe_models` — si sólo
estuviera en el diccionario, el contrato publicado y la realidad divergirían.

## Una divergencia que ya estaba ahí

`IncoherenceDetector.MODEL` decía `"all-MiniLM-L6-v2"` mientras su ficha decía
`"sentence-transformers/all-MiniLM-L6-v2"`. Dos cadenas distintas para el mismo
modelo. Resolvían igual, así que **no rompía nada** y podía durar indefinidamente
con la divulgación diciendo una cosa y el código cargando otra.

Es el caso que mejor ilustra la issue: el daño de la duplicación no es que falle,
es que no falla.

## Unificar no basta

Poner el id en un sitio no impide que vuelva a salir de ahí. Lo que lo impide es
un test que capture **con qué modelo se llama de verdad** por cada camino:
sustituye el backend por un espía, invoca las tools por el protocolo y las
señales por el orquestador, y compara lo capturado contra la ficha.

Y como un test de regresión que nunca se ha visto fallar no demuestra nada, se
verificó introduciendo cada divergencia posible:

```
tool MCP con otro id                                       lo caza
orquestador REST con otro id                               lo caza
detector con el nombre desnudo (la divergencia que HABÍA)  lo caza
```

## Lo que sigue duplicado, a propósito

Las etiquetas candidatas `["clickbait", "factual news"]` siguen en
`orchestrator.py` y en `tool.py`. Una ficha divulga **qué es** una señal, no cómo
se la invoca; y #115 sustituye ese modelo por un clasificador, que no lleva
etiquetas candidatas. Queda anotado en el código como decisión, no como olvido.

## Un fichero que viaja de más

Incluye `backend/evaluation/eval_candidatos.py`, la comparativa de modelos que
sustenta la decisión de #115. No pertenece a esta issue; se adelanta aquí porque
#115 arranca inmediatamente después y el módulo ya está medido y verificado.

## Verificación

192 tests pasan (dos nuevos), ruff y formato limpios.
