### PR TITLE
feat(nlp): un modelo dedicado y entrenado con etiqueta humana para la señal de clickbait (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,180 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### Una decisión que caducó dos épicas antes de que nadie volviera (#115)
+
+`detect_clickbait` usaba `facebook/bart-large-mnli`. El registro de **E3-02** dice
+por qué, sin ambigüedad:
+
+> *«el serverless `hf-inference` **no sirve ningún modelo de clickbait
+> específico** […] Lo **único** viable para clickbait en remoto es zero-shot vía
+> `bart-large-mnli`.»*
+>
+> *«**Decisión:** zero-shot remoto con `bart-large-mnli` **para el MVP**. […]
+> dejamos `elozano` como **mejora futura** en backend local, **si llega la
+> infra**.»*
+
+Se eligió **por eliminación**, no por mérito. La evidencia que lo sostenía era
+*«discrimina bien, ver ejemplo arriba»*: un ejemplo suelto, no una medida.
+
+Y la infra llegó. `LocalNLPClient`, construido en la Épica 5, carga cualquier
+modelo de HuggingFace sin pasar por el proveedor serverless que era la
+restricción original. **La condición del aplazamiento se cumplió dos épicas antes
+de que nadie volviera a la nota**, porque nadie tenía motivo para releerla.
+
+#### El sustituto obvio era el equivocado
+
+E3-02 dejaba nombre y apellidos: `elozano/bert-base-cased-clickbait-news`, un
+modelo entrenado *en* clickbait. Medido en #109 dio **99,7 %** sobre Chakraborty
+dev — y ese número, en ese corpus, es motivo de sospecha y no de celebración.
+Fuera: **F1 0,185** contra una clase mayoritaria del 69,0 %. Memorización.
+
+Eso obligó a buscar de verdad, con tres criterios y en este orden:
+
+1. **Licencia** clara que permita uso citando.
+2. **Procedencia de la etiqueta.** Humana vale; por-fuente reproduce el atajo que
+   #76 destapó y #109 cuantificó.
+3. **Independencia** del par acoplado — porque la plaza no necesita otra
+   confirmación, necesita una señal capaz de discrepar con fundamento.
+
+#### Y ahí salió el hallazgo que no buscábamos
+
+39 datasets candidatos en el Hub. En inglés y con licencia permisiva, cinco. Los
+cinco son **Chakraborty reempaquetado**, medido por solapamiento de titulares:
+
+| Dataset | Licencia | Solapamiento |
+|---|---|---|
+| `marksverdhei/clickbait_title_classification` | MIT | **100 %** |
+| `christinacdl/Multilingual_Clickbait_Dataset` | Apache-2.0 | 86 % |
+| `christinacdl/clickbait_detection_dataset` | Apache-2.0 | 86 % |
+| `christinacdl/clickbait_notclickbait_dataset` | Apache-2.0 | 57 % |
+| `christinacdl/Clickbait_New` | Apache-2.0 | 56 % |
+
+*(100 filas de cada uno; es cota inferior.)*
+
+**La variedad de corpus de clickbait es ilusoria: un dataset con cinco
+envoltorios.** Eso explica estructuralmente el caso de elozano —no fue mala
+suerte al elegir, es que casi todo lo que hay arrastra las mismas etiquetas
+por-fuente— y responde el bullet de #78 «búsqueda de corpus adicionales» con un
+**no medido** en vez de con un «no encontré».
+
+El inventario real en inglés es **Chakraborty** (etiqueta por fuente) y
+**Webis-17** (etiqueta humana). Nada más.
+
+#### El elegido, y por qué su patrón es el inverso
+
+`Stremie/roberta-base-clickbait`, Apache-2.0, cuyo README declara entrenamiento
+sobre **Webis-17** y **`postText`** — el mismo campo que tenemos vendorizado, sin
+desajuste — con ~0,7 de F1 en su test.
+
+|  | En su propio corpus | Fuera |
+|---|---|---|
+| `elozano` | 99,7 % (Chakraborty) | **F1 0,185** (Webis) |
+| `Stremie` | F1 0,631 (Webis) | **F1 0,946** (Chakraborty) |
+
+Alto **fuera** y más bajo **dentro**: eso es generalizar, no memorizar. Un modelo
+que hubiera memorizado rozaría el 1,0 en su propio material.
+
+Y el detalle que más pesa para la memoria: ese 0,946 en Chakraborty **supera al
+0,865 que el lineal saca dentro de su propio dominio**. Un modelo entrenado con
+juicio humano transfiere al corpus etiquetado por fuente mejor de lo que el
+modelo entrenado en ese corpus se maneja en él. Es el argumento de #78 —*la
+palanca es la supervisión, no el algoritmo*— medido por segunda vez y desde el
+otro lado.
+
+*(De paso contextualiza todos los números de Webis: si un modelo entrenado allí
+sólo llega a 0,631, el ~0,50 de nuestras señales no estaba tan lejos del techo
+real como parecía.)*
+
+#### El voto vuelve, y no es una marcha atrás
+
+#109 le había quitado el voto a esta señal. La sustitución lo devuelve:
+
+| Tercera señal | Acierto | `forma` AMBIGUO | de esa ambigüedad, error suyo |
+|---|---|---|---|
+| BART (antes) | 63,7 % | 37,0 % | **78,4 %** |
+| Stremie | **94,7 %** | **15,0 %** | **20,0 %** |
+
+Cuatro de cada cinco ambigüedades pasan de ser ruido a ser discrepancia legítima.
+Ése es el criterio, y no el acierto: *ambiguo* debe querer decir que dos señales
+fiables no coinciden, no que alguna se equivocó.
+
+No es contradecir a #109. Aquel silencio se declaró **condicional** en la propia
+ficha —«placeholder pendiente de #115»— precisamente para que se pudiera
+encontrar cuando llegara el momento. Es la lección de E3-02 aplicada: una nota
+provisional debe decir **qué la desbloquearía**.
+
+#### `dedicated.py`, o por qué faltaba un módulo
+
+Al ir a escribir la traducción de etiquetas apareció la causa de fondo de #116.
+Tres de las cinco señales tenían módulo propio —`lexical`, `linear`,
+`incoherence`—; ésta y el tono, no: llamaban al backend directamente **desde las
+dos fachadas**. Por eso su id y sus etiquetas acabaron duplicados: no había dónde
+ponerlos.
+
+`backend/integrations/nlp/dedicated.py` cierra esa asimetría. Contiene el id (que
+lee de la ficha), el mapeo de etiquetas y la normalización, y las dos fachadas lo
+llaman. El vocabulario del modelo **no sale hacia fuera**: la tool sigue
+publicando `clickbait`/`factual news`, que es contrato leído por el LLM, de modo
+que el próximo cambio de modelo no se propaga a quien consume la señal.
+
+Y ese mapeo **falla en vez de dejar pasar** una etiqueta que no conozca. Si se
+colara, el extractor de veredicto la compararía con `clickbait`, no coincidiría,
+y **todos los titulares saldrían factuales sin que se levantara ninguna
+excepción**. Es el mismo patrón que #116: el fallo peligroso no es el que rompe,
+es el que no rompe.
+
+#### Lo que no arregla
+
+Sigue siendo una señal **opaca**, así que `forma` gana acierto y no gana
+transparencia. Y su independencia del par acoplado es **desconocida, que no es lo
+mismo que buena**: su único corpus de test honesto es Chakraborty, donde tres
+clasificadores competentes coinciden por fuerza (kappa 0,726 y 0,772), y en Webis
+no se puede medir porque es su material de entrenamiento. Queda declarado en la
+ficha en esos términos.
+
+La segunda señal interpretable e independiente que a `forma` le sigue faltando es
+#75.
+
+#### Auditar el requisito destapó que el código mentía
+
+Cambiar de modelo es la prueba de fuego de **R3.9**, que pide divulgar los
+modelos empleados **y permitir intercambiarlos por configuración, sin cambios de
+código**. Así que al terminar se comprobó contra `docs/requisitos.md`.
+
+La primera mitad se cumple. La segunda **no**: la sustitución exigió tocar la
+tabla de fichas, escribir `dedicated.py` y añadir un mapeo de etiquetas. Todo
+código, que es justo lo que el requisito excluye.
+
+Lo llamativo es que el docstring de `model_cards.py` **afirmaba lo contrario**:
+
+> *«La otra mitad de R3.9 (intercambiar modelos por configuración) la cubre la
+> factoría `get_nlp_backend` vía el setting `nlp_backend` (remote/local).»*
+
+`nlp_backend` decide **dónde** corre el modelo, no **cuál** es. El docstring
+confundía las dos cosas y daba por cumplido un requisito que no lo estaba —
+durante dos épicas, sin que nadie lo notara, porque hasta ahora nunca se había
+cambiado un modelo. Corregido aquí; el hueco queda en **#119**.
+
+Y hay una tensión que conviene registrar antes de implementar nada, porque puede
+que la respuesta correcta sea matizar el requisito y no forzar el código: **el id
+se configura fácil, el mapeo de etiquetas no**. Cada modelo trae su vocabulario
+—`Clickbait`/`Not Clickbait` aquí, `LABEL_0`/`LABEL_1` en muchos otros— y la
+traducción es específica de cada uno. Se suma la diferencia de modo de
+invocación: un clasificador se llama con `classify`, un NLI con `zero_shot` más
+etiquetas candidatas. Cambiar entre esas dos familias no es cambiar un id.
+
+Del resto de lo auditado, dos apuntes que no son incumplimiento:
+
+- **R3.5** (texto vacío → error) sale **reforzado**: `dedicated.detect` comprueba
+  el titular antes de llamar al modelo.
+- **R3.8** (priorizar medios interpretables) gana **evidencia propia a favor**: lo
+  medido en #109 dice que la señal white-box es la que mejor generaliza fuera de
+  dominio, por delante de las opacas.
+- **R3.6** (tiempos razonables) probablemente mejora —el modelo pasa de
+  BART-large a un roberta-base—, pero **no se ha medido**, así que no se apunta
+  como mejora.
+
 ### Un campo que servía a tres amos: los ids de modelo (#116)
 
 Tres modelos, **ocho declaraciones de su identificador** repartidas por el

--- a/backend/analysis/orchestrator.py
+++ b/backend/analysis/orchestrator.py
@@ -4,9 +4,10 @@ Lanza las señales de clickbait a la vez, envuelve cada una en el formato
 uniforme de ``domain`` y agrega el resultado. Tres invariantes lo gobiernan:
 
 1. **Una señal vota si —y solo si— su ``is_clickbait`` no es None.** Ahí caen
-   sin caso especial tres cosas distintas: las que fallaron, el tono —que por
-   naturaleza no emite veredicto de clickbait— y, desde #109, las excluidas por
-   medición, hoy solo el zero-shot (el porqué, en su entrada de ``_SIGNALS``).
+   sin caso especial las que fallaron y el tono, que por naturaleza no emite
+   veredicto de clickbait. Entre #109 y #115 hubo un tercer caso —una señal
+   excluida por medirse peor que las demás— y el mismo ``None`` bastó para
+   expresarlo sin tocar la agregación: la palanca ya estaba puesta.
 2. **Una dimensión aparece si alguna de sus señales votó.** Si las que votaron
    discrepan, no se promedia ni se resuelve por mayoría: se declara ``None``.
 3. **El veredicto global sale de las dimensiones con jerarquía** —el engaño pesa
@@ -43,7 +44,7 @@ from backend.analysis.domain import (
     SignalType,
 )
 from backend.core.models import ToolResult
-from backend.integrations.nlp import lexical, linear
+from backend.integrations.nlp import dedicated, lexical, linear
 from backend.integrations.nlp.factory import get_nlp_backend
 from backend.integrations.nlp.incoherence import IncoherenceDetector
 from backend.integrations.nlp.model_cards import cards_by_signal
@@ -62,18 +63,15 @@ _detector = IncoherenceDetector()
 # test_model_cards_signals_match_registered_tools.
 _CARDS = cards_by_signal()
 
-# Los ids salen de la ficha (#116). Antes estaban cableados aquí y otra vez en
+# El id sale de la ficha (#116). Antes estaba cableado aquí y otra vez en
 # integrations/nlp/tool.py, así que cambiar el modelo en un sitio dejaba las dos
 # fachadas —REST y MCP— respondiendo con modelos distintos al mismo titular, y
 # sin que nada fallara: los dos caminos seguían devolviendo una etiqueta válida.
-_ZERO_SHOT_MODEL = _CARDS["detect_clickbait"]["model_id"]
+#
+# Sólo queda el del tono: la señal de clickbait pasó a `integrations/nlp/dedicated`
+# en #115, que es donde viven ya sus hermanas —léxico, lineal, incoherencia— y
+# donde el id y el mapeo de etiquetas tienen un único sitio.
 _SENTIMENT_MODEL = _CARDS["analyze_sentiment"]["model_id"]
-
-# Las etiquetas candidatas SIGUEN duplicadas en tool.py, y es deliberado: una
-# ficha divulga qué es cada señal, no cómo se la invoca. Además #115 sustituye
-# este modelo por un clasificador, que no lleva etiquetas candidatas — meterlas
-# ahora en la ficha sería trabajo para borrarlo en la siguiente PR.
-_ZERO_SHOT_LABELS = ["clickbait", "factual news"]
 
 
 @dataclass(frozen=True)
@@ -116,36 +114,26 @@ class _Signal:
 _SIGNALS: tuple[_Signal, ...] = (
     _Signal(
         name="detect_clickbait",
-        run=lambda h, c: _api.zero_shot(h, _ZERO_SHOT_MODEL, _ZERO_SHOT_LABELS),
-        # NO VOTA desde #109: se sigue mostrando como tarjeta, pero su veredicto
-        # no entra en `forma`. Devolver None aquí es toda la implementación,
-        # igual que en el tono — pero por un motivo distinto, y conviene no
-        # confundirlos: el tono no vota porque MIDE OTRA COSA; este no vota
-        # porque, midiendo lo mismo, se midió peor.
+        run=lambda h, c: dedicated.detect(_api, h),
+        # VUELVE A VOTAR (#115), después de que #109 se lo quitara. No es una
+        # marcha atrás: aquel silencio se declaró condicional en la ficha —
+        # «placeholder pendiente de #115»— y esto es la condición cumpliéndose.
         #
-        # Es la señal más floja en los DOS dominios evaluados: 63,7 % de acierto
-        # en Chakraborty dev, frente al 87,0 % del léxico y el 89,3 % del
-        # lineal; y F1 0,405 en Webis-17, frente a 0,526 y 0,519.
+        # Lo que #109 silenció fue un modelo elegido POR ELIMINACIÓN en E3-02,
+        # que acertaba el 63,7 %. Su problema no era el error sino cómo se
+        # propagaba: al discrepar en solitario dejaba la dimensión en None
+        # (invariante 2), y así el 37 % de los titulares salía AMBIGUO con el
+        # 78 % de esa ambigüedad siendo un error suyo.
         #
-        # Lo que obligaba a silenciarla no era su error, sino cómo se propagaba.
-        # Al discrepar en solitario dejaba la dimensión en None (invariante 2),
-        # de modo que el 37 % de los titulares salía AMBIGUO — y el 78 % de esa
-        # ambigüedad era un error suyo. «Ambiguo» debe significar que dos
-        # señales fiables discrepan, no que alguna discrepa; si no, se le
-        # presenta al usuario ruido con apariencia de matiz.
+        # El sustituto cambia esos dos números a 15 % y 20 %. O sea que cuatro
+        # de cada cinco ambigüedades pasan a ser discrepancia legítima, y
+        # AMBIGUO recupera el significado que la tesis le atribuye. Ése es el
+        # criterio, y no el acierto: «ambiguo» debe querer decir que dos señales
+        # fiables no coinciden, no que alguna se equivocó.
         #
-        # Callarla NO arregla el fondo: `forma` queda entonces sobre el par
-        # léxico+lineal, acoplado POR CONSTRUCCIÓN (el veredicto del léxico es
-        # el indicador de soporte del mismo vector que consume el lineal, con
-        # THRESHOLD=1). La dimensión pasa a descansar sobre una sola familia de
-        # evidencia, y eso está declarado en las fichas.
-        #
-        # El modelo es además un placeholder heredado de E3-02, elegido por
-        # eliminación —lo único que el serverless de HuggingFace servía— y no
-        # por medida. Sustituirlo es #115; se conserva visible mientras tanto
-        # porque, al no haber visto ningún corpus de clickbait, es la única
-        # señal inmune al sesgo de fuente (#78).
-        verdict=lambda d: None,
+        # La etiqueta la normaliza `dedicated`, no esta tabla: el veredicto se
+        # lee igual que antes aunque el modelo de debajo hable otro idioma.
+        verdict=lambda d: d["label"] == "clickbait",
     ),
     _Signal(
         name="detect_clickbait_lexical",

--- a/backend/integrations/nlp/dedicated.py
+++ b/backend/integrations/nlp/dedicated.py
@@ -1,0 +1,79 @@
+"""Señal de clickbait con un modelo dedicado (issue #115).
+
+Las otras señales de titular ya tenían módulo propio —``lexical``, ``linear``,
+``incoherence``—; ésta no, y llamaba al backend directamente desde las DOS
+fachadas. Esa asimetría es la causa de que su id y sus etiquetas acabaran
+duplicados (#116): no había dónde ponerlos. Aquí los hay.
+
+POR QUÉ ESTE MODELO
+
+``Stremie/roberta-base-clickbait`` sustituye a ``facebook/bart-large-mnli``, que
+se eligió en E3-02 **por eliminación** —era lo único que el serverless de
+HuggingFace servía para esto— y nunca por medida. Medido en #109, aquél acertaba
+el 63,7 %: la señal más floja de la dimensión.
+
+Lo que distingue a éste no es su puntuación, es **de qué aprendió**. Se entrenó
+sobre Webis-Clickbait-17, cuyas etiquetas son el juicio de anotadores humanos, no
+la fuente que publicó el titular. Es la única señal del sistema con supervisión
+no sesgada por fuente, y eso importa más que unos puntos de acierto: el sesgo de
+fuente es el fallo que #76 destapó y que #109 cuantificó.
+
+Su patrón es además **el inverso** del que descartó a ``elozano``:
+
+    elozano   99,7 % en Chakraborty (su corpus)  ->  F1 0,185 en Webis
+    Stremie    0,631 F1 en Webis (su corpus)     ->  F1 0,946 en Chakraborty
+
+Alto FUERA y más bajo DENTRO. Eso es generalizar, no memorizar — y su 0,946 en
+Chakraborty supera al 0,865 que el lineal saca *dentro* de su propio dominio.
+
+Con él, la dimensión ``forma`` deja el 15 % de titulares sin resolver en vez del
+37 %, y sólo el 20 % de esa ambigüedad restante es error suyo (antes, el 78 %).
+Por eso **vuelve a votar**: el motivo por el que #109 lo silenció desaparece.
+
+Lo que NO arregla: sigue siendo opaca, y su independencia del par acoplado es
+**desconocida** —no buena—, porque su único corpus de test honesto es el fácil.
+Ver la ficha.
+"""
+
+from backend.core.models import ToolResult
+from backend.integrations.nlp.model_cards import cards_by_signal
+
+MODEL = cards_by_signal()["detect_clickbait"]["model_id"]
+
+# El vocabulario del modelo NO sale hacia fuera. La tool MCP publica
+# `clickbait`/`factual news`, que es contrato leído por el LLM (spike #82), y
+# mantenerlo estable significa que el próximo cambio de modelo no se propaga a
+# quien consume la señal. Traducir aquí es lo que convierte las etiquetas del
+# modelo en un detalle de implementación.
+ETIQUETAS = {
+    "Clickbait": "clickbait",
+    "Not Clickbait": "factual news",
+}
+
+
+async def detect(api, headline: str) -> ToolResult:
+    """Clasifica un titular con el modelo dedicado y normaliza su etiqueta.
+
+    Recibe el backend en vez de construirlo: las dos fachadas ya tienen uno
+    —cacheado, porque cargar el modelo cuesta— y crear otro aquí tiraría esa
+    caché y duplicaría el modelo en memoria.
+    """
+    if not headline or not headline.strip():
+        return ToolResult.fail("El titular está vacío o no es válido")
+
+    respuesta = await api.classify(headline, MODEL)
+    if not respuesta.has_content():
+        return respuesta
+
+    cruda = respuesta.data["label"]
+    if cruda not in ETIQUETAS:
+        # Falla en vez de dejar pasar la etiqueta cruda. Si se colara, el
+        # extractor de veredicto la compararía con «clickbait», no coincidiría,
+        # y TODOS los titulares saldrían factuales — un fallo total que no
+        # levanta ninguna excepción y que sólo se ve midiendo.
+        return ToolResult.fail(
+            f"{MODEL} devolvió la etiqueta «{cruda}», que no está en el mapeo "
+            f"{sorted(ETIQUETAS)}: revisa si el modelo ha cambiado de convención"
+        )
+
+    return ToolResult.ok({**respuesta.data, "label": ETIQUETAS[cruda]})

--- a/backend/integrations/nlp/model_cards.py
+++ b/backend/integrations/nlp/model_cards.py
@@ -5,8 +5,21 @@ forward-compatible con un futuro frontend. El campo ``type`` enlaza con R3.8:
 marca qué señales son white-box (``interpretable``) frente a caja negra
 (``opaco``), pasando por las ``híbrido`` (decisión transparente, feature opaca).
 
-La otra mitad de R3.9 (intercambiar modelos por configuración) la cubre la
-factoría ``get_nlp_backend`` vía el setting ``nlp_backend`` (remote/local).
+CUIDADO CON LA OTRA MITAD DE R3.9
+
+Este docstring afirmaba que «intercambiar modelos por configuración» lo cubría la
+factoría ``get_nlp_backend`` vía el setting ``nlp_backend``. **Es falso, y se
+comprobó al cambiar de modelo en #115**: ``nlp_backend`` decide DÓNDE corre el
+modelo (remoto o local), no CUÁL es. Sustituir el modelo de la señal de clickbait
+exigió tocar esta tabla, escribir ``dedicated.py`` y añadir un mapeo de
+etiquetas — todo código, que es justo lo que el requisito excluye.
+
+Queda por tanto **sin cumplir**, y anotado como tal en vez de darlo por hecho.
+#116 lo dejó a un paso —el id ya vive en un único sitio, así que leerlo de
+settings con la ficha como defecto es pequeño—, pero hay una tensión de fondo: el
+mapeo de etiquetas NO se configura igual de fácil, porque cada modelo trae su
+propio vocabulario. Intercambiar cualquier modelo por configuración sólo es
+realista dentro de una familia que comparta convención.
 
 TRES CAMPOS QUE PARECEN LO MISMO Y NO LO SON
 
@@ -54,18 +67,18 @@ def cards_by_signal() -> dict[str, dict]:
 MODEL_CARDS = [
     {
         "signal": "detect_clickbait",
-        "model_id": "facebook/bart-large-mnli",
-        "name": "BART-large MNLI (zero-shot por inferencia)",
-        "task": "Clasifica el titular como clickbait vs factual por inferencia natural (NLI, zero-shot).",
+        "model_id": "Stremie/roberta-base-clickbait",
+        "name": "RoBERTa dedicado (entrenado en Webis-17)",
+        "task": "Clasifica el titular como clickbait vs factual con un modelo afinado específicamente para esta tarea.",
         "type": "opaco",
         "dimension": "forma",
         "limitations": [
-            "Modelo genérico de NLI, no entrenado específicamente en clickbait.",
             "Caja negra: sin explicación intrínseca (post-hoc opcional, R3.11).",
-            "Solo inglés.",
-            "En backend remoto (HF): sujeto a timeouts/caídas del proveedor.",
-            "NO VOTA (#109): se muestra pero su veredicto no entra en la dimensión `forma`. Es la señal más floja en los dos dominios medidos — 63.7% de acierto en Chakraborty dev (vs 87.0% del léxico y 89.3% del lineal) y F1 0.405 en Webis-17 (vs 0.526 y 0.519) — y al discrepar en solitario dejaba el 37% de los titulares en AMBIGUO.",
-            "PLACEHOLDER pendiente de #115: elegido en E3-02 por eliminación (lo único que el serverless de HuggingFace servía entonces), no por medida. Se conserva visible en vez de retirarlo porque, al no haber visto ningún corpus de clickbait, es la única señal inmune al sesgo de fuente (#78).",
+            "Solo inglés. Entrenado sobre `postText` de Webis-17, es decir TUITS de medios, no titulares de portada.",
+            "INDEPENDENCIA DESCONOCIDA, que no es lo mismo que buena: su único corpus de test honesto es Chakraborty, donde tres clasificadores competentes coinciden por fuerza (kappa 0.726 con el léxico y 0.772 con el lineal). En Webis no se puede medir, porque es su material de entrenamiento.",
+            "Sustituye a `facebook/bart-large-mnli` (#115), elegido en E3-02 por eliminación y medido en #109 al 63.7%. La sustitución sí se decidió por medida: F1 0.946 en Chakraborty — corpus que NO vio — frente al 0.473 del anterior, y con la ambigüedad de `forma` cayendo del 37% al 15%.",
+            "A favor, y es lo que más pesa: entrenado con ETIQUETA HUMANA (`truthMean` de anotadores), no por fuente. Es la única señal del sistema con supervisión no sesgada por el medio que publicó el titular — el fallo que #76 destapó y #109 cuantificó.",
+            "No memoriza, verificado: rinde MEJOR fuera de su dominio (F1 0.946 en Chakraborty) que dentro (0.631 en Webis), el patrón inverso al de `elozano/bert-base-cased-clickbait-news`, descartado por 99.7% dentro y F1 0.185 fuera.",
         ],
         "backend": "remote | local",
     },

--- a/backend/integrations/nlp/tool.py
+++ b/backend/integrations/nlp/tool.py
@@ -1,5 +1,5 @@
 """
-NLP Tool: detección de clickbait en titulares (zero-shot).
+NLP Tool: detección de clickbait en titulares.
 
 Cada tool declara su tipo de salida, así que MCP publica un ``outputSchema`` y
 el cliente recibe el objeto estructurado en vez de una cadena que tenga que
@@ -13,7 +13,7 @@ from mcp.server.fastmcp.exceptions import ToolError
 
 from backend.core.observability import log_tool_invocation
 from backend.integrations.metadata import tool_meta
-from backend.integrations.nlp import lexical, linear, model_cards
+from backend.integrations.nlp import dedicated, lexical, linear, model_cards
 from backend.integrations.nlp.factory import get_nlp_backend
 from backend.integrations.nlp.incoherence import IncoherenceDetector
 from backend.integrations.nlp.outputs import (
@@ -40,26 +40,24 @@ def register(mcp: FastMCP):
     async def detect_clickbait(headline: str) -> Etiqueta:
         """Detecta si un titular de noticia es clickbait o informativo (factual).
 
-        Usa clasificación zero-shot (NLI) con las etiquetas fijas "clickbait" y
-        "factual news": no necesita un modelo entrenado específicamente en
-        clickbait. Pensado para titulares en inglés.
+        Usa un modelo afinado específicamente para esta tarea sobre anotaciones
+        humanas, no una clasificación genérica. Complementaria a
+        `detect_clickbait_lexical` y `detect_clickbait_linear`, que miran pistas
+        de superficie y sí explican su veredicto. Pensada para inglés.
 
         Args:
             headline (str): titular a evaluar (en inglés).
 
         Returns:
             La etiqueta ganadora y su confianza (0-1), p.ej.
-            {"label": "clickbait", "score": 0.79}.
+            {"label": "clickbait", "score": 0.79}. Las etiquetas son siempre
+            "clickbait" o "factual news", con independencia del modelo que haya
+            detrás.
 
         Raises:
             Si la llamada al modelo falla (timeout o caída del proveedor).
         """
-        response = await api.zero_shot(
-            headline,
-            _ficha["detect_clickbait"]["model_id"],
-            ["clickbait", "factual news"],
-            # Labels para crear y descartar hipotesis. FIJOS para no confundir LLM.
-        )
+        response = await dedicated.detect(api, headline)
         if not response.has_content():
             raise ToolError(response.error or "Error al analizar el titular")
         return response.data

--- a/tests/api/test_analyze.py
+++ b/tests/api/test_analyze.py
@@ -8,6 +8,7 @@ globales del módulo EN CADA LLAMADA, así que monkeypatchear el módulo basta.
 
 import asyncio
 import time
+from typing import ClassVar
 
 import pytest
 from pydantic import ValidationError
@@ -28,7 +29,7 @@ from backend.analysis.orchestrator import (
     _run_signals,
 )
 from backend.core.models import ToolResult
-from backend.integrations.nlp import lexical, linear
+from backend.integrations.nlp import dedicated, lexical, linear
 
 _SPECS = {spec.name: spec for spec in _SIGNALS}
 
@@ -37,7 +38,23 @@ _SPECS = {spec.name: spec for spec in _SIGNALS}
 
 
 class _FakeAPI:
-    """Backend NLP sin red. `delay` sirve para medir la concurrencia."""
+    """Backend NLP sin red. `delay` sirve para medir la concurrencia.
+
+    `classify` DESPACHA POR MODELO desde #115. Antes sólo lo usaba el tono, así
+    que devolver siempre su etiqueta bastaba; ahora la señal de clickbait usa el
+    mismo método, y un doble que ignorase el modelo le devolvería «neutral» a
+    `dedicated`, que lo rechazaría por no estar en su mapeo. El test pasaría o
+    fallaría por el motivo equivocado.
+
+    `label` sigue expresándose en el vocabulario del CONTRATO (`clickbait` /
+    `factual news`) porque es como lo escriben los tests; se traduce aquí al del
+    modelo, que es lo que `dedicated` espera recibir y normalizar.
+    """
+
+    _AL_MODELO: ClassVar[dict[str, str]] = {
+        "clickbait": "Clickbait",
+        "factual news": "Not Clickbait",
+    }
 
     def __init__(self, label="clickbait", sentiment="neutral", delay=0.0):
         self.label, self.sentiment, self.delay = label, sentiment, delay
@@ -48,11 +65,9 @@ class _FakeAPI:
 
     async def classify(self, text, model):
         await asyncio.sleep(self.delay)
+        if model == dedicated.MODEL:
+            return ToolResult.ok({"label": self._AL_MODELO[self.label], "score": 0.91})
         return ToolResult.ok({"label": self.sentiment, "score": 0.84})
-
-
-async def _revienta(*args, **kwargs):
-    raise TimeoutError("el proveedor no respondió")
 
 
 async def _falla(*args, **kwargs):
@@ -161,9 +176,10 @@ def test_señales_de_acuerdo_dan_veredicto_de_dimension(señales):
 
 def test_señales_en_discrepancia_no_se_resuelven_por_mayoria():
     # Dos a uno NO gana: la discrepancia se declara, no se promedia.
-    # Ejercita `_aggregate` directamente, con tres votantes en `forma`. Desde
-    # #109 esa terna no se da en producción (el zero-shot no vota), pero la
-    # invariante es de la función y debe aguantar los votantes que le lleguen.
+    # La terna vuelve a darse en producción desde #115, que devolvió el voto a
+    # la señal dedicada. Entre #109 y #115 no se daba, y el test siguió siendo
+    # correcto igualmente: la invariante es de `_aggregate`, que debe aguantar
+    # los votantes que le lleguen, no de quién vote esta semana.
     verdicts = _por_dimension(
         _aggregate(
             [
@@ -195,26 +211,53 @@ def test_el_tono_no_vota_y_no_genera_dimension():
 
 
 @pytest.mark.asyncio
-async def test_el_zero_shot_no_vota_pero_sigue_apareciendo(señales):
-    """Regresión de #109: sin este test, un refactor la revierte en silencio.
+async def test_la_señal_dedicada_vota_y_su_etiqueta_va_normalizada(señales):
+    """#115 devuelve el voto que #109 había quitado, y fija la normalización.
 
-    La distinción que fija es que NO votar y HABER FALLADO son cosas distintas
-    aunque compartan ``is_clickbait is None``: la tarjeta sigue en estado OK y
-    conserva sus datos para pintarse.
+    Las dos cosas van juntas a propósito. El voto depende de que el veredicto se
+    extraiga con ``d["label"] == "clickbait"``, y el modelo de debajo dice
+    ``Clickbait``: si la traducción de ``dedicated`` se cayera, la comparación
+    no casaría, TODOS los titulares saldrían factuales y ningún test de voto lo
+    notaría — porque seguiría habiendo voto, sólo que siempre el mismo.
     """
-    señales()
+    señales(label="clickbait")
     signals = {s.name: s for s in await _run_signals("Un titular", None)}
 
-    zero_shot = signals["detect_clickbait"]
-    assert zero_shot.status == SignalStatus.OK
-    assert zero_shot.is_clickbait is None
-    assert zero_shot.data  # label y score siguen ahí para la interfaz
+    dedicada = signals["detect_clickbait"]
+    assert dedicada.status == SignalStatus.OK
+    assert dedicada.is_clickbait is True
+    assert dedicada.data["label"] == "clickbait"  # no «Clickbait»
 
     forma = _por_dimension(_aggregate(list(signals.values())))[Dimension.FORMA]
     assert forma.contributing == [
+        "detect_clickbait",
         "detect_clickbait_lexical",
         "detect_clickbait_linear",
     ]
+
+
+@pytest.mark.asyncio
+async def test_una_etiqueta_desconocida_del_modelo_no_pasa_por_factual(
+    señales, monkeypatch
+):
+    """El fallo silencioso que más caro sale: el modelo cambia de convención.
+
+    Si `dedicated` dejara pasar la etiqueta cruda, el extractor la compararía
+    con «clickbait», no coincidiría, y la señal declararía factual TODO sin que
+    nada fallara. Tiene que degradarse a error, que sí se ve.
+    """
+    señales()
+
+    async def responde_raro(text, model):
+        return ToolResult.ok({"label": "LABEL_0", "score": 0.9})
+
+    monkeypatch.setattr(orchestrator._api, "classify", responde_raro)
+    signals = {s.name: s for s in await _run_signals("Un titular", None)}
+
+    dedicada = signals["detect_clickbait"]
+    assert dedicada.status == SignalStatus.ERROR
+    assert dedicada.is_clickbait is None
+    assert "LABEL_0" in dedicada.detail  # dice QUÉ llegó, para poder arreglarlo
 
 
 def test_señal_fallida_no_genera_dimension():
@@ -293,7 +336,18 @@ async def test_cuerpo_en_blanco_equivale_a_no_tenerlo(señales, cuerpo):
 @pytest.mark.asyncio
 async def test_una_señal_que_revienta_no_tumba_a_las_demas(señales, monkeypatch):
     señales()
-    monkeypatch.setattr(orchestrator._api, "zero_shot", _revienta)
+
+    # Se rompe SÓLO el modelo dedicado, no el método. Desde #115 el tono comparte
+    # `classify` con él, así que parchear el método entero tumbaría dos señales y
+    # el test dejaría de probar lo que dice: que las demás sobreviven.
+    original = orchestrator._api.classify
+
+    async def revienta_solo_el_dedicado(text, model):
+        if model == dedicated.MODEL:
+            raise TimeoutError("el proveedor no respondió")
+        return await original(text, model)
+
+    monkeypatch.setattr(orchestrator._api, "classify", revienta_solo_el_dedicado)
 
     signals = {s.name: s for s in await _run_signals("Un titular", "Un cuerpo")}
 

--- a/tests/integrations/test_nlp.py
+++ b/tests/integrations/test_nlp.py
@@ -513,16 +513,27 @@ async def test_las_dos_fachadas_usan_el_id_de_la_ficha(monkeypatch):
     fichas = model_cards.cards_by_signal()
 
     class _Espia:
+        """Registra CADA llamada, no la última por método.
+
+        La primera versión guardaba en un dict con clave `zero_shot`/`classify`.
+        Cuando #115 pasó la señal de clickbait de `zero_shot` a `classify`, las
+        dos señales que usan `classify` empezaron a pisarse: el test seguía en
+        verde comprobando la mitad de lo que decía comprobar.
+        """
+
         def __init__(self):
-            self.modelos = {}
+            self.llamadas = []
 
         async def zero_shot(self, text, model, labels):
-            self.modelos["zero_shot"] = model
+            self.llamadas.append(model)
             return ToolResult.ok({"label": "clickbait", "score": 0.9})
 
         async def classify(self, text, model):
-            self.modelos["classify"] = model
-            return ToolResult.ok({"label": "neutral", "score": 0.8})
+            self.llamadas.append(model)
+            # `Clickbait` es lo que devuelve el modelo dedicado; `dedicated`
+            # lo traduce. El doble tiene que hablar como el modelo real, no
+            # como el contrato, o no se estaría probando la traducción.
+            return ToolResult.ok({"label": "Clickbait", "score": 0.8})
 
     # --- fachada MCP ---
     espia_mcp = _Espia()
@@ -538,11 +549,14 @@ async def test_las_dos_fachadas_usan_el_id_de_la_ficha(monkeypatch):
     await orchestrator._run_signals("Un titular", None)
 
     esperado = {
-        "zero_shot": fichas["detect_clickbait"]["model_id"],
-        "classify": fichas["analyze_sentiment"]["model_id"],
+        fichas["detect_clickbait"]["model_id"],
+        fichas["analyze_sentiment"]["model_id"],
     }
-    assert espia_mcp.modelos == esperado, "la tool MCP no usa el id de la ficha"
-    assert espia_rest.modelos == esperado, "el orquestador no usa el id de la ficha"
+    assert set(espia_mcp.llamadas) == esperado, "la tool MCP no usa el id de la ficha"
+    assert len(espia_mcp.llamadas) == 2, "alguna señal no llamó al backend"
+    assert set(espia_rest.llamadas) == esperado, (
+        "el orquestador no usa el id de la ficha"
+    )
 
     # El tercero no pasa por el backend NLP: carga su modelo él mismo. Antes
     # decía "all-MiniLM-L6-v2" mientras la ficha decía la ruta completa — dos


### PR DESCRIPTION
Cierra #115.

`detect_clickbait` usaba `facebook/bart-large-mnli`, elegido en E3-02 **por
eliminación** —era lo único que el serverless de HuggingFace servía— y nunca por
medida. El aplazamiento traía condición explícita, «si llega la infra», y la
infra llegó en la Épica 5 con `LocalNLPClient`. **Nadie volvió a la nota durante
dos épicas**, porque nadie tenía motivo para releerla.

Medido en #109, aquel modelo acertaba el 63,7 %: la señal más floja de `forma`.

## El sustituto obvio era el equivocado

E3-02 dejaba nombre: `elozano/bert-base-cased-clickbait-news`. Da **99,7 %** en
Chakraborty dev y **F1 0,185** en Webis-17, contra una mayoritaria del 69,0 %.
Memorización, no capacidad.

Eso obligó a buscar con criterios: licencia clara, **procedencia de la etiqueta**
(humana, no por-fuente) e **independencia** del par acoplado.

## Y ahí salió el hallazgo que no se buscaba

39 datasets candidatos en el Hub; cinco en inglés con licencia permisiva. **Los
cinco son Chakraborty reempaquetado**, medido por solapamiento de titulares: 100 %,
86 %, 86 %, 57 % y 56 %.

La variedad de corpus de clickbait es ilusoria: un dataset con cinco envoltorios.
Explica estructuralmente el caso de elozano —casi todo lo que hay arrastra las
mismas etiquetas por-fuente— y responde el bullet de #78 «búsqueda de corpus
adicionales» con un **no medido** en vez de con un «no encontré».

## El elegido

`Stremie/roberta-base-clickbait` (Apache-2.0). Su README declara entrenamiento
sobre **Webis-17** y **`postText`** — el mismo campo que tenemos vendorizado — con
~0,7 F1 en su test.

|  | En su corpus | Fuera |
|---|---|---|
| `elozano` | 99,7 % (Chakraborty) | **F1 0,185** (Webis) |
| `Stremie` | F1 0,631 (Webis) | **F1 0,946** (Chakraborty) |

Alto **fuera** y más bajo **dentro**: el patrón inverso, que es el de generalizar.
Y ese 0,946 **supera al 0,865 que el lineal saca dentro de su propio dominio** —
el argumento de #78, *la palanca es la supervisión*, medido desde el otro lado.

## El voto vuelve, y no es marcha atrás

| Tercera señal | Acierto | `forma` AMBIGUO | de esa ambigüedad, error suyo |
|---|---|---|---|
| BART (antes) | 63,7 % | 37,0 % | **78,4 %** |
| Stremie | **94,7 %** | **15,0 %** | **20,0 %** |

Cuatro de cada cinco ambigüedades pasan de ruido a discrepancia legítima. #109
declaró ese silencio **condicional** en la ficha —«placeholder pendiente de
#115»— precisamente para poder encontrarlo cuando llegara el momento.

## `dedicated.py`: faltaba un módulo

Tres de las cinco señales tenían módulo propio (`lexical`, `linear`,
`incoherence`); ésta no, y llamaba al backend desde las dos fachadas. Por eso su
id y sus etiquetas acabaron duplicados (#116): no había dónde ponerlos.

El módulo nuevo contiene el id (leído de la ficha), el mapeo de etiquetas y la
normalización. El vocabulario del modelo **no sale hacia fuera**: la tool sigue
publicando `clickbait`/`factual news`, contrato leído por el LLM, así que el
próximo cambio de modelo no se propaga a quien consume la señal.

Y el mapeo **falla en vez de dejar pasar** una etiqueta desconocida. Si se
colara, el extractor la compararía con `clickbait`, no coincidiría, y **todos los
titulares saldrían factuales sin levantar ninguna excepción**.

## Auditoría de requisitos: R3.9 no se cumple, y el código decía que sí

Cambiar de modelo es la prueba de fuego de R3.9 («intercambiarlos por
configuración, sin cambios de código»). No se cumple: hizo falta tocar la tabla
de fichas, escribir un módulo y añadir un mapeo.

Lo llamativo es que el docstring de `model_cards.py` **afirmaba lo contrario**,
confundiendo `nlp_backend` —que decide **dónde** corre el modelo— con **cuál** es.
Llevaba dos épicas dándolo por cumplido, invisible porque hasta ahora nunca se
había cambiado un modelo. Corregido aquí; el hueco queda en **#119**, con la
tensión de fondo planteada: el id se configura fácil, el mapeo de etiquetas y el
modo de invocación no.

Del resto de lo auditado: **R3.5** sale reforzado y **R3.8** gana evidencia propia
a favor. **R3.6** probablemente mejora al pasar de BART-large a roberta-base, pero
no se ha medido y no se apunta como mejora.

## Lo que no arregla

Sigue siendo una señal **opaca**: `forma` gana acierto, no transparencia. Y su
independencia del par acoplado es **desconocida, que no es lo mismo que buena** —
su único test honesto es Chakraborty, donde tres clasificadores competentes
coinciden por fuerza. Declarado así en la ficha. La segunda señal interpretable e
independiente sigue siendo #75.

## Verificación

193 tests pasan, ruff y formato limpios. Además, verificación de humo con el
**modelo real** —los dobles sólo prueban lo que uno cree que devuelve el modelo—:
los cuatro casos correctos, etiquetas normalizadas al contrato, y el camino
completo de `orchestrator.analyze` resolviendo `forma` con las tres señales.

Un test se cayó y estuvo bien que lo hiciera: `test_una_señal_que_revienta_no_tumba_a_las_demas`
saboteaba `zero_shot`, y la señal ya no pasa por ahí. Ahora rompe **sólo ese
modelo**, no el método, porque el tono comparte `classify` desde este cambio.
