### PR TITLE
docs: diagramas del flujo de peticiones y dos reglas de capas con test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,173 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### Diagramas del flujo de peticiones, y dos reglas que pasan a tener test (#106)
+
+`docs/arquitectura.md` se declaraba «documento vivo» y reflejaba el estado al
+cerrar el MVP, en junio. Desde entonces se había construido la capa REST entera y
+el documento no la mencionaba: su tabla marcaba `R4–R9 ⬜ Fase B` con R4, R5 y R9
+completos. Y el camino que sigue una petición no estaba dibujado en ninguna parte.
+
+#### Un documento que se equivocaba sobre sí mismo
+
+La cabecera decía, desde junio, *«Diagramas en Mermaid (se renderizan en
+GitHub)»*. **Sus dos diagramas eran SVG exportados de draw.io.** Llevaba meses
+afirmando algo falso sobre su propio contenido, y nadie lo notó porque una
+cabecera no se relee.
+
+Es el argumento entero de esta issue en pequeño: **una afirmación que nada
+sostiene se desincroniza en silencio**. Vale para la cabecera de un fichero y
+vale para una regla de arquitectura, y por eso el trabajo acabó incluyendo tests.
+
+#### El formato: los dos, con un criterio
+
+Mermaid para los diagramas de flujo, draw.io para el UML que va a la memoria. La
+diferencia no es estética:
+
+- Un diagrama de secuencia en XML de draw.io **se escribe una vez y no se
+  actualiza nunca**. Vive fuera del texto, no aparece en el diff de una PR y
+  nadie sabe si sigue siendo cierto.
+- En Mermaid vive dentro del Markdown, se corrige en una línea y **se revisa en
+  la pull request** como cualquier otro cambio.
+
+De ahí sale el criterio que queda escrito en el propio documento:
+
+> Si un diagrama necesita control fino de la disposición, o va en draw.io, o está
+> diciendo dos cosas y hay que partirlo.
+
+Los dos SVG de la Fase A se conservan, reencuadrados: describen **el servidor
+MCP**, que sigue siendo cierto como componente aunque ya no sea el sistema entero.
+
+#### Un diagrama, un mensaje
+
+El primer borrador del diagrama de fachadas salió con las líneas cruzándose, y la
+tentación era culpar al motor de disposición. No era suya:
+
+- **Llevaba dos mensajes a la vez** —quién cruza la frontera MCP y quién escribe
+  en el historial—. Partido en dos, los dos quedan limpios.
+- **El de capas cruzaba por una flecha «prohibido»** que iba hacia atrás.
+  Cualquier arista que remonte el flujo obliga a rodear el grafo entero. Y lo
+  importante: esa flecha **dibujaba una ausencia**. La regla dice que ese import
+  no existe, así que representarlo era representar lo que no hay. Fuera del
+  dibujo y escrita debajo.
+
+#### Dos trampas de Mermaid, y lo que costaron
+
+Encontradas al renderizar, no leyendo documentación:
+
+- **`#` inicia un código de entidad** (`#quot;` y compañía) y se traga lo que
+  venga detrás. Escribir `(#133)` produjo `(`. En este repositorio, donde las
+  issues se citan por número constantemente, es una trampa esperando.
+- **`;` termina la sentencia.** Una etiqueta con punto y coma se parte en dos y
+  **el diagrama entero deja de renderizarse**, sin error visible en el Markdown.
+
+Las dos quedan anotadas en la cabecera del documento.
+
+#### Verificar el documento, no una copia
+
+Los diagramas se validaron primero en un HTML aparte, y ahí apareció un tercer
+problema que era del método y no del contenido: metiendo la fuente en un
+`<pre class="mermaid">`, **el navegador interpreta las etiquetas HTML antes que
+Mermaid**, así que un `<b>` dentro de una etiqueta llegaba ya convertido y rompía
+el análisis sintáctico. En GitHub eso no pasa —una valla ```` ```mermaid ````
+entrega el texto crudo—, así que el banco de pruebas estaba inventando un fallo.
+
+La comprobación final se hace al revés: un script **extrae las siete vallas del
+propio `arquitectura.md` ya escrito** y las renderiza. Las siete devuelven SVG.
+Lo verificado es exactamente lo que se commitea, no una versión paralela que
+podría haber divergido.
+
+#### Dos diagramas fuera del alcance original
+
+La issue pedía cuatro. Se añaden dos más porque son los que sirven para decidir,
+no sólo para explicar:
+
+- **El dominio del análisis.** Ahí se ve de un vistazo que `data` es un
+  diccionario sin tipo que nadie vigila, y que un `is_clickbait` nulo en una
+  dimensión **es el resultado** —dos señales fiables que no coinciden— y no un
+  hueco. Las dos cosas están en el centro de las decisiones abiertas.
+- **Las capas y su dirección permitida.** Hace visual dónde puede entrar la
+  configuración sin romper nada, que es la pregunta que trae la parametrización
+  de umbrales (#93).
+
+#### El alcance creció: dos reglas pasan a tener test
+
+Al escribir el diagrama de capas hubo que verificar sus dos afirmaciones, y las
+dos resultaron ciertas… y sostenidas por nada:
+
+1. Ninguna capa del núcleo importa de las fachadas.
+2. Los detectores —`lexical`, `linear`, `incoherence`, `dedicated`— no importan
+   `settings`; sólo lo hacen `client.py`, que necesita el token, y `factory.py`,
+   cuyo trabajo es leer configuración.
+
+Publicar un diagrama que dibuja una regla que nada defiende es repetir el error
+de la cabecera. Así que `tests/test_arquitectura.py` entra en una issue de
+documentación, a propósito.
+
+**Parsea el árbol con `ast`, no hace `grep`:** un import comentado no debe hacer
+fallar nada. Y recorre el árbol entero, así que **también ve los imports dentro
+de funciones** — hay uno legítimo en `precalentar()`, y es por ahí por donde se
+esquivaría la regla sin querer.
+
+**Se comprobó rompiéndolas.** Se añadió `from backend.api import schemas` a
+`core/models.py` y `from backend.config.settings import settings` a `lexical.py`,
+y los dos tests fallaron nombrando fichero e import culpables. Un test de
+arquitectura que pasa, pero que nadie ha visto fallar, no demuestra nada: podría
+estar recorriendo un directorio vacío.
+
+**La segunda regla lista excepciones, no detectores.** Recorre *todos* los
+módulos de `integrations/nlp/` y sólo perdona a dos. Así un detector nuevo queda
+cubierto sin tocar nada, y meter `settings` en un módulo de esa capa obliga a
+**editar la lista a mano** — que es justo la decisión consciente que se quiere
+forzar cuando llegue #93. La regla no sólo describe el pasado: defiende una
+decisión futura.
+
+**Se descartó `import-linter`**, que es la herramienta hecha para esto y expresa
+el apilado completo de forma declarativa. Para dos reglas traería una dependencia
+más y un paso de CI más —el job de Python instala sólo `requirements.txt` y añade
+`ruff` aparte y pineado— mientras que esto usa la biblioteca estándar y corre en
+el `pytest` que ya existe. Con cinco contratos de capas, se reconsidera.
+
+#### Lo que estaba desfasado, corregido
+
+| Decía | Dice |
+| :--- | :--- |
+| «Diagramas en Mermaid» siendo SVG | el criterio real, con sus dos trampas |
+| «un servidor MCP, transporte stdio» | dos fachadas, y el transporte configurable (#90) |
+| `detect_clickbait` = zero-shot BART | el dominio se describe por su forma, no por el modelo de turno (#115) |
+| R3.7 (incoherencia) pendiente | ✅ (#56) |
+| `R4–R9 ⬜ Fase B` | R4, R5 y R9 ✅; R6 parcial; R7 y el CD pendientes |
+| Sin rastro de `analysis/` | es la capa central del diagrama de capas |
+
+La tabla de requisitos dice ahora también **lo que falta y con qué issue**: R3.9 a
+medias (#119), el texto de excepción sin sanear (#89) y las tres pantallas que
+quedan de R6.
+
+#### Lo que sigue sin vigilancia, dicho para que no se olvide
+
+- **Las formas del `data` están declaradas dos veces**: tres `TypedDict` en
+  `outputs.py` para MCP y cuatro guardianes escritos a mano en `datos.ts`. Ningún
+  guardián del CI ve esa duplicación, porque el contrato REST declara `data` como
+  diccionario libre.
+- **Los diccionarios de `vocabulario.ts` no están atados a los enums.**
+  `VEREDICTOS` y `DIMENSIONES` son `Record<string, string>` cuando podrían ser
+  `Record<OverallVerdict, string>` y `Record<Dimension, string>`, que ya son
+  uniones generadas: entonces añadir un veredicto en el backend rompería el build
+  en vez de pintar la clave cruda. `NOMBRES` y `CATEGORIAS` **no** se pueden
+  tipar así, porque no viajan en el contrato — y eso separa solo lo que el
+  contrato puede defender de lo que no.
+- **`tests/api/test_analyze.py` prueba `analysis/orchestrator`.** El código se
+  movió en #107 y sus tests se quedaron, rompiendo el espejo `tests/` ↔
+  `backend/` del PR #52.
+- **No se mide cobertura.** `pytest-cov` está en `requirements.in` y el CI no lo
+  invoca, así que «qué más no tiene test» hoy sólo se responde leyendo.
+
+#### Una nota sobre la versión
+
+La issue pedía que esto entrara **antes del tag `v0.3.0`**, para que la release no
+quedara sin la documentación de su propia arquitectura. No llegó a tiempo, y los
+tags son cortes en el tiempo que no se reabren: entra en **`v0.4.0`**, con H3.
+
 ### La pantalla de análisis: el lienzo de explicabilidad (#127)
 
 La primera pantalla que pinta algo propio, y la que sostiene la tesis del

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -1,52 +1,329 @@
-# Arquitectura (estado actual — MVP)
+# Arquitectura
 
-> Documento vivo. Refleja el estado del sistema al **cerrar el MVP** (Fase A del plan). Diagramas en Mermaid (se renderizan en GitHub). Para los requisitos ver [`requisitos.md`](requisitos.md).
+> **Documento vivo.** Refleja el estado tras cerrar **H2** (API REST completa) y
+> la primera pantalla de H3. Para los requisitos, ver [`requisitos.md`](requisitos.md);
+> para dónde vive cada cosa y con qué criterio, [`estructura.md`](estructura.md).
+>
+> **Formato.** Los diagramas de flujo van en **Mermaid**: GitHub los renderiza,
+> viven junto al texto y se revisan en el diff de una pull request. Los dos SVG
+> de **draw.io** son el UML de la Fase A y se conservan como material de la
+> memoria. El criterio para elegir: si un diagrama necesita control fino de la
+> disposición, o va en draw.io, o está diciendo dos cosas y hay que partirlo.
+>
+> Dos trampas al escribir Mermaid, encontradas al hacer estos diagramas:
+> **`#` inicia un código de entidad** y se traga lo que venga detrás (escribir
+> «issue 133», no «#133»), y **`;` termina la sentencia**, así que parte una
+> etiqueta en dos y deja el diagrama sin renderizar.
 
 ## Visión general
 
-El sistema es un **servidor MCP** (FastMCP, transporte *stdio*) que expone *tools* a un cliente MCP (un LLM, p.ej. Claude Desktop). Las tools consumen APIs públicas (meteorología, noticias) y aplican análisis NLP (clickbait, sentimiento) vía HuggingFace.
+El sistema es **un núcleo servido por dos fachadas**.
 
-Capas (de fuera hacia dentro):
+El **núcleo** —`analysis/`, `integrations/`, `core/`— sabe qué es el clickbait y
+cómo se analiza un titular, y no sabe quién lo llama. Encima hay dos formas de
+consumirlo:
 
-- **`main.py`** — arranca `FastMCP`, configura logging y **registra** todas las tools.
-- **Tools** (`integrations/*/tool.py`, `core/health.py`) — capa fina que declara la herramienta MCP (`@mcp.tool()` + `@log_tool_invocation`) y delega en el cliente.
-- **Clients** (`integrations/*/client.py`) — la lógica de cada API; todos heredan de `BaseAPI`.
-- **`BaseAPI`** (`core/base_api.py`) — el corazón compartido: *rate-limit*, reintentos, cuota, autenticación y el log `api.call`.
-- **Transversal** — `config/settings` (configuración con `pydantic-settings`), `core/models` (`ToolResult`), `core/logging` (`structlog`), `core/observability` (decorador `log_tool_invocation`).
+- **El servidor MCP** (`backend/main.py`, FastMCP), que expone las herramientas a
+  un cliente MCP: hoy Claude Desktop, mañana el agente de R13. El transporte es
+  configurable (`stdio` o `streamable-http`).
+- **La API REST** (`backend/api/`, FastAPI), que sirve a la SPA de Angular.
 
-## Diagrama de componentes
+No es una encima de la otra: son **dos fachadas sobre el mismo núcleo**. Esa
+decisión explica la asimetría del primer diagrama, que es lo que más se malinterpreta.
+
+## 1 · Las dos fachadas: qué cruza la frontera MCP
+
+```mermaid
+flowchart LR
+    subgraph directo["Importan el núcleo"]
+        AN["POST /analyze"]
+        HE["GET /health"]
+    end
+    subgraph protocolo["Pasan por el protocolo MCP"]
+        TO["GET /tools"]
+        EX["POST /tools/.../execute"]
+    end
+
+    MCP["Servidor MCP<br/>backend/main.py"]
+    NUC["Núcleo<br/>analysis · integrations · core"]
+    EXT["APIs externas<br/>NYT · Guardian · HuggingFace"]
+
+    directo --> NUC
+    protocolo --> MCP
+    MCP --> NUC
+    NUC --> EXT
+```
+
+**`/analyze` y `/health` importan el núcleo.** Dar el rodeo por el protocolo
+significaría serializar a JSON, volver a parsear y acabar **en la misma
+función**. `/health` reutiliza el mismo `check_health` que la tool MCP, así que
+las dos no pueden divergir.
+
+**`/tools` y `/execute` sí necesitan el protocolo**, y no por elegancia: enumerar
+las herramientas conectadas en tiempo de ejecución no se puede hacer importando
+módulos. Es lo que exige R5.8.
+
+La consecuencia a tener presente en H4: si algún día el NLP se separa en su
+propio contenedor, `/analyze` deja de poder importar y hay que reescribirlo sobre
+MCP. Es el único cambio de lógica base que ya sabemos que existe.
+
+## 2 · Quién toca el historial
+
+```mermaid
+flowchart LR
+    AN["POST /analyze"] -->|"escribe: un análisis"| DB[("SQLite<br/>var/history.db")]
+    EX["POST /tools/.../execute"] -->|"escribe: una herramienta"| DB
+    HI["GET /history"] -->|"lee, filtra y pagina"| DB
+```
+
+Se guardan **análisis, no invocaciones**: un `POST /analyze` es UNA entrada, no
+cinco. La traza de invocaciones ya vive en los logs.
+
+## 3 · Secuencia de `POST /analyze`
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SPA as SPA
+    participant API as FastAPI
+    participant ORQ as orchestrator.analyze
+    participant S as Señales
+    participant H as Historial
+
+    SPA->>API: POST /analyze (headline, content?)
+    API->>ORQ: analyze(request)
+    ORQ->>ORQ: aparta las que necesitan cuerpo si no hay
+    ORQ->>S: gather(..., return_exceptions=True)
+    S-->>ORQ: resultados Y excepciones, en orden de entrada
+    ORQ->>ORQ: agrupa por dimensión · el engaño manda sobre la forma
+    ORQ-->>API: AnalyzeResponse
+    API->>H: record(payload completo)
+    H-->>API: id — que hoy se descarta (issue 133)
+    API-->>SPA: 200 aunque alguna señal falle
+```
+
+**`return_exceptions=True` es lo que aísla los fallos.** En vez de propagar la
+primera excepción, `gather` la devuelve dentro de la lista, en la posición que le
+toca; ahí se traduce a una señal en estado `error` y la respuesta sigue siendo un
+200 con lo que sí se pudo calcular. Perder tres análisis correctos porque el
+cuarto dio timeout sería el error de verdad.
+
+**El orden se conserva.** `gather` devuelve en orden de entrada, no de
+finalización, así que la interfaz pinta las tarjetas siempre igual.
+
+**El veredicto no sale de contar señales**, sino de agrupar por dimensión y
+aplicar una jerarquía explícita donde el engaño pesa más que la forma. Un titular
+sobrio cuyo cuerpo no cumple lo prometido tiene tres señales diciendo «no» y una
+diciendo «sí», y la correcta es la cuarta.
+
+## 4 · Secuencia de `POST /tools/.../execute`
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Cliente
+    participant API as FastAPI
+    participant EX as execute_tool
+    participant M as Servidor MCP
+
+    C->>API: POST a la ruta de ejecución
+    API->>EX: execute_tool(nombre, argumentos)
+
+    loop por cada servidor de mcp_servers
+        EX->>M: handshake y list_tools
+        alt no tiene la herramienta
+            M-->>EX: no está, pasa al siguiente
+        else la tiene
+            EX->>EX: valida los argumentos contra su inputSchema
+            EX->>M: call_tool(nombre, argumentos)
+            M-->>EX: CallToolResult
+        end
+    end
+
+    Note over EX,M: todo va dentro de un asyncio.timeout<br/>que acota la operación ENTERA, no sólo call_tool
+
+    EX-->>API: 404 no existe / 422 argumentos / 504 tardó / 200 con status ok o error
+    API-->>C: respuesta
+```
+
+**La validación ocurre antes de invocar** (R4.5). Si se dejara a MCP, un argumento
+mal escrito llegaría como fallo de ejecución y sería indistinguible de un análisis
+que salió mal; validando aquí, la API responde 422 diciendo qué campo falla.
+
+**Cuatro salidas, cuatro significados distintos.** El 200 con `status: error`
+dice «la herramienta se ejecutó y falló»: la petición era correcta. El 504 es su
+propia categoría porque **la herramienta pudo terminar bien al otro lado** — lo
+que falló es la espera, y decir «el análisis falló» sería mentir.
+
+**Hay dos timeouts y hacen falta los dos.** El de `httpx` mide inactividad entre
+bytes; el `asyncio.timeout` acota la duración. Hasta el arreglo de la issue 113,
+sólo estaba el primero y una herramienta lenta **no fallaba, se colgaba**.
+
+## 5 · El historial: escritura y lectura
+
+```mermaid
+flowchart TD
+    subgraph W["Escritura — record()"]
+        W1["INSERT en history"] --> W2["poda por cantidad"] --> W3["poda por antigüedad"] --> W4["un solo commit, un solo fsync"]
+    end
+
+    subgraph R["Lectura — query()"]
+        R1["arma el WHERE con los filtros"] --> R2["COUNT con el MISMO WHERE"] --> R3["SELECT columnas nombradas<br/>ORDER BY id DESC, LIMIT y OFFSET"] --> R4["deserializa el payload"]
+    end
+```
+
+**La poda va dentro de la transacción del `INSERT`**, y eso es lo que la hace
+prácticamente gratis: una escritura ya paga un `fsync`, y las dos sentencias de
+poda viajan en ese mismo commit. Se descartaron las alternativas: podar de forma
+programada exige un proceso vivo, y podar al leer convierte una consulta en una
+operación destructiva.
+
+**El `COUNT` lleva el mismo `WHERE` que la consulta.** Con filtros aplicados, el
+total tiene que ser el de lo filtrado, o la interfaz pintaría «1-3 de 500» sobre
+una lista de tres.
+
+**Las columnas se nombran en vez de usar `SELECT *`.** No es repetición inútil:
+como la capa de arriba construye el modelo con `HistoryEntry(**fila)`, con el
+asterisco sería la forma de la tabla la que decidiría la del contrato — y
+renombrar una columna dejaría su campo a `None` sin un solo error.
+
+## 6 · El dominio del análisis
+
+```mermaid
+classDiagram
+    direction LR
+
+    class AnalyzeResponse {
+        +headline: str
+        +content: str
+        +signals: SignalResult
+        +dimensions: DimensionVerdict
+        +verdict: OverallVerdict
+    }
+
+    class SignalResult {
+        +name: str
+        +status: SignalStatus
+        +dimension: Dimension
+        +type: SignalType
+        +is_clickbait: bool
+        +data: dict
+        +detail: str
+    }
+
+    class DimensionVerdict {
+        +dimension: Dimension
+        +is_clickbait: bool
+        +contributing: str
+    }
+
+    class FichaModelo {
+        +signal: str
+        +model_id: str
+        +name: str
+        +type: str
+        +dimension: str
+        +limitations: str
+    }
+
+    AnalyzeResponse "1" *-- "5" SignalResult
+    AnalyzeResponse "1" *-- "0..3" DimensionVerdict
+    SignalResult ..> FichaModelo : dimension y type se leen de la ficha
+
+    note for SignalResult "data es un diccionario LIBRE. Ningun tipo lo vigila, y de ahi salen los tres huecos de la issue 133."
+    note for DimensionVerdict "is_clickbait nulo significa DISCREPANCIA entre senales. Es el resultado, no un hueco."
+```
+
+**Las señales son una lista de objetos con la misma forma**, no un objeto con un
+campo por señal. Así la interfaz itera y pinta tarjetas sin conocerlas de
+antemano: añadir una quinta señal no obliga a tocar Angular.
+
+**El estado va por señal, no global.** Un único `status` cubre dos situaciones que
+desde la respuesta son la misma —esa señal no tiene resultado pero las demás sí—:
+que falten datos de entrada (`no_aplicable`) y que la ejecución falle (`error`).
+
+**`is_clickbait` nulo en una dimensión es el resultado**, no un hueco: significa
+que dos señales fiables no coincidieron. No se promedia ni se resuelve por mayoría.
+
+**`data` no tiene tipo, y es deliberado**: es el JSON crudo de la herramienta, sin
+aplanar, porque es lo que alimenta las tarjetas de explicabilidad. El precio lo
+paga quien lo consume, que tiene que declarar por su cuenta qué espera — y de ahí
+salieron los tres huecos de contrato de la issue 133.
+
+## 7 · Capas y dirección de dependencias
+
+```mermaid
+flowchart TD
+    FACH["Fachadas<br/>api/ · main.py<br/>saben que sirven a alguien"]
+    ANA["analysis/<br/>domain · orchestrator<br/>qué es el clickbait"]
+    INT["integrations/<br/>nlp · nyt · guardian · weather"]
+    CORE["core/<br/>BaseAPI · ToolResult · logging"]
+    CONF["config/<br/>settings"]
+
+    FACH --> ANA --> INT --> CORE --> CONF
+```
+
+Las flechas son la **dirección permitida**, no cada import concreto. La regla que
+sostiene el diseño es la inversa, y no se dibuja porque no existe:
+
+- **Ninguna capa del núcleo importa de las fachadas.** Verificado: cero
+  coincidencias de `backend.api` en `analysis/`, `integrations/` y `core/`.
+- **Los detectores no conocen la configuración.** `lexical`, `linear`,
+  `incoherence` y `dedicated` no importan `settings`; sólo lo hacen `client.py`,
+  que necesita el token, y `factory.py`, cuyo trabajo es leer configuración. Eso
+  es lo que permite probarlos sin montar nada, y lo que hay que preservar al
+  parametrizar sus umbrales.
+
+**Las dos las sostiene [`tests/test_arquitectura.py`](../tests/test_arquitectura.py).**
+Parsea el árbol de cada módulo —no hace `grep`, así que un import comentado no lo
+hace fallar— y recorre también los imports dentro de funciones, que es por donde
+se esquivaría la regla sin querer. Al fallar nombra el fichero y el import
+culpables.
+
+Se comprobó **rompiendo las dos reglas a propósito** y verificando que fallan: un
+test de arquitectura que pasa, pero que nadie ha visto fallar, no demuestra nada.
+
+La segunda regla lista **excepciones, no detectores**. Así un detector nuevo queda
+cubierto sin tocar nada, y meter `settings` en un módulo de la capa NLP obliga a
+editar esa lista a mano — que es justo la decisión consciente que se quiere
+forzar al parametrizar los umbrales (issue 93).
+
+## Los diagramas de la Fase A
+
+Se conservan como estaban. Describen **el servidor MCP**, que sigue siendo cierto
+como componente aunque ya no sea el sistema entero.
 
 ![Diagrama de componentes del MCP Server](img/componentes.svg)
 
-- **Capas:** `Cliente MCP → MCP Server (stdio) → Tools → Clients`. Cada `tool` delega en su `client`; todos los clients **heredan `BaseAPI`** (donde viven rate-limit, retry, cuota, auth y el log `api.call`).
-- **`health_check`** es un caso aparte: no pasa por `BaseAPI` — hace *probes* directos con su propio `httpx` a weather/guardian/nyt y agrega `ok` / `degraded` / `down`.
-- **Transversal:** `pydantic-settings` (config), `ToolResult` (modelo de retorno) y `structlog` (logging) sostienen a `BaseAPI` y a las capas.
-- Solo **APIS EXTERNAS** queda fuera de la frontera del server.
-- El patrón **`tool.py` (registro) + `client.py` (lógica)** se repite idéntico en las 4 integraciones → estructura predecible.
-
-## Diagrama de secuencia — flujo estrella
-
-"Dame titulares del NYT sobre `<tema>`" (el primer paso del caso de uso clickbait). Los demás flujos de noticias/NLP siguen la misma forma `Tool → Client → BaseAPI → API`.
+- **Capas:** `Cliente MCP → MCP Server → Tools → Clients`. Cada `tool` delega en
+  su `client`; todos heredan de `BaseAPI`, donde viven rate-limit, reintentos,
+  cuota, autenticación y el log `api.call`.
+- **`health_check`** es un caso aparte: no pasa por `BaseAPI`, hace sondeos
+  directos con su propio `httpx` y agrega `ok` / `degraded` / `down`.
+- El patrón **`tool.py` (registro) + `client.py` (lógica)** se repite idéntico en
+  las integraciones, así que la estructura es predecible.
 
 ![Diagrama de secuencia del flujo get_nyt_news](img/secuencia.svg)
 
-- **Dentro de `BaseAPI.make_request`** (el diagrama lo resume en la nota): además de `_apply_auth`, aplica **rate-limit** (`async with limiter`, R2.4) y, tras la respuesta, calcula la **cuota** (`_read_quota`, R2.7) y emite el log `api.call` con `call_count` / `remaining_quota` (R2.6).
+- Dentro de `BaseAPI.make_request`: rate-limit (R2.4), cálculo de cuota (R2.7) y
+  el log `api.call` con `call_count` y `remaining_quota` (R2.6).
+- El bucle reintenta sólo ante `TimeoutException` o `503`, y sólo si el cliente
+  declara reintentos (HuggingFace 3; NYT y Guardian 0).
 
-- **Reintento (E4-02):** el bucle de `make_request` reintenta solo ante `TimeoutException`/`503` y solo si `MAX_RETRIES > 0` (HF = 3; NYT/Guardian = 0, no reintentan).
-- **Encadenado:** para "¿cuáles son clickbait?", el LLM toma esos titulares y llama a `detect_clickbait`, que sigue el mismo camino contra el `HFClient` (zero-shot `facebook/bart-large-mnli`).
+## Estado de los requisitos
 
-## Cierre del MVP
-
-El MVP cubre el **núcleo del detector de clickbait sobre titulares** vía MCP, con dos fuentes de noticias reputadas + NLP. Estado de los requisitos ([`requisitos.md`](requisitos.md)):
-
-| Requisito | Estado en el MVP |
+| Requisito | Estado |
 | :--- | :--- |
-| **R1** Infraestructura MCP | ✅ completo |
-| **R2** Tools de APIs públicas | ✅ para weather/guardian/nyt, con validación (R2.5), rate-limit (R2.4), tracking (R2.6) y cuota (R2.7, observabilidad) |
-| **R3** NLP (clickbait + sentimiento) | ◑ parcial: sentimiento ✅, clickbait *zero-shot* ✅, **solo inglés** (R3.4 relajado); clickbait por **incoherencia** (R3.7) pendiente |
-| **R10** Errores y logging | ✅ logging estructurado + invocaciones + health check |
+| **R1** Infraestructura MCP | ✅ transporte configurable y registro automático de integraciones |
+| **R2** Tools de APIs públicas | ✅ con validación, rate-limit, tracking y cuota |
+| **R3** NLP y explicabilidad | ◑ cinco señales contrastadas, incoherencia (R3.7) y fichas de modelo (R3.9) ✅; **sólo inglés**, y R3.9 a medias — los modelos no son intercambiables por configuración (issue 119) |
+| **R4** API REST | ✅ análisis, catálogo, ejecución, historial, CORS y OpenAPI |
+| **R5** Catálogo y transparencia | ✅ catálogo por handshake MCP, con procedencia y ficha de modelo |
+| **R6** Interfaz web | ◑ pantalla de análisis ✅ (issue 127); catálogo, historial y responsive pendientes (128, 129, 130); el asistente llega con R13 |
+| **R7** Docker | ⬜ H4 |
+| **R8** CI/CD | ◑ integración continua ✅ (Python y frontend); despliegue continuo ⬜ |
+| **R9** Persistencia e historial | ✅ SQLite con filtros y retención configurable |
+| **R10** Errores y logging | ✅ logging estructurado, invocaciones y health check |
 | **R11** Configuración | ✅ `pydantic-settings`, *fail-fast*, sin secretos en logs |
-| **R12** Seguridad/validación | ◑ parcial: validación de entrada (pydantic `Field`), validación de API keys al arranque |
-| **R4–R9** REST/catálogo/web/Docker/CI-CD/persistencia | ⬜ Fase B |
-
-**Frontera del MVP:** servidor MCP funcional consumible por un LLM. Lo que queda (API REST con FastAPI, catálogo de tools, web Angular, Docker, persistencia de historial) constituye la **Fase B** del plan.
+| **R12** Seguridad y validación | ◑ validación de entrada y de API keys al arranque; falta sanear el texto de excepción que se expone (issue 89) |
+| **R13** Agente conversacional | ⬜ *tool calling* validado en el spike 82; sin construir |

--- a/tests/test_arquitectura.py
+++ b/tests/test_arquitectura.py
@@ -1,0 +1,103 @@
+"""Las reglas de capas, sostenidas por un test en vez de por un comentario.
+
+Las dos que se comprueban aquí eran ciertas y no estaban escritas en ningún
+sitio, así que nada impedía romperlas. Un diagrama las ilustra pero no las
+defiende: se queda desfasado en silencio, que es exactamente lo que le pasó a la
+cabecera de ``docs/arquitectura.md``, afirmando durante meses que sus diagramas
+eran Mermaid cuando eran SVG.
+
+**Se parsea el árbol, no se hace grep.** Un ``# from backend.api import ...``
+comentado no debe hacer fallar nada, y ``ast`` distingue código de prosa.
+
+**Se miran también los imports dentro de funciones.** ``ast.walk`` recorre el
+árbol entero, no sólo la cabecera del fichero: hay imports locales legítimos —
+``orchestrator.precalentar()`` tiene uno— y el día que alguien esconda uno dentro
+de una función para esquivar la regla, esto lo ve igual.
+
+Se descartó ``import-linter``, que es la herramienta hecha para esto y expresa el
+apilado entero de forma declarativa. Para dos reglas traería una dependencia más
+y un paso de CI más —el job de Python instala sólo ``requirements.txt``— mientras
+que esto usa la biblioteca estándar y corre en el pytest que ya existe. Si algún
+día hay cinco contratos de capas, se reconsidera.
+"""
+
+import ast
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parents[1] / "backend"
+
+# Las fachadas: saben que están sirviendo a alguien. El núcleo no debe conocerlas.
+FACHADAS = ("backend.api", "backend.main")
+
+# Los paquetes que forman el núcleo.
+NUCLEO = ("analysis", "integrations", "core")
+
+# Únicos módulos de la capa NLP a los que se les permite leer configuración:
+# `client.py` necesita el token y el trabajo de `factory.py` ES leer settings.
+#
+# La lista es de EXCEPCIONES, no de detectores, y eso es deliberado: un detector
+# nuevo queda cubierto sin tocar nada, y meter `settings` en un módulo nuevo
+# obliga a editar esta línea a mano — que es la decisión consciente que se quiere
+# forzar cuando llegue la parametrización de umbrales.
+LEEN_CONFIGURACION = {"client.py", "factory.py"}
+
+CONFIGURACION = "backend.config.settings"
+
+
+def _importes(fichero: Path) -> set[str]:
+    """Módulos que importa el fichero, en cualquier punto del árbol."""
+    arbol = ast.parse(fichero.read_text(encoding="utf-8"))
+    modulos: set[str] = set()
+    for nodo in ast.walk(arbol):
+        if isinstance(nodo, ast.Import):
+            modulos.update(alias.name for alias in nodo.names)
+        elif isinstance(nodo, ast.ImportFrom) and nodo.module:
+            modulos.add(nodo.module)
+    return modulos
+
+
+def _modulos_del_nucleo() -> list[Path]:
+    ficheros: list[Path] = []
+    for paquete in NUCLEO:
+        ficheros.extend(sorted((BACKEND / paquete).rglob("*.py")))
+    return ficheros
+
+
+def test_el_nucleo_no_importa_de_las_fachadas():
+    """El núcleo no sabe quién lo llama, y por eso puede tener dos fachadas.
+
+    Si `analysis/` importara de `api/`, servir el mismo análisis por MCP dejaría
+    de ser posible sin arrastrar FastAPI detrás.
+    """
+    infracciones = [
+        f"{fichero.relative_to(BACKEND)} importa {modulo}"
+        for fichero in _modulos_del_nucleo()
+        for modulo in _importes(fichero)
+        if modulo.startswith(FACHADAS)
+    ]
+
+    assert not infracciones, "El núcleo importa de las fachadas:\n" + "\n".join(
+        infracciones
+    )
+
+
+def test_los_detectores_no_conocen_la_configuracion():
+    """Los detectores son lógica pura: se prueban sin montar nada.
+
+    En cuanto uno lea `settings`, probarlo exige un entorno con las claves
+    puestas y deja de poder usarse como biblioteca suelta.
+    """
+    nlp = BACKEND / "integrations" / "nlp"
+
+    infracciones = [
+        f"{fichero.name} importa {CONFIGURACION}"
+        for fichero in sorted(nlp.glob("*.py"))
+        if fichero.name not in LEEN_CONFIGURACION
+        and any(modulo.startswith(CONFIGURACION) for modulo in _importes(fichero))
+    ]
+
+    assert not infracciones, (
+        "Un módulo de la capa NLP que no debería lee la configuración:\n"
+        + "\n".join(infracciones)
+        + "\n\nSi es deliberado, añádelo a LEEN_CONFIGURACION y explica por qué."
+    )


### PR DESCRIPTION
## #106 · Diagramas del flujo de peticiones y actualización de `arquitectura.md`

Closes #106

`docs/arquitectura.md` se declaraba «documento vivo» y reflejaba el estado al
cerrar el MVP, en junio. Desde entonces se construyó la capa REST entera y el
documento no la mencionaba: su tabla marcaba `R4–R9 ⬜ Fase B` con **R4, R5 y R9
completos**. Y el camino que sigue una petición no estaba dibujado en ninguna
parte.

### Qué incluye

- `docs/arquitectura.md` — reescritura: siete diagramas en Mermaid, la visión
  general de las dos fachadas, y la tabla de requisitos al día.
- `tests/test_arquitectura.py` — **nuevo**: dos reglas de capas que hasta ahora
  sólo eran ciertas por costumbre.

### Un documento que se equivocaba sobre sí mismo

Su cabecera decía desde junio *«Diagramas en Mermaid (se renderizan en
GitHub)»*. **Sus dos diagramas eran SVG de draw.io.** Llevaba meses afirmando
algo falso sobre su propio contenido, y nadie lo notó porque una cabecera no se
relee.

Es la tesis de la issue en pequeño: **una afirmación que nada sostiene se
desincroniza en silencio**. Vale para una cabecera y vale para una regla de
arquitectura, y de ahí sale el crecimiento de alcance de esta rama.

### El alcance creció: una issue de `[docs]` trae tests

Al dibujar el diagrama de capas hubo que verificar sus dos afirmaciones. Las dos
eran ciertas y **ninguna estaba sostenida por nada**:

1. Ninguna capa del núcleo importa de las fachadas.
2. Los detectores —`lexical`, `linear`, `incoherence`, `dedicated`— no importan
   `settings`; sólo lo hacen `client.py`, que necesita el token, y `factory.py`,
   cuyo trabajo es leer configuración.

Publicar un diagrama que dibuja una regla que nada defiende es repetir
exactamente el error de la cabecera. Por eso los tests entran aquí y no en una
issue aparte.

- **Parsea el árbol con `ast`, no hace `grep`**: un import comentado no debe
  hacer fallar nada. Y recorre el árbol entero, así que **ve también los imports
  dentro de funciones** — hay uno legítimo en `precalentar()`, y es por ahí por
  donde se esquivaría la regla sin querer.
- **Se comprobó rompiéndolas**: añadiendo `from backend.api import schemas` a
  `core/models.py` y `from backend.config.settings import settings` a
  `lexical.py`, los dos fallan nombrando fichero e import. Un test de
  arquitectura que pasa pero que nadie ha visto fallar podría estar recorriendo
  un directorio vacío.
- **La segunda lista excepciones, no detectores**: recorre todos los módulos de
  `integrations/nlp/` y sólo perdona a dos. Un detector nuevo queda cubierto sin
  tocar nada, y meter `settings` en un módulo de esa capa obliga a editar la
  lista a mano — la decisión consciente que se quiere forzar cuando llegue #93.
- **Sin dependencias nuevas ni cambios en el CI**: usa la biblioteca estándar y
  corre en el `pytest` que ya existe.

### El formato, con criterio

Mermaid para los flujos, draw.io para el UML de la memoria. Un diagrama de
secuencia en XML de draw.io se escribe una vez y no se actualiza nunca: vive
fuera del texto y no aparece en ningún diff. En Mermaid se corrige en una línea y
se revisa en la PR.

> Si un diagrama necesita control fino de la disposición, o va en draw.io, o está
> diciendo dos cosas y hay que partirlo.

Los dos SVG de la Fase A se conservan, reencuadrados: describen el servidor MCP,
cierto como componente aunque ya no sea el sistema entero.

### Tres trampas encontradas al hacerlo

- **`#` inicia un código de entidad** en Mermaid y se traga lo que venga detrás:
  `(#133)` produjo `(`. En este repositorio, donde las issues se citan por número
  constantemente, es una trampa esperando.
- **`;` termina la sentencia**: una etiqueta con punto y coma parte el diagrama y
  **deja de renderizarse entero**, sin error visible en el Markdown.
- **La tercera era del método**: validando en un HTML aparte con la fuente en un
  `<pre class="mermaid">`, el navegador interpreta las etiquetas antes que
  Mermaid y un `<b>` rompía el análisis sintáctico. En GitHub no pasa. Por eso la
  verificación final **extrae las siete vallas del propio `arquitectura.md`** y
  las renderiza: lo comprobado es lo que se commitea.

### Dos diagramas fuera del alcance original

La issue pedía cuatro. Se añaden el **dominio del análisis** y las **capas**,
porque sirven para decidir y no sólo para explicar: en el primero se ve que
`data` es un diccionario sin tipo que nadie vigila y que un `is_clickbait` nulo
**es el resultado**; el segundo hace visual dónde puede entrar la configuración,
que es la pregunta de #93.

### Notas

- **Sigue sin vigilancia, y queda escrito en el README**: las formas del `data`
  declaradas dos veces (`outputs.py` frente a `datos.ts`), los diccionarios de
  `vocabulario.ts` sin atar a los enums generados, `tests/api/test_analyze.py`
  probando `analysis/` desde #107, y la cobertura sin medir (`pytest-cov`
  instalado y sin invocar).
- **La issue pedía entrar antes del tag `v0.3.0`.** No llegó, y los tags son
  cortes en el tiempo que no se reabren: entra en `v0.4.0` con H3. Corregido en
  el README.
- 198 tests (196 más los dos nuevos), ruff limpio. Sin cambios de comportamiento.
