### PR TITLE
feat(api): precalentar los modelos en el lifespan (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,7 +1023,9 @@ uvicorn backend.api.app:app --reload
 | Arranque de proceso en frío | ~20 s |
 | Primerísima ejecución | ~60 s (descarga de `all-MiniLM-L6-v2`) |
 
-Los 20 s **no son una limitación, son una consecuencia**: `IncoherenceDetector` carga el modelo de forma perezosa, en la primera petición, en vez de al arrancar. Precalentarlo en el `lifespan` los trasladaría del primer usuario a uvicorn — decisión de H4, con el `healthcheck` del contenedor delante, porque un arranque de 20 s cambia el `start_period`.
+Los 20 s **no son una limitación, son una consecuencia**: `IncoherenceDetector` carga el modelo de forma perezosa, en la primera petición, en vez de al arrancar. Precalentarlo en el `lifespan` los traslada del primer usuario a uvicorn.
+
+> **Resuelto en #125**, adelantado desde H4 al arrancar H3: con la SPA por delante dejó de ser una optimización de despliegue. Y los 20 s medidos aquí se quedaron cortos — eran sólo el detector de incoherencia; con los tres modelos son ~102 s. Sigue en pie la nota sobre el `start_period` del `healthcheck`, que ahora tiene que cubrir ~75 s de arranque.
 
 **Y el sistema discrimina:**
 
@@ -1186,6 +1188,95 @@ El mínimo de 1 no es cosmético: **en SQLite un `LIMIT` negativo significa «si
 Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa ruta en escritores del historial real: una corrida de la suite dejaba cuatro entradas «Un titular» en `var/history.db`. El aislamiento va en un fixture `autouse` de `tests/conftest.py` y no en el fichero que prueba el historial, porque **quien contamina no es quien lo prueba**: lo hace cualquier test que llame a un endpoint que registre, incluidos los que aún no existen.
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
+
+### Precalentar los modelos, adelantado desde H4 (#125)
+
+`/analyze` en frío tardaba **~105 s**. Estaba anotado como decisión de H4 —donde
+el argumento era el arranque del contenedor— pero al empezar H3 dejó de ser una
+optimización de despliegue: con ese tiempo no se puede desarrollar una pantalla
+de resultados, porque **cada reinicio del backend cuesta lo mismo**.
+
+#### Primero, dónde se iban los 105 s
+
+Antes de decidir qué precalentar había que saber en qué se gastaban. El desglose
+reparte el tiempo de forma muy distinta a lo que parecía:
+
+| | |
+|---|---|
+| `import torch` | 22,83 s |
+| `import transformers` | 11,99 s |
+| `import sentence_transformers` | 18,69 s |
+| **coste único de imports** | **53,5 s** |
+| carga del modelo dedicado | 10,11 s |
+| carga del de sentimiento | 14,70 s |
+| carga del de embeddings | 8,16 s |
+| **carga de los tres modelos** | **33,0 s** |
+| primera inferencia (ver abajo) | 15,5 s |
+
+**El 52 % es importar librerías**, que es coste único compartido por los tres
+modelos. Cargar los modelos son sólo 33 s.
+
+#### Y un detalle que decide el diseño
+
+```
+dedicada, primera inferencia      9,78 s   ·  segunda  0,01 s
+sentimiento, primera inferencia   0,01 s   ·  segunda  0,01 s
+incoherencia, primera inferencia  5,75 s   ·  segunda  0,01 s
+```
+
+La primera inferencia del sentimiento tarda 0,01 s. No es que el modelo sea
+rápido: es que **para cuando le toca, torch ya hizo su primer forward** con el
+dedicado y pagó la inicialización. El coste de «primera inferencia» también es
+**global**, no por modelo.
+
+De ahí sale que basta con **ejercitar**, no sólo cargar — esos 15,5 s no los paga
+`SentenceTransformer(...)`, los paga hacerle pasar una entrada— y que calentar
+una señal ya abarata las demás.
+
+#### Cuatro decisiones
+
+**Apagado por defecto.** El defecto importa más que el flag: si fuera `True`,
+cada `TestClient(app)` de la suite cargaría tres modelos. Eso no se manifiesta
+como un fallo sino como que «los tests van lentos», que es mucho peor de
+diagnosticar. Hay un test que lo vigila. Y en desarrollo con `--reload` pasaría
+lo mismo en cada reinicio.
+
+**Respeta `nlp_backend`.** Con el defecto `remote`, las señales de titular van
+por HTTP a HuggingFace: precalentar sus modelos en local sería cargar cosas que
+las peticiones no van a usar. Sólo la incoherencia corre siempre en local.
+
+**Bloquea el arranque.** Hacerlo en segundo plano dejaría a uvicorn aceptando
+conexiones mientras los modelos cargan: las primeras peticiones seguirían siendo
+lentas y no habría forma limpia de saber cuándo está listo. Bloquear es lo que
+quiere un orquestador de contenedores — el servicio no está *ready* hasta que lo
+está. **Consecuencia para H4:** un arranque de ~75 s obliga a un `start_period`
+generoso en el `healthcheck`, o el orquestador matará el contenedor por no
+responder a tiempo.
+
+**Vive en `orchestrator.py`, no en la app REST.** Y no es cuestión de capas:
+`LocalNLPClient` cachea sus pipelines **por instancia**, así que hay que calentar
+los objetos `_api` y `_detector` concretos que usará la petición. Calentar otros
+equivalentes pagaría el coste dos veces y dejaría la primera petición igual de
+lenta.
+
+#### El resultado
+
+```
+PRECALENTADO                     74,7 s
+  detect_clickbait                 57,1 s   ← paga los imports por todos
+  analyze_sentiment                 9,6 s   ← sólo carga: torch ya está caliente
+  detect_clickbait_incoherence      8,0 s
+
+primer análisis                   0,05 s
+segundo análisis                  0,06 s
+```
+
+**De ~102 s a 0,05 s.** Y se ve el efecto predicho: la primera señal se come 57 s
+pagando los imports, y las otras dos bajan a 9,6 y 8,0 porque ya están pagados.
+
+Un fallo al precalentar **no impide arrancar**: se registra y se sigue. Un modelo
+que no carga no debería dejar sin servir `/tools` ni `/history`, que no lo
+necesitan.
 
 ### El umbral que estaba a ojo, y lo que se vio al mirarlo (#92)
 

--- a/backend/analysis/orchestrator.py
+++ b/backend/analysis/orchestrator.py
@@ -29,9 +29,12 @@ define qué significa el resultado, y las dos fachadas —REST y MCP— la compa
 """
 
 import asyncio
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
+
+import structlog
 
 from backend.analysis.domain import (
     AnalyzeRequest,
@@ -49,11 +52,16 @@ from backend.integrations.nlp.factory import get_nlp_backend
 from backend.integrations.nlp.incoherence import IncoherenceDetector
 from backend.integrations.nlp.model_cards import cards_by_signal
 
+log = structlog.get_logger()
+
 # Instancias únicas: LocalNLPClient cachea los pipelines por instancia y el
 # detector carga el modelo de forma perezosa, así que crearlos por petición
 # tiraría la caché y recargaría el modelo cada vez. Como contrapartida, el
 # backend queda fijado al importar: cambiarlo exige reiniciar, igual que en la
 # tool MCP (que lo fija en register()).
+#
+# Y es lo que obliga a que precalentar() viva aquí: hay que calentar ESTAS dos
+# instancias, no unas equivalentes, o el coste se paga dos veces.
 _api = get_nlp_backend()
 _detector = IncoherenceDetector()
 
@@ -162,6 +170,63 @@ _SIGNALS: tuple[_Signal, ...] = (
         verdict=lambda d: None,
     ),
 )
+
+
+async def precalentar() -> dict[str, float]:
+    """Carga y ejercita los modelos antes de la primera petición (#125).
+
+    Vive aquí y no en la app REST porque ``LocalNLPClient`` cachea sus pipelines
+    **por instancia**: hay que calentar exactamente los objetos ``_api`` y
+    ``_detector`` que va a usar la petición. Calentar otros equivalentes pagaría
+    el coste dos veces y dejaría la primera petición igual de lenta.
+
+    EJERCITA, no sólo carga. Medido en #125, el desglose de los ~102 s en frío:
+
+        imports de torch/transformers/sentence-transformers   53,5 s
+        carga de los tres modelos                             33,0 s
+        PRIMERA inferencia                                    15,5 s
+
+    Esos últimos 15,5 s no los paga cargar el modelo, sólo hacerle pasar una
+    entrada. Y son en su mayoría coste GLOBAL, no por modelo: la primera
+    inferencia del dedicado tardó 9,78 s y la del sentimiento 0,01 s, porque
+    para entonces torch ya había inicializado lo suyo.
+
+    Respeta ``nlp_backend``: con ``remote`` las señales de titular van por HTTP a
+    HuggingFace y cargar sus modelos en local sería trabajo tirado. La
+    incoherencia corre siempre en local, así que se calienta siempre.
+
+    Devuelve los tiempos por señal para poder registrarlos, en vez de imprimir
+    desde aquí: quien llama decide si eso se loguea y cómo.
+    """
+    from backend.config.settings import settings
+
+    tiempos: dict[str, float] = {}
+    titular = "Precalentando el modelo"
+
+    async def cronometrar(etiqueta: str, tarea) -> None:
+        inicio = time.perf_counter()
+        try:
+            await tarea()
+        except Exception as exc:
+            # No se propaga: un modelo que no carga no debe impedir que la API
+            # sirva `/tools` o `/history`. Se registra el fallo con un tiempo
+            # negativo para que sea inconfundible en los logs.
+            log.warning("preheat.failed", signal=etiqueta, error=str(exc))
+            tiempos[etiqueta] = -1.0
+            return
+        tiempos[etiqueta] = time.perf_counter() - inicio
+
+    if settings.nlp_backend == "local":
+        await cronometrar("detect_clickbait", lambda: dedicated.detect(_api, titular))
+        await cronometrar(
+            "analyze_sentiment", lambda: _api.classify(titular, _SENTIMENT_MODEL)
+        )
+
+    await cronometrar(
+        "detect_clickbait_incoherence",
+        lambda: _detector.detect(titular, "Un cuerpo cualquiera para calentar."),
+    )
+    return tiempos
 
 
 async def analyze(request: AnalyzeRequest) -> AnalyzeResponse:

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -20,6 +20,7 @@ al llegar a ``/tools``, que sí necesita la capa MCP: enumerar las herramientas
 conectadas en runtime no se puede hacer importando módulos.
 """
 
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Annotated
@@ -29,7 +30,7 @@ from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.analysis.domain import AnalyzeRequest, AnalyzeResponse
-from backend.analysis.orchestrator import analyze
+from backend.analysis.orchestrator import analyze, precalentar
 from backend.api import history
 from backend.api.catalog import fetch_catalog
 from backend.api.execute import (
@@ -69,7 +70,24 @@ async def lifespan(app: FastAPI):
         service="clickbait-api",
         nlp_backend=settings.nlp_backend,
         cors_origins=settings.cors_origins,
+        preheat_models=settings.preheat_models,
     )
+
+    # Precalentado BLOQUEANTE, a propósito (#125). Hacerlo en segundo plano
+    # dejaría a uvicorn aceptando conexiones mientras los modelos cargan: las
+    # primeras peticiones seguirían siendo lentas y encima no habría forma
+    # limpia de saber cuándo está listo. Bloquear es lo que quiere un
+    # orquestador de contenedores — el servicio no está *ready* hasta que lo
+    # está — a cambio de un `start_period` generoso en el healthcheck de H4.
+    if settings.preheat_models:
+        inicio = time.perf_counter()
+        tiempos = await precalentar()
+        log.info(
+            "api.preheat",
+            total_s=round(time.perf_counter() - inicio, 1),
+            **{k: round(v, 1) for k, v in tiempos.items()},
+        )
+
     yield
 
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -20,6 +20,23 @@ class Settings(BaseSettings):
         "remote"  # Añadimos dos opciones de backend NLP, así mantenemos remoto sin cambiar mucho.
     )
 
+    # Cargar los modelos NLP al arrancar en vez de en la primera petición.
+    #
+    # POR DEFECTO APAGADO, y el defecto importa más que el flag. Precalentar
+    # cuesta ~102 s medidos (#125) y hay dos casos habituales donde eso es PEOR
+    # que la carga perezosa: desarrollar con `--reload`, donde se pagarían en
+    # cada reinicio, y los tests, que no deben cargar un modelo jamás.
+    #
+    # Encendido tiene sentido en despliegue, donde el contenedor arranca antes
+    # de recibir tráfico: traslada la espera del primer usuario a uvicorn. Ojo
+    # en H4 — un arranque de ~102 s obliga a un `start_period` generoso en el
+    # `healthcheck`, o el orquestador matará el contenedor por no responder.
+    #
+    # Respeta `nlp_backend`: con `remote` sólo la incoherencia corre en local,
+    # así que precalentar los otros dos sería cargar modelos que las peticiones
+    # no van a usar.
+    preheat_models: bool = False
+
     # Orígenes permitidos por CORS. Configurable porque el frontend vive
     # en localhost:4200 en desarrollo pero no en despliegue. Desde el
     # entorno se pasa como JSON: CORS_ORIGINS='["https://ejemplo.org"]'

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -160,3 +160,44 @@ def test_openapi_documenta_las_rutas_y_el_contrato():
     # consume /docs y lo que hereda el cliente TypeScript generado.
     propiedades = esquema["components"]["schemas"]["SignalResult"]["properties"]
     assert "herramienta MCP" in propiedades["name"]["description"]
+
+
+# ----- Precalentado (#125) -----
+
+
+def test_por_defecto_no_se_precalienta(monkeypatch):
+    """El defecto es lo que protege a los otros 193 tests de volverse lentos.
+
+    Precalentar cuesta ~102 s medidos. Si el defecto fuera `True`, cada
+    `TestClient(app)` de la suite cargaría tres modelos, y eso no se nota como
+    un fallo: se nota como que los tests «van lentos» y nadie sabe por qué.
+    """
+    llamadas = []
+    monkeypatch.setattr(app_mod, "precalentar", lambda: llamadas.append(1))
+
+    assert settings.preheat_models is False
+    with TestClient(app):
+        pass
+    assert llamadas == []
+
+
+def test_con_el_flag_encendido_se_precalienta_antes_de_servir(monkeypatch, analisis):
+    """Y que ocurre DENTRO del lifespan, no en la primera petición.
+
+    Es la diferencia entre trasladar la espera a uvicorn —que es el objetivo— y
+    dejarla donde estaba.
+    """
+    orden = []
+
+    async def falso_precalentar():
+        orden.append("precalienta")
+        return {"detect_clickbait_incoherence": 1.23}
+
+    monkeypatch.setattr(settings, "preheat_models", True)
+    monkeypatch.setattr(app_mod, "precalentar", falso_precalentar)
+
+    with TestClient(app) as cliente:
+        orden.append("sirve")
+        cliente.post("/analyze", json={"headline": "Un titular"})
+
+    assert orden == ["precalienta", "sirve"]


### PR DESCRIPTION
Cierra #125. Primera pieza de **H3**.

`/analyze` en frío tardaba **~105 s**. Estaba anotado como decisión de H4, donde
el argumento era el arranque del contenedor, pero al empezar H3 dejó de ser una
optimización de despliegue: con ese tiempo no se puede desarrollar la pantalla de
resultados, porque **cada reinicio del backend cuesta lo mismo**.

## Primero, dónde se iban los 105 s

| | |
|---|---|
| imports de `torch`, `transformers` y `sentence_transformers` | **53,5 s** |
| carga de los tres modelos (10,1 + 14,7 + 8,2) | **33,0 s** |
| primera inferencia | **15,5 s** |

**El 52 % es importar librerías**, que es coste único compartido. Cargar los tres
modelos son sólo 33 s.

## Y el detalle que decidió el diseño

```
dedicada, primera inferencia      9,78 s   ·  segunda  0,01 s
sentimiento, primera inferencia   0,01 s   ·  segunda  0,01 s
incoherencia, primera inferencia  5,75 s   ·  segunda  0,01 s
```

La primera inferencia del sentimiento tarda 0,01 s: para cuando le toca, **torch
ya hizo su primer forward** con el dedicado. El coste de «primera inferencia»
también es global, no por modelo.

De ahí que haya que **ejercitar y no sólo cargar** —esos 15,5 s no los paga
`SentenceTransformer(...)`, los paga pasarle una entrada— y que calentar una
señal abarate las demás.

## Cuatro decisiones

**Apagado por defecto.** El defecto importa más que el flag: con `True`, cada
`TestClient(app)` de la suite cargaría tres modelos, y eso no se manifiesta como
un fallo sino como que «los tests van lentos». Hay un test que lo vigila.

**Respeta `nlp_backend`.** Con el defecto `remote` las señales de titular van por
HTTP: precalentar sus modelos en local sería cargar lo que no se va a usar.

**Bloquea el arranque.** En segundo plano, uvicorn aceptaría conexiones mientras
carga y las primeras peticiones seguirían siendo lentas, sin señal limpia de
*ready*. **Para H4**: un arranque de ~75 s obliga a un `start_period` generoso en
el `healthcheck`.

**Vive en `orchestrator.py`, no en la app REST.** No es cuestión de capas:
`LocalNLPClient` cachea sus pipelines **por instancia**, así que hay que calentar
los objetos `_api` y `_detector` que usará la petición. Calentar otros
equivalentes pagaría el coste dos veces.

## El resultado

```
PRECALENTADO                     74,7 s
  detect_clickbait                 57,1 s   ← paga los imports por todos
  analyze_sentiment                 9,6 s
  detect_clickbait_incoherence      8,0 s

primer análisis                   0,05 s
segundo análisis                  0,06 s
```

**De ~102 s a 0,05 s.** Un fallo al precalentar no impide arrancar: se registra y
se sigue, porque `/tools` y `/history` no necesitan modelos.

## Corrección al README

La nota que asignaba esto a H4 decía «un arranque de 20 s cambia el
`start_period`». Esos 20 s eran de #86 y medían **sólo el detector de
incoherencia**; con los tres modelos son ~102 s. La corrección queda a la vista,
no sustituida en silencio, y la advertencia sobre el `healthcheck` sigue viva con
el número bueno.

## Verificación

195 tests pasan (dos nuevos), ruff y formato limpios. Comprobado además con los
modelos reales: los tests usan dobles y sólo prueban que el `lifespan` llama a
`precalentar`, no que el resultado sea rápido.
