### PR TITLE
refactor(domain): claves del dominio en inglés y sin diacríticos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ CLAUDE.md
 var/
 repomix-output.xml
 
+# Base de datos SQLite donde coverage.py va anotando qué líneas se ejecutan
+# mientras corren los tests. Es del mismo tipo que var/ —estado local y
+# regenerable, que sólo significa algo en la máquina que lo produjo— y aparece en
+# cuanto alguien lanza `pytest --cov`, que es lo que hará #138.
+.coverage
+
 # Frontend Angular (H3). node_modules/ sin acotar a frontend/ y a cualquier
 # profundidad: un solo npm install descuidado en otro directorio metería
 # decenas de miles de ficheros en el primer git status, y a esas alturas ya

--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,120 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### Las claves del dominio, en inglés y sin diacríticos (#134)
+
+Salió al escribir la plantilla de #127. Para pintar cada señal con el color de su
+naturaleza hay que llevar `type` a un atributo del HTML, y ahí se vio que el
+dominio **no seguía su propia regla**:
+
+```python
+class Dimension(str, Enum):
+    ENGANO = "engano"  # sin ñ
+
+
+class SignalType(str, Enum):
+    HIBRIDO = "híbrido"  # con tilde
+```
+
+Dos enums, el mismo fichero, reglas opuestas. Que `engano` renunciara a la ñ dice
+que en algún momento se decidió que las claves fueran ASCII; `híbrido` se saltó
+esa decisión, o nunca llegó a ser explícita. El resultado es que no se podía
+responder «¿las claves llevan diacríticos?» mirando el código.
+
+#### Se eligió el inglés, no sólo quitar la tilde
+
+La opción barata era `HIBRIDO = "hibrido"`: un valor, y la regla ASCII pasa a
+cumplirse. Se descartó por ser **media medida** — arregla el síntoma y deja la
+mezcla de idiomas en claves que son de máquina.
+
+Lo que entra es el vocabulario completo en inglés: `form` / `deception` / `tone`,
+`interpretable` / `hybrid` / `opaque`, `deceptive` / `stylistic_clickbait` /
+`factual` / `ambiguous` / `no_data`. Es coherente con todo lo que ya lo estaba
+—los nombres de las tools (`detect_clickbait_lexical`), las etiquetas que
+publican (`clickbait` / `factual news`), los corpus y la literatura—, sale ASCII
+de regalo y no deja ninguna decisión de diacríticos pendiente para el futuro.
+
+La regla queda **escrita en el docstring de `domain.py`**, que es lo que faltaba:
+antes había dos reglas conviviendo y ninguna declarada.
+
+#### El enum que la issue se dejaba
+
+La issue enumeraba tres enums. Hay cuatro:
+
+```python
+class SignalStatus(str, Enum):
+    OK = "ok"
+    NO_APLICABLE = "no_aplicable"  # ← castellano
+    ERROR = "error"
+```
+
+Dejarlo fuera habría hecho que la regla **naciera ya incumplida**, que es
+exactamente el reproche que la issue le hace a la media medida. Y no era un valor
+escondido: el frontend lo compara literalmente en `estadoDeSenal()`. Entra como
+`not_applicable`.
+
+Los **nombres de miembro siguen a los valores** (`Dimension.DECEPTION`,
+`SignalType.HYBRID`, `OverallVerdict.STYLISTIC_CLICKBAIT`). `ENGANO = "deception"`
+habría sido cambiar una incoherencia por otra.
+
+#### Qué se tocó de la prosa, y qué no
+
+La regla aplicada: **se actualiza toda cita del valor entre comillas invertidas,
+salvo en `evaluation/` y `spikes/`**, que son registro de experimentos ya
+ejecutados y describen lo que se hizo entonces.
+
+Lo que NO cambia es la prosa en castellano que nombra el concepto —los nombres de
+los tests, los comentarios de diseño, `docs/requisitos.md`, este README— porque
+ahí «engaño» y «forma» no son claves: son las palabras del dominio, y son las que
+la interfaz sigue enseñando al usuario.
+
+Hay una excepción a la vista y es deliberada: el docstring de `domain.py`
+conserva `engano` e `híbrido` escritos tal cual, porque está contando **qué se
+arregló**. Y `R5.9` en `docs/requisitos.md` sigue enumerando «interpretable /
+híbrido / opaco» en castellano; tocarlo obligaría a justificar un cambio de
+requisito por algo puramente cosmético.
+
+#### Lo que NO arregla, para no venderlo de más
+
+**La capa de traducción a texto legible se queda entera.** `nombreDeDimension()`
+hace falta igual, porque la pantalla dice «Engaño» tanto si la clave es `engano`
+como si es `deception`. Lo único que desaparece de verdad es `claseDeTipo()`, una
+función cuyo trabajo completo era convertir `híbrido` en `hibrido` para poder
+casarlo en un selector CSS.
+
+O sea: esto es **coherencia y robustez, no ahorro de código**. Vendido como lo
+segundo, no compensaría.
+
+#### El historial viejo no se rompe, y eso estaba previsto
+
+Las filas ya escritas en SQLite guardan la respuesta completa, así que dicen
+`clickbait_de_forma`. No falla nada, y no por suerte: `HistoryEntry.verdict` es
+`str | None` y **no un enum**, decisión tomada en #102 con este motivo exacto
+anotado —«son datos leídos de disco, que pudo escribir otra versión del código»—.
+El frontend las pinta con su valor crudo gracias al `??` de `nombreDeVeredicto`:
+fea, pero visible, que es la misma regla que gobierna las señales desconocidas.
+
+Repoblar la base es opcional, y se puede porque los datos guardados son de prueba.
+
+#### El cliente tipado cazó lo que el grep no vio
+
+El primer barrido buscó `engano` e `híbrido` —los dos casos que nombra el título
+de la issue— y **se dejó `opaco`, `forma` y `tono` como valores sueltos**. Quedó
+vivo un `this.senal().type !== 'opaco'` en `senal-card.ts`, que decide si una
+tarjeta nace abierta.
+
+No lo encontró una búsqueda: lo paró `ng build`. Con `SignalType` generado desde
+el contrato como `"interpretable" | "hybrid" | "opaque"`, comparar contra
+`'opaco'` deja de compilar porque los tipos no se solapan. Es la cadena de #126
+haciendo el trabajo para el que se montó, en el primer refactor que la ejercita:
+sin ella el fallo habría sido silencioso —una comparación siempre falsa, tarjetas
+abriéndose cuando no toca— y sin ninguna línea roja en ningún sitio.
+
+#### Verificación
+
+198 tests de Python y 25 del frontend en verde, ruff limpio, y el contrato
+regenerado en el mismo commit — los dos guardianes de #126 lo comprueban.
+
 ### Diagramas del flujo de peticiones, y dos reglas que pasan a tener test (#106)
 
 `docs/arquitectura.md` se declaraba «documento vivo» y reflejaba el estado al

--- a/backend/analysis/domain.py
+++ b/backend/analysis/domain.py
@@ -14,7 +14,7 @@ Tres principios los gobiernan:
 2. **El estado va por señal, no global.** Un único campo ``status`` cubre dos
    situaciones que, desde el punto de vista de la respuesta, son la misma —esa
    señal no tiene resultado, pero las demás sí—: que falten datos de entrada
-   (``no_aplicable``: la incoherencia necesita el cuerpo) y que la ejecución
+   (``not_applicable``: la incoherencia necesita el cuerpo) y que la ejecución
    falle (``error``: ~1 de cada 5 llamadas a HuggingFace da timeout, medido en la
    Épica 4). El análisis NO devuelve error global mientras alguna señal funcione:
    perder tres análisis correctos porque el cuarto falló sería el mismo error que
@@ -29,6 +29,17 @@ Tres principios los gobiernan:
    objetividad no es lo mismo que hacer clickbait, y cuánto pesa eso es juicio
    de quien lee. No hace falta ningún caso especial para conseguirlo —
    simplemente no emite veredicto, igual que una señal que ha fallado.
+
+**Las claves van en inglés y sin diacríticos** (#134). Los valores de estos enums
+son claves de máquina: viajan por JSON, acaban como atributos del DOM y como
+selectores CSS. Traducirlos a «Engaño», «Híbrido» o «Sin datos» es trabajo de la
+capa de vocabulario del frontend, que es donde vive esa decisión.
+
+Hasta #134 convivían dos reglas opuestas en este mismo fichero —``engano``
+renunciaba a la ñ y ``híbrido`` la conservaba—, así que no se podía responder
+«¿las claves llevan tildes?» mirando el código. El síntoma era una función en el
+frontend cuyo único trabajo era convertir ``híbrido`` en ``hibrido`` para poder
+casarla en CSS.
 """
 
 from enum import Enum
@@ -38,7 +49,7 @@ from pydantic import BaseModel, Field, StringConstraints
 
 # Recorta antes de medir. Con un simple `min_length=1`, un titular de un solo
 # espacio pasa la validación —mide 1 carácter— y llega hasta las señales, que
-# fallan una a una: la respuesta sería un 200 con veredicto `sin_datos` en vez
+# fallan una a una: la respuesta sería un 200 con veredicto `no_data` en vez
 # del 422 que corresponde a una petición inválida. Pydantic aplica
 # `strip_whitespace` antes que `min_length`, así que el blanco se rechaza aquí.
 NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
@@ -48,29 +59,29 @@ class SignalStatus(str, Enum):
     """Por qué una señal tiene o no resultado."""
 
     OK = "ok"
-    NO_APLICABLE = "no_aplicable"  # faltan datos de entrada (p. ej. el cuerpo)
+    NOT_APPLICABLE = "not_applicable"  # faltan datos de entrada (p. ej. el cuerpo)
     ERROR = "error"  # la ejecución falló (timeout, proveedor caído...)
 
 
 class Dimension(str, Enum):
     """Qué mide una señal. Determina cómo se agrupan los veredictos."""
 
-    FORMA = "forma"  # sensacionalismo en la redacción
-    ENGANO = "engano"  # el titular promete algo que el cuerpo no cumple
-    TONO = "tono"  # carga emocional; contexto que se muestra, no veredicto
+    FORM = "form"  # sensacionalismo en la redacción
+    DECEPTION = "deception"  # el titular promete algo que el cuerpo no cumple
+    TONE = "tone"  # carga emocional; contexto que se muestra, no veredicto
 
 
 class SignalType(str, Enum):
     """Naturaleza del modelo. Se muestra como badge en la interfaz.
 
     No mide cuán complejo es el modelo sino **dónde está la transparencia**:
-    ``híbrido`` es decisión transparente sobre un rasgo opaco — un umbral legible
+    ``hybrid`` es decisión transparente sobre un rasgo opaco — un umbral legible
     aplicado a una similitud de embeddings, por ejemplo.
     """
 
     INTERPRETABLE = "interpretable"
-    HIBRIDO = "híbrido"
-    OPACO = "opaco"
+    HYBRID = "hybrid"
+    OPAQUE = "opaque"
 
 
 class SignalResult(BaseModel):
@@ -142,11 +153,11 @@ class OverallVerdict(str, Enum):
     que la forma— en lugar de por mayoría de señales.
     """
 
-    ENGANOSO = "enganoso"  # hay engaño: el cuerpo no corresponde al titular
-    CLICKBAIT_DE_FORMA = "clickbait_de_forma"  # sensacionalista, pero sin engañar
+    DECEPTIVE = "deceptive"  # hay engaño: el cuerpo no corresponde al titular
+    STYLISTIC_CLICKBAIT = "stylistic_clickbait"  # sensacionalista, pero sin engañar
     FACTUAL = "factual"
-    AMBIGUO = "ambiguo"  # las señales de una misma dimensión se contradicen
-    SIN_DATOS = "sin_datos"  # ninguna señal llegó a emitir veredicto
+    AMBIGUOUS = "ambiguous"  # las señales de una misma dimensión se contradicen
+    NO_DATA = "no_data"  # ninguna señal llegó a emitir veredicto
 
 
 class AnalyzeRequest(BaseModel):
@@ -155,7 +166,7 @@ class AnalyzeRequest(BaseModel):
         default=None,
         description=(
             "Cuerpo o teaser. Opcional: sin él, la señal de incoherencia queda "
-            "en 'no_aplicable' y no se puede evaluar la dimensión de engaño."
+            "en 'not_applicable' y no se puede evaluar la dimensión de engaño."
         ),
     )
 

--- a/backend/analysis/orchestrator.py
+++ b/backend/analysis/orchestrator.py
@@ -255,7 +255,7 @@ async def _run_signals(headline: str, content: str | None) -> list[SignalResult]
         if spec.needs_content and not (content and content.strip()):
             by_name[spec.name] = _build(
                 spec,
-                SignalStatus.NO_APLICABLE,
+                SignalStatus.NOT_APPLICABLE,
                 detail="Requiere el cuerpo o teaser de la noticia.",
             )
         else:
@@ -346,7 +346,7 @@ def _aggregate(signals: list[SignalResult]) -> list[DimensionVerdict]:
         # `is None` y no `if not signal.is_clickbait`: False es un veredicto
         # VÁLIDO —"esta señal dice que no es clickbait"— y con la comprobación
         # por falsedad se perderían todos los votos negativos, dejando cualquier
-        # titular factual en sin_datos. Este único filtro cubre a la vez las
+        # titular factual en no_data. Este único filtro cubre a la vez las
         # señales que fallaron y las que no votan por naturaleza (el tono).
         if signal.is_clickbait is None:
             continue
@@ -381,21 +381,21 @@ def _overall(dimensions: list[DimensionVerdict]) -> OverallVerdict:
     # Primero: con la lista vacía, el any() de abajo daría False y caería en
     # FACTUAL, declarando factual un titular que nadie pudo analizar.
     if not dimensions:
-        return OverallVerdict.SIN_DATOS
+        return OverallVerdict.NO_DATA
 
     by_dimension = {d.dimension: d for d in dimensions}
-    engano = by_dimension.get(Dimension.ENGANO)
-    forma = by_dimension.get(Dimension.FORMA)
+    deception = by_dimension.get(Dimension.DECEPTION)
+    form = by_dimension.get(Dimension.FORM)
 
     # El engaño manda: un titular que promete lo que el cuerpo no cumple es
     # clickbait aunque esté redactado con sobriedad.
-    if engano is not None and engano.is_clickbait:
-        return OverallVerdict.ENGANOSO
-    if forma is not None and forma.is_clickbait:
-        return OverallVerdict.CLICKBAIT_DE_FORMA
+    if deception is not None and deception.is_clickbait:
+        return OverallVerdict.DECEPTIVE
+    if form is not None and form.is_clickbait:
+        return OverallVerdict.STYLISTIC_CLICKBAIT
     # Una detección positiva pesa más que una discrepancia: solo si nadie ha
     # detectado nada importa que alguna dimensión quedara sin resolver. La
     # discrepancia no se pierde, sigue visible en dimensions[].
     if any(d.is_clickbait is None for d in dimensions):
-        return OverallVerdict.AMBIGUO
+        return OverallVerdict.AMBIGUOUS
     return OverallVerdict.FACTUAL

--- a/backend/analysis/tool.py
+++ b/backend/analysis/tool.py
@@ -56,7 +56,7 @@ def register(mcp: FastMCP):
             headline: El titular a analizar, en inglés.
             content: Cuerpo o teaser de la noticia. Opcional; sin él no se puede
                 evaluar la dimensión de engaño y esa señal queda como
-                `no_aplicable`.
+                `not_applicable`.
 
         Returns:
             El veredicto global, el resultado de cada señal con su naturaleza

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -129,7 +129,7 @@ async def post_analyze(request: AnalyzeRequest) -> AnalyzeResponse:
     Devuelve **200 aunque alguna señal falle**: cada una lleva su propio
     `status`, y perder tres análisis correctos porque el cuarto dio timeout
     sería un error. Si el cuerpo de la noticia no se
-    envía, la señal de incoherencia queda en `no_aplicable` y la dimensión de
+    envía, la señal de incoherencia queda en `not_applicable` y la dimensión de
     engaño no se puede evaluar.
 
     Cada análisis queda registrado en el historial. Si esa escritura
@@ -245,7 +245,7 @@ async def get_history(
         str | None,
         Query(
             max_length=50,
-            description="Qué CONCLUYÓ el análisis: `enganoso`, `factual`, `ambiguo`…",
+            description="Qué CONCLUYÓ el análisis: `deceptive`, `factual`, `ambiguous`…",
         ),
     ] = None,
     status: Annotated[

--- a/backend/api/history.py
+++ b/backend/api/history.py
@@ -458,7 +458,7 @@ async def query(
     el total de lo filtrado, no el de la tabla.
 
     `verdict` y `status` responden preguntas distintas y por eso son dos y no
-    uno: el veredicto es **qué concluyó el análisis** (`enganoso`, `factual`…) y
+    uno: el veredicto es **qué concluyó el análisis** (`deceptive`, `factual`…) y
     es el que le interesa a quien mira sus análisis; el estado es **si funcionó
     la maquinaria**, y es operativo. Meterlos en un solo parámetro «estado» era
     lo que hacía que el criterio no encajara.

--- a/backend/integrations/nlp/dedicated.py
+++ b/backend/integrations/nlp/dedicated.py
@@ -26,7 +26,7 @@ Su patrón es además **el inverso** del que descartó a ``elozano``:
 Alto FUERA y más bajo DENTRO. Eso es generalizar, no memorizar — y su 0,946 en
 Chakraborty supera al 0,865 que el lineal saca *dentro* de su propio dominio.
 
-Con él, la dimensión ``forma`` deja el 15 % de titulares sin resolver en vez del
+Con él, la dimensión ``form`` deja el 15 % de titulares sin resolver en vez del
 37 %, y sólo el 20 % de esa ambigüedad restante es error suyo (antes, el 78 %).
 Por eso **vuelve a votar**: el motivo por el que #109 lo silenció desaparece.
 

--- a/backend/integrations/nlp/incoherence.py
+++ b/backend/integrations/nlp/incoherence.py
@@ -22,7 +22,7 @@ class IncoherenceDetector:
     # curva es el punto de mayor precisión (0,649 en test), a cambio de
     # pronunciarse sólo en el 7,4 % de los titulares.
     #
-    # Se conserva justamente por eso. `engano` PISA a `forma` en la jerarquía de
+    # Se conserva justamente por eso. `deception` PISA a `form` en la jerarquía de
     # `_overall`, así que un falso positivo suyo declara «engañoso» anulando a
     # las otras tres señales: aquí la precisión pesa más que el recall, y los
     # umbrales más generosos la hunden (0,516 con 0,46; 0,412 con 0,56).

--- a/backend/integrations/nlp/model_cards.py
+++ b/backend/integrations/nlp/model_cards.py
@@ -3,7 +3,7 @@
 Fuente única, consultable en runtime vía la tool ``describe_models`` y
 forward-compatible con un futuro frontend. El campo ``type`` enlaza con R3.8:
 marca qué señales son white-box (``interpretable``) frente a caja negra
-(``opaco``), pasando por las ``híbrido`` (decisión transparente, feature opaca).
+(``opaque``), pasando por las ``hybrid`` (decisión transparente, feature opaca).
 
 CUIDADO CON LA OTRA MITAD DE R3.9
 
@@ -42,9 +42,9 @@ vuelvan a separarse.
 
 El campo ``dimension`` indica QUÉ mide cada señal, no cómo de transparente es:
 
-- ``forma``  — sensacionalismo en la redacción del titular (estilo).
-- ``engano`` — que el titular prometa algo que el cuerpo no cumple.
-- ``tono``   — carga emocional del texto; no es una señal de clickbait.
+- ``form``      — sensacionalismo en la redacción del titular (estilo).
+- ``deception`` — que el titular prometa algo que el cuerpo no cumple.
+- ``tone``      — carga emocional del texto; no es una señal de clickbait.
 
 Es lo que permite a ``/analyze`` agrupar los veredictos por dimensión en vez de
 promediar señales que miden cosas distintas: tres señales de *forma* de acuerdo
@@ -70,8 +70,8 @@ MODEL_CARDS = [
         "model_id": "Stremie/roberta-base-clickbait",
         "name": "RoBERTa dedicado (entrenado en Webis-17)",
         "task": "Clasifica el titular como clickbait vs factual con un modelo afinado específicamente para esta tarea.",
-        "type": "opaco",
-        "dimension": "forma",
+        "type": "opaque",
+        "dimension": "form",
         "limitations": [
             "Caja negra: sin explicación intrínseca (post-hoc opcional, R3.11).",
             "Solo inglés. Entrenado sobre `postText` de Webis-17, es decir TUITS de medios, no titulares de portada.",
@@ -90,8 +90,8 @@ MODEL_CARDS = [
         "model_id": "cardiffnlp/twitter-roberta-base-sentiment-latest",
         "name": "RoBERTa afinado en tuits (3 clases)",
         "task": "Análisis de sentimiento en 3 clases (positivo / neutral / negativo).",
-        "type": "opaco",
-        "dimension": "tono",
+        "type": "opaque",
+        "dimension": "tone",
         "limitations": [
             "Entrenado en tuits, no en titulares de noticias.",
             "Caja negra.",
@@ -101,11 +101,11 @@ MODEL_CARDS = [
     },
     {
         "signal": "detect_clickbait_incoherence",
-        "dimension": "engano",
+        "dimension": "deception",
         "model_id": "sentence-transformers/all-MiniLM-L6-v2",
         "name": "MiniLM-L6-v2 (embeddings de frase)",
         "task": "Similitud coseno titular↔contenido; una similitud baja indica posible clickbait por incoherencia.",
-        "type": "híbrido",
+        "type": "hybrid",
         "limitations": [
             "Decisión transparente (umbral sobre la similitud) pero feature opaca (embeddings).",
             "Umbral 0.3 CALIBRADO en #92 sobre 19484 pares de Webis-17, eligiéndolo en una mitad y midiéndolo en la otra: es el punto de mayor precisión de la curva (0.649 en test) a cambio de pronunciarse sólo en el 7.4% de los titulares. ROC-AUC de la señal 0.720.",
@@ -119,7 +119,7 @@ MODEL_CARDS = [
     },
     {
         "signal": "detect_clickbait_lexical",
-        "dimension": "forma",
+        "dimension": "form",
         # Sin `model_id`: no hay nada que descargar. Son regex y listas de cues.
         "model_id": None,
         "name": "Léxico por reglas (listas de cues de Chakraborty et al. 2016)",
@@ -138,7 +138,7 @@ MODEL_CARDS = [
     },
     {
         "signal": "detect_clickbait_linear",
-        "dimension": "forma",
+        "dimension": "form",
         # Sin `model_id`: los pesos son un JSON del repo, no un modelo de la Hub.
         "model_id": None,
         "name": "Regresión logística sobre features léxicas (entrenada en Chakraborty)",

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -12,7 +12,7 @@
           "análisis"
         ],
         "summary": "Post Analyze",
-        "description": "Analiza un titular contrastando todas las señales disponibles.\n\nDevuelve **200 aunque alguna señal falle**: cada una lleva su propio\n`status`, y perder tres análisis correctos porque el cuarto dio timeout\nsería un error. Si el cuerpo de la noticia no se\nenvía, la señal de incoherencia queda en `no_aplicable` y la dimensión de\nengaño no se puede evaluar.\n\nCada análisis queda registrado en el historial. Si esa escritura\nfalla, la respuesta se devuelve igual: perder un análisis correcto porque el\ndisco esté lleno sería peor que no guardarlo.",
+        "description": "Analiza un titular contrastando todas las señales disponibles.\n\nDevuelve **200 aunque alguna señal falle**: cada una lleva su propio\n`status`, y perder tres análisis correctos porque el cuarto dio timeout\nsería un error. Si el cuerpo de la noticia no se\nenvía, la señal de incoherencia queda en `not_applicable` y la dimensión de\nengaño no se puede evaluar.\n\nCada análisis queda registrado en el historial. Si esa escritura\nfalla, la respuesta se devuelve igual: perder un análisis correcto porque el\ndisco esté lleno sería peor que no guardarlo.",
         "operationId": "post_analyze_analyze_post",
         "requestBody": {
           "content": {
@@ -206,10 +206,10 @@
                   "type": "null"
                 }
               ],
-              "description": "Qué CONCLUYÓ el análisis: `enganoso`, `factual`, `ambiguo`…",
+              "description": "Qué CONCLUYÓ el análisis: `deceptive`, `factual`, `ambiguous`…",
               "title": "Verdict"
             },
-            "description": "Qué CONCLUYÓ el análisis: `enganoso`, `factual`, `ambiguo`…"
+            "description": "Qué CONCLUYÓ el análisis: `deceptive`, `factual`, `ambiguous`…"
           },
           {
             "name": "status",
@@ -338,7 +338,7 @@
               }
             ],
             "title": "Content",
-            "description": "Cuerpo o teaser. Opcional: sin él, la señal de incoherencia queda en 'no_aplicable' y no se puede evaluar la dimensión de engaño."
+            "description": "Cuerpo o teaser. Opcional: sin él, la señal de incoherencia queda en 'not_applicable' y no se puede evaluar la dimensión de engaño."
           }
         },
         "type": "object",
@@ -426,9 +426,9 @@
       "Dimension": {
         "type": "string",
         "enum": [
-          "forma",
-          "engano",
-          "tono"
+          "form",
+          "deception",
+          "tone"
         ],
         "title": "Dimension",
         "description": "Qué mide una señal. Determina cómo se agrupan los veredictos."
@@ -684,11 +684,11 @@
       "OverallVerdict": {
         "type": "string",
         "enum": [
-          "enganoso",
-          "clickbait_de_forma",
+          "deceptive",
+          "stylistic_clickbait",
           "factual",
-          "ambiguo",
-          "sin_datos"
+          "ambiguous",
+          "no_data"
         ],
         "title": "OverallVerdict",
         "description": "Etiqueta única, para listados compactos como el historial.\n\nSe deriva de las dimensiones con una jerarquía explícita —el engaño pesa más\nque la forma— en lugar de por mayoría de señales."
@@ -839,7 +839,7 @@
         "type": "string",
         "enum": [
           "ok",
-          "no_aplicable",
+          "not_applicable",
           "error"
         ],
         "title": "SignalStatus",
@@ -849,11 +849,11 @@
         "type": "string",
         "enum": [
           "interpretable",
-          "híbrido",
-          "opaco"
+          "hybrid",
+          "opaque"
         ],
         "title": "SignalType",
-        "description": "Naturaleza del modelo. Se muestra como badge en la interfaz.\n\nNo mide cuán complejo es el modelo sino **dónde está la transparencia**:\n``híbrido`` es decisión transparente sobre un rasgo opaco — un umbral legible\naplicado a una similitud de embeddings, por ejemplo."
+        "description": "Naturaleza del modelo. Se muestra como badge en la interfaz.\n\nNo mide cuán complejo es el modelo sino **dónde está la transparencia**:\n``hybrid`` es decisión transparente sobre un rasgo opaco — un umbral legible\naplicado a una similitud de embeddings, por ejemplo."
       },
       "ToolInfo": {
         "properties": {

--- a/frontend/src/app/analisis/analisis-page.html
+++ b/frontend/src/app/analisis/analisis-page.html
@@ -101,7 +101,7 @@
   <!-- Índice compacto: todas las señales caben sobre la línea de flotación. -->
   <ul class="pastillas">
     @for (senal of analisis.signals; track senal.name) {
-      <li class="pastilla" [attr.data-tipo]="tipo(senal)">
+      <li class="pastilla" [attr.data-tipo]="senal.type">
         <strong>{{ nombre(senal) }}</strong>
         <span>{{ estado(senal) }}</span>
       </li>

--- a/frontend/src/app/analisis/analisis-page.scss
+++ b/frontend/src/app/analisis/analisis-page.scss
@@ -158,9 +158,9 @@ button[disabled] {
 .veredicto {
   margin-top: 1.5rem;
   padding: 1.1rem 1.3rem;
-  border: 1px solid var(--hibrido);
+  border: 1px solid var(--hybrid);
   border-radius: 8px;
-  background: var(--hibrido-fondo);
+  background: var(--hybrid-fondo);
 }
 
 .veredicto h2 {
@@ -211,14 +211,14 @@ button[disabled] {
   background: var(--interpretable-fondo);
 }
 
-.pastilla[data-tipo='hibrido'] {
-  border-color: var(--hibrido);
-  background: var(--hibrido-fondo);
+.pastilla[data-tipo='hybrid'] {
+  border-color: var(--hybrid);
+  background: var(--hybrid-fondo);
 }
 
-.pastilla[data-tipo='opaco'] {
-  border-color: var(--opaco);
-  background: var(--opaco-fondo);
+.pastilla[data-tipo='opaque'] {
+  border-color: var(--opaque);
+  background: var(--opaque-fondo);
 }
 
 .pastilla span {

--- a/frontend/src/app/analisis/analisis-page.spec.ts
+++ b/frontend/src/app/analisis/analisis-page.spec.ts
@@ -16,7 +16,7 @@ const RESPUESTA: AnalyzeResponse = {
     {
       name: 'detect_clickbait_lexical',
       status: 'ok',
-      dimension: 'forma',
+      dimension: 'form',
       type: 'interpretable',
       is_clickbait: true,
       data: {
@@ -29,29 +29,29 @@ const RESPUESTA: AnalyzeResponse = {
     },
     {
       name: 'detect_clickbait_incoherence',
-      status: 'no_aplicable',
-      dimension: 'engano',
-      type: 'híbrido',
+      status: 'not_applicable',
+      dimension: 'deception',
+      type: 'hybrid',
       is_clickbait: null,
       detail: 'Requiere el cuerpo o teaser de la noticia.',
     },
     {
       name: 'analyze_sentiment',
       status: 'ok',
-      dimension: 'tono',
-      type: 'opaco',
+      dimension: 'tone',
+      type: 'opaque',
       is_clickbait: null,
       data: { label: 'negative', score: 0.71 },
     },
   ],
   dimensions: [
     {
-      dimension: 'forma',
+      dimension: 'form',
       is_clickbait: true,
       contributing: ['detect_clickbait_lexical'],
     },
   ],
-  verdict: 'clickbait_de_forma',
+  verdict: 'stylistic_clickbait',
 };
 
 describe('AnalisisPage', () => {
@@ -114,7 +114,7 @@ describe('AnalisisPage', () => {
     const pastillas = html().querySelectorAll('.pastilla');
     expect(pastillas.length).toBe(3);
     // El tipo va al atributo, y de ahí sale el color.
-    expect(pastillas[1].getAttribute('data-tipo')).toBe('hibrido');
+    expect(pastillas[1].getAttribute('data-tipo')).toBe('hybrid');
   });
 
   it('resalta sobre el titular las pistas que encontró el léxico', async () => {

--- a/frontend/src/app/analisis/analisis-page.ts
+++ b/frontend/src/app/analisis/analisis-page.ts
@@ -14,7 +14,6 @@ import { mensajeDeError } from './errores';
 import { SenalCard } from './senal-card';
 import { TitularResaltado } from './titular-resaltado';
 import {
-  claseDeTipo,
   estadoDeSenal,
   nombreDeDimension,
   nombreDeSenal,
@@ -57,7 +56,6 @@ export class AnalisisPage {
   protected readonly estado = estadoDeSenal;
   protected readonly dimension = nombreDeDimension;
   protected readonly resumen = resumenDimension;
-  protected readonly tipo = claseDeTipo;
 
   analizar(): void {
     // Dos envíos son dos ejecuciones de los modelos y dos entradas de historial.
@@ -74,7 +72,7 @@ export class AnalisisPage {
 
     this.analyze
       // Sin cuerpo se omite la clave entera, que es lo que deja la incoherencia
-      // en `no_aplicable`. Mandar "" sería otra cosa: un cuerpo vacío.
+      // en `not_applicable`. Mandar "" sería otra cosa: un cuerpo vacío.
       .analizar({
         headline: headline.trim(),
         content: content.trim() || undefined,

--- a/frontend/src/app/analisis/senal-card.html
+++ b/frontend/src/app/analisis/senal-card.html
@@ -1,4 +1,4 @@
-<article class="tarjeta" [attr.data-tipo]="tipo(senal())">
+<article class="tarjeta" [attr.data-tipo]="senal().type">
   <button
     type="button"
     class="cabecera"

--- a/frontend/src/app/analisis/senal-card.scss
+++ b/frontend/src/app/analisis/senal-card.scss
@@ -10,11 +10,11 @@
 .tarjeta[data-tipo='interpretable'] {
   border-left-color: var(--interpretable);
 }
-.tarjeta[data-tipo='hibrido'] {
-  border-left-color: var(--hibrido);
+.tarjeta[data-tipo='hybrid'] {
+  border-left-color: var(--hybrid);
 }
-.tarjeta[data-tipo='opaco'] {
-  border-left-color: var(--opaco);
+.tarjeta[data-tipo='opaque'] {
+  border-left-color: var(--opaque);
 }
 
 .cabecera {
@@ -49,11 +49,11 @@
 [data-tipo='interpretable'] .badge {
   background: var(--interpretable-fondo);
 }
-[data-tipo='hibrido'] .badge {
-  background: var(--hibrido-fondo);
+[data-tipo='hybrid'] .badge {
+  background: var(--hybrid-fondo);
 }
-[data-tipo='opaco'] .badge {
-  background: var(--opaco-fondo);
+[data-tipo='opaque'] .badge {
+  background: var(--opaque-fondo);
 }
 
 .estado {
@@ -117,7 +117,7 @@
   background: var(--interpretable-fondo);
 }
 .pistas li[data-categoria='hyperbole'] {
-  background: var(--opaco-fondo);
+  background: var(--opaque-fondo);
 }
 .pistas li[data-categoria='forward_reference'] {
   background: #dae8fc;
@@ -151,7 +151,7 @@
 .cues .barra {
   height: 0.7rem;
   border-radius: 3px;
-  background: var(--opaco-fondo);
+  background: var(--opaque-fondo);
 }
 
 .cues .barra.contra {

--- a/frontend/src/app/analisis/senal-card.spec.ts
+++ b/frontend/src/app/analisis/senal-card.spec.ts
@@ -6,7 +6,7 @@ import { SenalCard } from './senal-card';
 const LEXICA: SignalResult = {
   name: 'detect_clickbait_lexical',
   status: 'ok',
-  dimension: 'forma',
+  dimension: 'form',
   type: 'interpretable',
   is_clickbait: true,
   data: {
@@ -21,8 +21,8 @@ const LEXICA: SignalResult = {
 const OPACA: SignalResult = {
   name: 'detect_clickbait',
   status: 'ok',
-  dimension: 'forma',
-  type: 'opaco',
+  dimension: 'form',
+  type: 'opaque',
   is_clickbait: true,
   data: { label: 'clickbait', score: 0.83 },
 };
@@ -30,8 +30,8 @@ const OPACA: SignalResult = {
 const CAIDA: SignalResult = {
   name: 'detect_clickbait',
   status: 'error',
-  dimension: 'forma',
-  type: 'opaco',
+  dimension: 'form',
+  type: 'opaque',
   data: null,
   detail: 'HTTP error: 400 - Model not supported by provider hf-inference',
 };
@@ -39,7 +39,7 @@ const CAIDA: SignalResult = {
 const DESCONOCIDA: SignalResult = {
   name: 'una_senal_futura',
   status: 'ok',
-  dimension: 'forma',
+  dimension: 'form',
   type: 'interpretable',
   is_clickbait: false,
   data: { algo: 'que nadie ha previsto' },

--- a/frontend/src/app/analisis/senal-card.ts
+++ b/frontend/src/app/analisis/senal-card.ts
@@ -3,7 +3,6 @@ import { Component, computed, input, linkedSignal } from '@angular/core';
 import type { SignalResult } from '../api/models';
 import { comoEtiqueta, comoIncoherencia, comoLexico, comoLineal } from './datos';
 import {
-  claseDeTipo,
   estadoDeSenal,
   nombreDeCategoria,
   nombreDeSenal,
@@ -32,7 +31,7 @@ export class SenalCard {
    * habría que reiniciarlo a mano, y olvidarlo dejaría la tarjeta como la dejó
    * el análisis anterior.
    */
-  readonly abierta = linkedSignal(() => this.senal().type !== 'opaco');
+  readonly abierta = linkedSignal(() => this.senal().type !== 'opaque');
 
   readonly lexico = computed(() => comoLexico(this.senal().data));
   readonly lineal = computed(() => comoLineal(this.senal().data));
@@ -50,7 +49,6 @@ export class SenalCard {
 
   protected readonly nombre = nombreDeSenal;
   protected readonly estado = estadoDeSenal;
-  protected readonly tipo = claseDeTipo;
   protected readonly categoria = nombreDeCategoria;
   protected readonly numero = numero;
 

--- a/frontend/src/app/analisis/titular-resaltado.scss
+++ b/frontend/src/app/analisis/titular-resaltado.scss
@@ -16,7 +16,7 @@ mark[data-categoria='leading_number'] {
   background: var(--interpretable-fondo);
 }
 mark[data-categoria='hyperbole'] {
-  background: var(--opaco-fondo);
+  background: var(--opaque-fondo);
 }
 mark[data-categoria='forward_reference'] {
   background: #dae8fc;
@@ -27,7 +27,7 @@ mark[data-categoria='curiosity_gap'] {
 mark[data-categoria='question'],
 mark[data-categoria='all_caps'],
 mark[data-categoria='ellipsis'] {
-  background: var(--hibrido-fondo);
+  background: var(--hybrid-fondo);
 }
 
 .leyenda {

--- a/frontend/src/app/analisis/vocabulario.ts
+++ b/frontend/src/app/analisis/vocabulario.ts
@@ -15,11 +15,11 @@ const NOMBRES: Record<string, string> = {
 // En caja normal a propósito: las mayúsculas las pone el CSS. Muchos lectores
 // de pantalla deletrean las palabras escritas en caja alta.
 const VEREDICTOS: Record<string, string> = {
-  enganoso: 'Engañoso',
-  clickbait_de_forma: 'Clickbait de forma',
+  deceptive: 'Engañoso',
+  stylistic_clickbait: 'Clickbait de forma',
   factual: 'Factual',
-  ambiguo: 'Ambiguo',
-  sin_datos: 'Sin datos',
+  ambiguous: 'Ambiguo',
+  no_data: 'Sin datos',
 };
 
 /** Las siete categorías de pista de `lexical.py`. */
@@ -34,9 +34,9 @@ const CATEGORIAS: Record<string, string> = {
 };
 
 const DIMENSIONES: Record<string, string> = {
-  forma: 'Forma',
-  engano: 'Engaño', // la clave del backend viene sin ñ
-  tono: 'Tono',
+  form: 'Forma',
+  deception: 'Engaño',
+  tone: 'Tono',
 };
 
 // El `??` es lo que hace que una señal desconocida se pinte con su id crudo en
@@ -57,14 +57,9 @@ export function nombreDeCategoria(categoria: string): string {
   return CATEGORIAS[categoria] ?? categoria;
 }
 
-/** `híbrido` lleva tilde, y como valor de atributo es frágil de casar en CSS. */
-export function claseDeTipo(senal: SignalResult): string {
-  return senal.type === 'híbrido' ? 'hibrido' : senal.type;
-}
-
 /** Qué dijo la señal, o por qué no dijo nada. */
 export function estadoDeSenal(senal: SignalResult): string {
-  if (senal.status === 'no_aplicable') return 'no aplicable';
+  if (senal.status === 'not_applicable') return 'no aplicable';
   if (senal.status === 'error') return 'error';
   // `== null` cubre null Y undefined: el campo es opcional en el contrato, y
   // con `=== null` una señal sin él se pintaría como «no clickbait».

--- a/frontend/src/app/api/analyze.service.spec.ts
+++ b/frontend/src/app/api/analyze.service.spec.ts
@@ -10,7 +10,7 @@ import type { AnalyzeResponse } from './models';
 
 /**
  * Respuesta mínima que sigue validando contra el contrato: sin señales y con
- * `sin_datos`, que es lo que devuelve el backend cuando ninguna llegó a
+ * `no_data`, que es lo que devuelve el backend cuando ninguna llegó a
  * pronunciarse. Aquí no se prueba el análisis, sólo el transporte.
  */
 const RESPUESTA: AnalyzeResponse = {
@@ -18,7 +18,7 @@ const RESPUESTA: AnalyzeResponse = {
   content: null,
   signals: [],
   dimensions: [],
-  verdict: 'sin_datos',
+  verdict: 'no_data',
 };
 
 describe('AnalyzeService', () => {

--- a/frontend/src/app/api/schema.d.ts
+++ b/frontend/src/app/api/schema.d.ts
@@ -20,7 +20,7 @@ export interface paths {
          *     Devuelve **200 aunque alguna señal falle**: cada una lleva su propio
          *     `status`, y perder tres análisis correctos porque el cuarto dio timeout
          *     sería un error. Si el cuerpo de la noticia no se
-         *     envía, la señal de incoherencia queda en `no_aplicable` y la dimensión de
+         *     envía, la señal de incoherencia queda en `not_applicable` y la dimensión de
          *     engaño no se puede evaluar.
          *
          *     Cada análisis queda registrado en el historial. Si esa escritura
@@ -187,7 +187,7 @@ export interface components {
             headline: string;
             /**
              * Content
-             * @description Cuerpo o teaser. Opcional: sin él, la señal de incoherencia queda en 'no_aplicable' y no se puede evaluar la dimensión de engaño.
+             * @description Cuerpo o teaser. Opcional: sin él, la señal de incoherencia queda en 'not_applicable' y no se puede evaluar la dimensión de engaño.
              */
             content?: string | null;
         };
@@ -227,7 +227,7 @@ export interface components {
          * @description Qué mide una señal. Determina cómo se agrupan los veredictos.
          * @enum {string}
          */
-        Dimension: "forma" | "engano" | "tono";
+        Dimension: "form" | "deception" | "tone";
         /**
          * DimensionVerdict
          * @description Veredicto agregado de las señales que miden lo mismo (principio 3).
@@ -403,7 +403,7 @@ export interface components {
          *     que la forma— en lugar de por mayoría de señales.
          * @enum {string}
          */
-        OverallVerdict: "enganoso" | "clickbait_de_forma" | "factual" | "ambiguo" | "sin_datos";
+        OverallVerdict: "deceptive" | "stylistic_clickbait" | "factual" | "ambiguous" | "no_data";
         /**
          * RetentionPolicy
          * @description Política de retención vigente, para que la interfaz no la cablee.
@@ -505,17 +505,17 @@ export interface components {
          * @description Por qué una señal tiene o no resultado.
          * @enum {string}
          */
-        SignalStatus: "ok" | "no_aplicable" | "error";
+        SignalStatus: "ok" | "not_applicable" | "error";
         /**
          * SignalType
          * @description Naturaleza del modelo. Se muestra como badge en la interfaz.
          *
          *     No mide cuán complejo es el modelo sino **dónde está la transparencia**:
-         *     ``híbrido`` es decisión transparente sobre un rasgo opaco — un umbral legible
+         *     ``hybrid`` es decisión transparente sobre un rasgo opaco — un umbral legible
          *     aplicado a una similitud de embeddings, por ejemplo.
          * @enum {string}
          */
-        SignalType: "interpretable" | "híbrido" | "opaco";
+        SignalType: "interpretable" | "hybrid" | "opaque";
         /**
          * ToolInfo
          * @description Una herramienta del catálogo, con su procedencia y sus metadatos.
@@ -687,7 +687,7 @@ export interface operations {
                 kind?: components["schemas"]["HistoryKind"] | null;
                 /** @description Nombre de la herramienta. Sólo casa con ejecuciones sueltas: un análisis invoca cinco señales y no tiene *una* herramienta. */
                 tool?: string | null;
-                /** @description Qué CONCLUYÓ el análisis: `enganoso`, `factual`, `ambiguo`… */
+                /** @description Qué CONCLUYÓ el análisis: `deceptive`, `factual`, `ambiguous`… */
                 verdict?: string | null;
                 /** @description Si funcionó la MAQUINARIA: `ok` o `error`. Filtro operativo. */
                 status?: string | null;

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -11,13 +11,13 @@
   --acento: #6c8ebf;
 
   /* Tipo de señal. NO es «cuán bueno es el modelo» sino dónde está la
-   * transparencia: interpretable / híbrido / opaco. */
+   * transparencia: interpretable / hybrid / opaque. */
   --interpretable: #82b366;
   --interpretable-fondo: #d5e8d4;
-  --hibrido: #d6b656;
-  --hibrido-fondo: #fff2cc;
-  --opaco: #b85450;
-  --opaco-fondo: #f8cecc;
+  --hybrid: #d6b656;
+  --hybrid-fondo: #fff2cc;
+  --opaque: #b85450;
+  --opaque-fondo: #f8cecc;
 
   --aviso: #996600;
   --aviso-fondo: #fff2cc;

--- a/tests/analysis/test_tool.py
+++ b/tests/analysis/test_tool.py
@@ -73,7 +73,7 @@ def test_no_se_presenta_como_una_senal_mas(tool):
 
 def test_el_cuerpo_es_opcional(tool):
     """Sin cuerpo no se puede evaluar el engaño, pero el análisis sigue siendo
-    válido: la señal queda en `no_aplicable` y las demás votan igual."""
+    válido: la señal queda en `not_applicable` y las demás votan igual."""
     requeridos = tool.inputSchema.get("required", [])
     assert "headline" in requeridos
     assert "content" not in requeridos

--- a/tests/api/test_analyze.py
+++ b/tests/api/test_analyze.py
@@ -148,7 +148,7 @@ def _por_dimension(verdicts):
 @pytest.mark.parametrize("blanco", [" ", "", "\t\n", "   "])
 def test_headline_en_blanco_se_rechaza(blanco):
     # Un titular de solo espacios medía 1 carácter y pasaba `min_length=1`,
-    # produciendo un 200 con `sin_datos` en lugar de un 422.
+    # produciendo un 200 con `no_data` en lugar de un 422.
     with pytest.raises(ValidationError):
         AnalyzeRequest(headline=blanco)
 
@@ -170,8 +170,8 @@ def test_señales_de_acuerdo_dan_veredicto_de_dimension(señales):
             ]
         )
     )
-    assert verdicts[Dimension.FORMA].is_clickbait is True
-    assert len(verdicts[Dimension.FORMA].contributing) == 3
+    assert verdicts[Dimension.FORM].is_clickbait is True
+    assert len(verdicts[Dimension.FORM].contributing) == 3
 
 
 def test_señales_en_discrepancia_no_se_resuelven_por_mayoria():
@@ -189,15 +189,15 @@ def test_señales_en_discrepancia_no_se_resuelven_por_mayoria():
             ]
         )
     )
-    assert verdicts[Dimension.FORMA].is_clickbait is None
-    assert len(verdicts[Dimension.FORMA].contributing) == 3
+    assert verdicts[Dimension.FORM].is_clickbait is None
+    assert len(verdicts[Dimension.FORM].contributing) == 3
 
 
 def test_veredicto_negativo_cuenta_como_voto():
     # Regresión: con `if not signal.is_clickbait` en vez de `is None`, los votos
-    # False se descartarían y un titular factual saldría sin_datos.
+    # False se descartarían y un titular factual saldría no_data.
     verdicts = _por_dimension(_aggregate([_signal("detect_clickbait_lexical", False)]))
-    assert verdicts[Dimension.FORMA].is_clickbait is False
+    assert verdicts[Dimension.FORM].is_clickbait is False
 
 
 def test_el_tono_no_vota_y_no_genera_dimension():
@@ -207,7 +207,7 @@ def test_el_tono_no_vota_y_no_genera_dimension():
             _signal("detect_clickbait_lexical", True),
         ]
     )
-    assert Dimension.TONO not in _por_dimension(verdicts)
+    assert Dimension.TONE not in _por_dimension(verdicts)
 
 
 @pytest.mark.asyncio
@@ -228,7 +228,7 @@ async def test_la_señal_dedicada_vota_y_su_etiqueta_va_normalizada(señales):
     assert dedicada.is_clickbait is True
     assert dedicada.data["label"] == "clickbait"  # no «Clickbait»
 
-    forma = _por_dimension(_aggregate(list(signals.values())))[Dimension.FORMA]
+    forma = _por_dimension(_aggregate(list(signals.values())))[Dimension.FORM]
     assert forma.contributing == [
         "detect_clickbait",
         "detect_clickbait_lexical",
@@ -277,36 +277,36 @@ def _dim(dimension, is_clickbait):
 def test_sin_dimensiones_es_sin_datos():
     # Debe comprobarse ANTES que la ambigüedad: con la lista vacía el any() da
     # False y caería en FACTUAL, declarando factual lo que nadie pudo analizar.
-    assert _overall([]) == OverallVerdict.SIN_DATOS
+    assert _overall([]) == OverallVerdict.NO_DATA
 
 
 def test_el_engaño_pesa_mas_que_la_forma():
     # Tres señales de forma dicen "no" y una de engaño dice "sí": gana la de
     # engaño. Por mayoría saldría "factual", que es justo el error a evitar.
-    verdict = _overall([_dim(Dimension.FORMA, False), _dim(Dimension.ENGANO, True)])
-    assert verdict == OverallVerdict.ENGANOSO
+    verdict = _overall([_dim(Dimension.FORM, False), _dim(Dimension.DECEPTION, True)])
+    assert verdict == OverallVerdict.DECEPTIVE
 
 
 def test_forma_sin_engaño_es_clickbait_de_forma():
-    verdict = _overall([_dim(Dimension.FORMA, True), _dim(Dimension.ENGANO, False)])
-    assert verdict == OverallVerdict.CLICKBAIT_DE_FORMA
+    verdict = _overall([_dim(Dimension.FORM, True), _dim(Dimension.DECEPTION, False)])
+    assert verdict == OverallVerdict.STYLISTIC_CLICKBAIT
 
 
 def test_todo_negativo_es_factual():
-    verdict = _overall([_dim(Dimension.FORMA, False), _dim(Dimension.ENGANO, False)])
+    verdict = _overall([_dim(Dimension.FORM, False), _dim(Dimension.DECEPTION, False)])
     assert verdict == OverallVerdict.FACTUAL
 
 
 def test_dimension_sin_resolver_es_ambiguo():
-    verdict = _overall([_dim(Dimension.FORMA, None), _dim(Dimension.ENGANO, False)])
-    assert verdict == OverallVerdict.AMBIGUO
+    verdict = _overall([_dim(Dimension.FORM, None), _dim(Dimension.DECEPTION, False)])
+    assert verdict == OverallVerdict.AMBIGUOUS
 
 
 def test_una_deteccion_positiva_pesa_mas_que_una_discrepancia():
     # Decisión consciente: la ambigüedad de forma no oculta el engaño detectado.
     # Sigue visible en dimensions[], solo no manda en la etiqueta única.
-    verdict = _overall([_dim(Dimension.FORMA, None), _dim(Dimension.ENGANO, True)])
-    assert verdict == OverallVerdict.ENGANOSO
+    verdict = _overall([_dim(Dimension.FORM, None), _dim(Dimension.DECEPTION, True)])
+    assert verdict == OverallVerdict.DECEPTIVE
 
 
 # ----- _run_signals: aplicabilidad, aislamiento, orden -----
@@ -318,7 +318,7 @@ async def test_sin_cuerpo_la_incoherencia_queda_no_aplicable(señales):
     signals = {s.name: s for s in await _run_signals("Un titular", None)}
 
     incoherencia = signals["detect_clickbait_incoherence"]
-    assert incoherencia.status == SignalStatus.NO_APLICABLE
+    assert incoherencia.status == SignalStatus.NOT_APPLICABLE
     assert incoherencia.is_clickbait is None
     assert incoherencia.detail  # explica por qué, para pintarla en gris
     # Las demás sí corren.
@@ -330,7 +330,7 @@ async def test_sin_cuerpo_la_incoherencia_queda_no_aplicable(señales):
 async def test_cuerpo_en_blanco_equivale_a_no_tenerlo(señales, cuerpo):
     señales()
     signals = {s.name: s for s in await _run_signals("Un titular", cuerpo)}
-    assert signals["detect_clickbait_incoherence"].status == SignalStatus.NO_APLICABLE
+    assert signals["detect_clickbait_incoherence"].status == SignalStatus.NOT_APPLICABLE
 
 
 @pytest.mark.asyncio
@@ -412,9 +412,9 @@ async def test_la_dimension_y_el_tipo_salen_de_la_ficha(señales):
     señales()
     signals = {s.name: s for s in await _run_signals("Un titular", "Un cuerpo")}
 
-    assert signals["detect_clickbait_incoherence"].dimension == Dimension.ENGANO
-    assert signals["analyze_sentiment"].dimension == Dimension.TONO
-    assert signals["detect_clickbait_lexical"].dimension == Dimension.FORMA
+    assert signals["detect_clickbait_incoherence"].dimension == Dimension.DECEPTION
+    assert signals["analyze_sentiment"].dimension == Dimension.TONE
+    assert signals["detect_clickbait_lexical"].dimension == Dimension.FORM
 
 
 # ----- analyze: extremo a extremo (con dobles) -----
@@ -428,12 +428,12 @@ async def test_clickbait_de_forma_con_cuerpo_coherente(señales):
         AnalyzeRequest(headline="You Won't Believe What Happened Next", content="...")
     )
 
-    assert response.verdict == OverallVerdict.CLICKBAIT_DE_FORMA
+    assert response.verdict == OverallVerdict.STYLISTIC_CLICKBAIT
     assert response.has_any_result
     assert len(response.signals) == len(_SIGNALS)
     # El tono aparece como tarjeta pero no como dimensión.
     assert "analyze_sentiment" in {s.name for s in response.signals}
-    assert Dimension.TONO not in {d.dimension for d in response.dimensions}
+    assert Dimension.TONE not in {d.dimension for d in response.dimensions}
 
 
 @pytest.mark.asyncio
@@ -446,10 +446,10 @@ async def test_forma_sobria_pero_engañosa(señales):
         AnalyzeRequest(headline="Report Details Q3 Financial Results", content="...")
     )
 
-    assert response.verdict == OverallVerdict.ENGANOSO
+    assert response.verdict == OverallVerdict.DECEPTIVE
     dimensiones = _por_dimension(response.dimensions)
-    assert dimensiones[Dimension.FORMA].is_clickbait is False
-    assert dimensiones[Dimension.ENGANO].is_clickbait is True
+    assert dimensiones[Dimension.FORM].is_clickbait is False
+    assert dimensiones[Dimension.DECEPTION].is_clickbait is True
 
 
 @pytest.mark.asyncio
@@ -462,7 +462,7 @@ async def test_si_todas_las_señales_fallan_no_hay_veredicto(señales, monkeypat
 
     response = await orchestrator.analyze(AnalyzeRequest(headline="Un titular"))
 
-    assert response.verdict == OverallVerdict.SIN_DATOS
+    assert response.verdict == OverallVerdict.NO_DATA
     assert not response.has_any_result
     assert response.dimensions == []
     # Aun así la respuesta es informativa: cada tarjeta dice qué le pasó.

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -34,7 +34,7 @@ def _respuesta(headline="Un titular", content=None):
             SignalResult(
                 name="detect_clickbait_lexical",
                 status=SignalStatus.OK,
-                dimension=Dimension.FORMA,
+                dimension=Dimension.FORM,
                 type=SignalType.INTERPRETABLE,
                 is_clickbait=True,
                 data={"score": 2, "is_clickbait": True},
@@ -42,12 +42,12 @@ def _respuesta(headline="Un titular", content=None):
         ],
         dimensions=[
             DimensionVerdict(
-                dimension=Dimension.FORMA,
+                dimension=Dimension.FORM,
                 is_clickbait=True,
                 contributing=["detect_clickbait_lexical"],
             )
         ],
-        verdict=OverallVerdict.CLICKBAIT_DE_FORMA,
+        verdict=OverallVerdict.STYLISTIC_CLICKBAIT,
     )
 
 
@@ -72,7 +72,7 @@ def test_analyze_devuelve_la_respuesta_completa(analisis):
 
     assert response.status_code == 200
     cuerpo = response.json()
-    assert cuerpo["verdict"] == "clickbait_de_forma"
+    assert cuerpo["verdict"] == "stylistic_clickbait"
     assert cuerpo["signals"][0]["name"] == "detect_clickbait_lexical"
     # El JSON crudo de la herramienta viaja sin aplanar: alimenta las tarjetas
     # de explicabilidad.
@@ -92,7 +92,7 @@ def test_sin_content_la_peticion_es_valida(analisis):
 
 @pytest.mark.parametrize("blanco", [" ", "", "\t\n"])
 def test_titular_en_blanco_es_422(blanco, analisis):
-    # 422 y no un 200 con `sin_datos`: la petición es inválida, no es que el
+    # 422 y no un 200 con `no_data`: la petición es inválida, no es que el
     # análisis no haya dado resultado.
     assert client.post("/analyze", json={"headline": blanco}).status_code == 422
 

--- a/tests/api/test_catalog.py
+++ b/tests/api/test_catalog.py
@@ -126,7 +126,7 @@ async def test_las_senales_traen_su_ficha_de_modelo(monkeypatch, servidor_mcp):
     ficha = tools["detect_clickbait_lexical"].model_card
     assert ficha is not None
     assert ficha.type.value == "interpretable"
-    assert ficha.dimension.value == "forma"
+    assert ficha.dimension.value == "form"
     # Los límites medidos son lo que evita que el catálogo prometa de más.
     assert any("0.498" in limite for limite in ficha.limitations)
 

--- a/tests/api/test_history.py
+++ b/tests/api/test_history.py
@@ -84,11 +84,11 @@ def test_el_payload_vuelve_como_diccionario():
     tendría que saber que aquí dentro se guarda serializado. Con Postgres y una
     columna `jsonb` ese `json.loads` de fuera reventaría.
     """
-    _guardar(payload={"verdict": "enganoso", "signals": [{"name": "lexical"}]})
+    _guardar(payload={"verdict": "deceptive", "signals": [{"name": "lexical"}]})
 
     filas, _ = _leer()
     assert filas[0]["payload"] == {
-        "verdict": "enganoso",
+        "verdict": "deceptive",
         "signals": [{"name": "lexical"}],
     }
 
@@ -289,7 +289,7 @@ def _respuesta_analisis(headline="Un titular"):
             SignalResult(
                 name="detect_clickbait_lexical",
                 status=SignalStatus.OK,
-                dimension=Dimension.FORMA,
+                dimension=Dimension.FORM,
                 type=SignalType.INTERPRETABLE,
                 is_clickbait=True,
                 data={"score": 2},
@@ -297,12 +297,12 @@ def _respuesta_analisis(headline="Un titular"):
         ],
         dimensions=[
             DimensionVerdict(
-                dimension=Dimension.FORMA,
+                dimension=Dimension.FORM,
                 is_clickbait=True,
                 contributing=["detect_clickbait_lexical"],
             )
         ],
-        verdict=OverallVerdict.CLICKBAIT_DE_FORMA,
+        verdict=OverallVerdict.STYLISTIC_CLICKBAIT,
     )
 
 
@@ -348,7 +348,7 @@ def test_un_analyze_deja_UNA_entrada_y_no_una_por_senal(analisis):
     assert cuerpo["total"] == 1
     assert cuerpo["items"][0]["kind"] == "analysis"
     assert cuerpo["items"][0]["headline"] == "Un titular"
-    assert cuerpo["items"][0]["verdict"] == "clickbait_de_forma"
+    assert cuerpo["items"][0]["verdict"] == "stylistic_clickbait"
 
 
 def test_la_entrada_guarda_la_respuesta_completa(analisis):
@@ -357,7 +357,7 @@ def test_la_entrada_guarda_la_respuesta_completa(analisis):
     client.post("/analyze", json={"headline": "Un titular"})
 
     payload = client.get("/history").json()["items"][0]["payload"]
-    assert payload["verdict"] == "clickbait_de_forma"
+    assert payload["verdict"] == "stylistic_clickbait"
     assert payload["signals"][0]["name"] == "detect_clickbait_lexical"
     assert payload["signals"][0]["data"] == {"score": 2}
 
@@ -445,9 +445,9 @@ def test_los_topes_salen_en_el_esquema_openapi():
 
 def _poblar():
     """Un historial variado: análisis con tres veredictos y dos herramientas."""
-    _guardar(headline="engañoso", verdict="enganoso", status="ok")
+    _guardar(headline="engañoso", verdict="deceptive", status="ok")
     _guardar(headline="factual", verdict="factual", status="ok")
-    _guardar(headline="roto", verdict="sin_datos", status="error")
+    _guardar(headline="roto", verdict="no_data", status="error")
     _guardar(kind=HistoryKind.TOOL, tool="analyze_sentiment", status="ok")
     _guardar(kind=HistoryKind.TOOL, tool="health_check", status="error")
 
@@ -476,7 +476,7 @@ def test_filtro_por_verdict():
     """Lo que CONCLUYÓ: es el filtro que quiere quien mira sus análisis."""
     _poblar()
 
-    cuerpo = client.get("/history?verdict=enganoso").json()
+    cuerpo = client.get("/history?verdict=deceptive").json()
     assert cuerpo["total"] == 1
     assert cuerpo["items"][0]["headline"] == "engañoso"
 
@@ -496,7 +496,7 @@ def test_los_filtros_se_acumulan():
 
     cuerpo = client.get("/history?kind=analysis&status=ok").json()
     assert cuerpo["total"] == 2
-    assert {i["verdict"] for i in cuerpo["items"]} == {"enganoso", "factual"}
+    assert {i["verdict"] for i in cuerpo["items"]} == {"deceptive", "factual"}
 
 
 def test_el_total_va_ya_filtrado():

--- a/tests/integrations/test_nlp.py
+++ b/tests/integrations/test_nlp.py
@@ -472,8 +472,8 @@ def test_model_cards_wellformed():
         "limitations",
         "backend",
     }
-    valid_types = {"interpretable", "híbrido", "opaco"}
-    valid_dimensions = {"forma", "engano", "tono"}
+    valid_types = {"interpretable", "hybrid", "opaque"}
+    valid_dimensions = {"form", "deception", "tone"}
     assert isinstance(model_cards.MODEL_CARDS, list) and model_cards.MODEL_CARDS
     for card in model_cards.MODEL_CARDS:
         assert required <= card.keys()


### PR DESCRIPTION
## #134 · Las claves del dominio, en inglés y sin diacríticos

Closes #134

Dos enums, el mismo fichero, reglas opuestas: `ENGANO = "engano"` renunciaba a la ñ y `HIBRIDO = "híbrido"` la conservaba. No se podía responder «¿las claves llevan diacríticos?» mirando el código, y el síntoma era una función en el frontend cuyo trabajo completo era convertir `híbrido` en `hibrido` para poder casarlo en un selector CSS.

Se adelanta a #133 a propósito: las dos abren `domain.py` y regeneran el contrato, así que hacerlo antes deja el diff de #133 hablando sólo del contrato nuevo y no mezclado con un renombrado que toca 29 ficheros.

### Qué incluye

- `analysis/domain.py` — los cuatro enums, miembros y valores. La regla queda **escrita en el docstring**, que es lo que faltaba: antes había dos conviviendo y ninguna declarada.
- `integrations/nlp/model_cards.py` — los diez valores de `dimension`/`type` de las cinco fichas. Ahí son cadenas crudas, no miembros del enum, así que un despiste no lo caza el tipado sino Pydantic al validar; lo vigila `test_nlp.py`.
- `analysis/orchestrator.py` — `Dimension.*`, `OverallVerdict.*` y las dos variables locales que los sostienen, para que no digan una cosa y contengan otra.
- Descripciones que **viajan al contrato** (`api/app.py`) y docstrings de tools MCP que **lee el LLM del agente** (`analysis/tool.py`): decirle «híbrido u opaco» cuando los valores son `hybrid`/`opaque` sería desinformarlo.
- Frontend: claves de `vocabulario.ts`, plantillas, selectores SCSS y datos de prueba.
- `openapi.json` y `schema.d.ts` regenerados.
- `.gitignore` gana `.coverage`, que no estaba. Es la base de datos SQLite donde `coverage.py` anota los arcos ejecutados durante los tests: estado local y regenerable, del mismo tipo que `var/`. Apareció como fichero sin seguimiento al medir la cobertura para escribir #138, y sin esa línea el primer `git add .` distraído se lo lleva al repositorio. Se adelanta aquí en vez de esperar a #138 porque el riesgo es inmediato y la línea es una.

### Se eligió el inglés, no sólo quitar la tilde

La opción barata era `HIBRIDO = "hibrido"`: un valor, y la regla ASCII pasa a cumplirse. Se descartó por **media medida** — arregla el síntoma y deja la mezcla de idiomas en claves que son de máquina.

El vocabulario completo queda `form` / `deception` / `tone`, `interpretable` / `hybrid` / `opaque`, `deceptive` / `stylistic_clickbait` / `factual` / `ambiguous` / `no_data`. Es coherente con lo que ya lo estaba —los nombres de las tools, las etiquetas que publican (`clickbait` / `factual news`), los corpus y la literatura—, sale ASCII de regalo y no deja ninguna decisión de diacríticos pendiente.

### El enum que la issue se dejaba

La issue enumeraba tres. Hay cuatro: `SignalStatus.NO_APLICABLE` también era castellano, y el frontend lo comparaba literalmente en `estadoDeSenal()`. Dejarlo fuera habría hecho que **la regla naciera ya incumplida**, que es justo el reproche que la issue le hace a la media medida. Entra como `not_applicable`.

Los nombres de miembro siguen a los valores: `ENGANO = "deception"` habría sido cambiar una incoherencia por otra.

### El cliente tipado cazó lo que la búsqueda no vio

El primer barrido buscó `engano` e `híbrido` —los dos casos que nombra el título de la issue— y **se dejó `opaco`, `forma` y `tono` como valores sueltos**. Quedó vivo un `this.senal().type !== 'opaco'` en `senal-card.ts`, que decide si una tarjeta nace abierta.

No lo encontró un `grep`: lo paró `ng build`. Con `SignalType` generado desde el contrato como `"interpretable" | "hybrid" | "opaque"`, comparar contra `'opaco'` deja de compilar porque los tipos no se solapan.

Es la cadena de #126 haciendo el trabajo para el que se montó, en el primer refactor que la ejercita. Sin ella el fallo habría sido silencioso: una comparación siempre falsa, tarjetas abriéndose cuando no toca, y ninguna línea roja en ningún sitio.

### El historial viejo no se rompe, y estaba previsto

Las filas ya escritas en SQLite guardan la respuesta completa, así que dicen `clickbait_de_forma`. No falla nada, y no por suerte: `HistoryEntry.verdict` es `str | None` y **no un enum**, decisión de #102 con este motivo exacto anotado — «son datos leídos de disco, que pudo escribir otra versión del código». El frontend las pinta con su valor crudo gracias al `??` de `nombreDeVeredicto`.

### Verificación

198 tests de Python y 25 del frontend en verde, ruff limpio, build de Angular pasando, y el contrato regenerado en el mismo commit — lo comprueban los dos guardianes de #126.

### Notas

- **Esto es coherencia y robustez, no ahorro de código.** `nombreDeDimension()` y compañía siguen haciendo falta, porque la pantalla dice «Engaño» tanto si la clave es `engano` como si es `deception`. Lo único que desaparece de verdad es `claseDeTipo()`. Vendido como ahorro, no compensaría.
- **`docs/requisitos.md` no se toca.** R5.9 sigue enumerando «interpretable / híbrido / opaco» en castellano; cambiarlo obligaría a justificar un cambio de requisito por algo cosmético.
- **`evaluation/` y `spikes/` tampoco**, ni los nombres de test en castellano: narran experimentos ya ejecutados y conceptos del dominio, no claves. La regla aplicada fue actualizar toda cita del valor entre comillas invertidas salvo en esos dos sitios.
- **`var/history.db` no se ha repoblado.** Es opcional —las filas viejas no rompen nada— y los datos guardados son de prueba.
- El docstring de `domain.py` conserva `engano` e `híbrido` escritos tal cual, a propósito: está contando qué se arregló.
