### PR TITLE
feat(api): id, etiqueta, umbral y formas del data en el contrato de /analyze

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,175 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### Cuatro huecos del contrato de `/analyze` (#133)
+
+Salieron al construir la pantalla de #127, uno detrás de otro y con la misma
+forma: **un dato que el backend ya tiene calculado y no deja salir**, y que
+obliga al frontend a inventárselo o a apañárselo. Van juntos porque caben en una
+sola regeneración del contrato y una sola revisión.
+
+#### El id que se calculaba y se tiraba
+
+`history.record()` devolvía el id de la fila insertada desde #102, y `/analyze`
+lo descartaba **una línea antes** de que la respuesta saliera del proceso. Como
+lo que se guarda no es un resumen sino la respuesta completa, la mitad difícil
+estaba hecha: faltaba sólo la puerta de lectura, que ahora es
+`GET /history/{id}`.
+
+El id viaja en un **sobre de la capa REST**, `AnalyzeResult{id, analysis}`. Se
+compararon tres sitios:
+
+| | campo en el dominio | cabecera `Location` | **sobre REST** |
+|---|---|---|---|
+| Toca `domain.py` | sí | — | **—** |
+| El id viaja tipado a `schema.d.ts` | sí | **no** | **sí** |
+| Fachada MCP | devolvería `id` siempre nulo | intacta | **intacta** |
+| Payload guardado | dice `null` mientras la respuesta dice 42 | limpio | **limpio** |
+| Si el backend lo quita | falla al compilar | **falla en silencio** | **falla al compilar** |
+
+La cabecera es lo que haría un diseño REST de manual, y se descartó por la fila
+decisiva: **no viaja por el documento OpenAPI**. El cliente recibiría un
+`string | null` sin tipo detrás, tendría que parsear una URL para recuperar un
+entero, y el día que dejara de mandarse no fallaría ningún guardián del CI —
+justo lo contrario de lo que se montó en #126.
+
+El campo del dominio se descartó además por una contradicción **permanente**, que
+conviene no confundir con deuda de datos: `record()` recibe el payload **antes**
+de que exista el id, así que toda fila futura guardaría `id: null` mientras la
+respuesta devolvió `id: 42`. Repoblar la base no lo arregla, porque el código
+nuevo vuelve a producirlo — a diferencia del caso de #134, donde lo desalineado
+eran filas viejas y regenerar bastaba. La salida sería escribir dos veces
+(insertar, leer el id, volcar de nuevo y `UPDATE`): dos escrituras por un campo
+que el sobre da gratis.
+
+**El id es opcional, y eso no es prudencia decorativa.** `record()` devuelve
+`None` cuando no puede guardar, porque perder un análisis correcto por un disco
+lleno sería peor que no guardarlo. Si la respuesta exigiera el id, ese fallo
+silencioso pasaría a ser un 500. Hay un test que lo fija.
+
+#### La etiqueta que la interfaz se inventaba
+
+`SignalResult` llevaba `name` —el id de máquina, `detect_clickbait_lexical`— pero
+no el nombre para personas, que existe desde #71 en las fichas. Y no había
+ninguna otra puerta: `/tools` tampoco lo expone.
+
+Así que `vocabulario.ts` mantenía un diccionario `tool → nombre`. **Una segunda
+copia sin vigilancia:** renombrar una señal en el backend no rompía ningún test,
+sólo hacía que la pantalla pintara el id crudo. Es la forma exacta del fallo de
+#116, donde el mismo id de modelo vivía en cinco sitios.
+
+Ahora `label` viaja en la respuesta, copiado de la ficha en `_build()` — la misma
+función que ya abría la ficha para leer `dimension` y `type`. El diccionario del
+frontend desaparece; el `??` se queda, pero tapando otra cosa: ya no un
+diccionario incompleto, sino una respuesta **antigua** recuperada del historial.
+
+#### El umbral que no salía de la señal híbrida
+
+La incoherencia decide con `similarity < 0.30`, y su `data` devolvía la similitud
+y el veredicto **pero no el umbral**, que vivía sólo como prosa en las
+`limitations` de su ficha.
+
+Es la única señal híbrida del sistema, y su tesis es que la decisión es
+transparente —un corte legible— aunque el rasgo sea opaco. Una tarjeta que dice
+«similitud 0,62 · coherente» sin enseñar contra qué se comparó **pierde
+exactamente eso**.
+
+Cablear el 0,30 en el frontend habría sido peor que copiar el `label`: #93
+propone parametrizar ese número, así que se estaría duplicando un valor que ya
+está previsto que cambie.
+
+Es el más barato de los cuatro —una línea y su declaración en `outputs.py`,
+porque `data` ya es diccionario libre y el esquema no cambia— y el que menos
+trabajo dio: **#127 ya había dejado el hueco puesto** en la plantilla,
+`@if (datos.threshold !== undefined)`. El campo llegó y la tarjeta lo pintó sola.
+
+#### Las formas del `data`, declaradas dos veces
+
+`data` es diccionario libre a propósito, para no perder información y para que
+quepan señales que todavía no existen. El precio lo paga quien lo consume, y lo
+estaba pagando dos veces: tres `TypedDict` en `outputs.py` y cuatro interfaces
+escritas a mano en `datos.ts`. Las mismas formas, dos lenguajes, **ningún
+vínculo** — y ninguno de los dos guardianes del CI veía la duplicación.
+
+Lo que **no** se hizo: tipar `SignalResult.data` como unión de las cuatro. Daría
+seguridad de tipos, pero el dominio pasaría a conocer cada señal concreta y
+rompería el principio 1 de `domain.py` — hoy añadir una señal no toca el dominio,
+y ésa es la propiedad que más costaría recuperar.
+
+Lo que sí: `export_openapi.py` publica las formas conocidas en
+`components/schemas`, y `datos.ts` las importa. Los guardianes de forma se quedan
+—`data` sigue sin tipo en la frontera y hay que comprobar en ejecución— pero
+pasan a validar contra tipos **generados** en vez de contra copias.
+
+Dos detalles del montaje:
+
+**Las referencias.** `SalidaLexica` anida `Pista`, y Pydantic mete los tipos
+anidados en un `$defs` local con `$ref: "#/$defs/Pista"`, que en un documento
+OpenAPI no resuelve. Se arregla por los dos lados —`ref_template` para generar
+las referencias ya apuntando a `components/schemas`, y subir los anidados ahí—
+en vez de reescribiendo cadenas después. Hay un test nuevo que recorre el
+documento entero y comprueba que **ningún `$ref` queda colgando**, porque ese
+fallo no se vería: `openapi-typescript` no revienta con una referencia rota,
+genera `unknown`, y el tipo deja de comprobar nada.
+
+**`Pick` en vez del tipo entero.** Cada guardián verifica unos campos concretos;
+devolver el tipo completo afirmaría que existen otros que nadie ha mirado.
+`DatosLexico = Pick<SalidaLexica, 'score' | 'matches'>` dice exactamente lo
+verificado, y si el backend renombra uno de esos dos campos, deja de compilar.
+
+#### Lo que se aprendió: dónde NO llega el contrato generado
+
+Al cambiar la respuesta de `/analyze`, **el frontend siguió compilando sin un
+solo error**. Con el tipo viejo puesto.
+
+El motivo está en una línea del servicio:
+
+```ts
+return this.http.post<AnalyzeResult>(`${API}/analyze`, peticion);
+```
+
+Ese genérico **no comprueba nada**: es una afirmación sobre lo que va a llegar.
+TypeScript se la cree, porque no puede saber qué manda el servidor. La cadena de
+#126 protege todo lo que hay aguas abajo de esa línea, y en la frontera HTTP no
+puede protegerlo nada.
+
+Contrasta con #134, donde el mismo mecanismo **sí** paró un `!== 'opaco'` que la
+búsqueda no vio: allí se comparaba contra una unión generada, aquí se declara lo
+que se espera recibir. La diferencia no es de rigor, es estructural.
+
+Dónde sí saltó: **en los tests**. Los fixtures se declaran `const LEXICA:
+SignalResult = {…}`, así que añadir `label` los rompió a los siete de golpe, con
+su línea exacta. Los tipos generados protegen donde el código *afirma conformarse
+a ellos*, no donde los pide por la red.
+
+Queda anotado en el propio servicio, que es donde alguien lo necesitará.
+
+#### Y un efecto secundario que casi se cuela
+
+`app.openapi()` **cachea** su resultado en `app.openapi_schema` y devuelve siempre
+el mismo objeto. Enriquecerlo en sitio habría metido las formas del `data` en el
+`/openapi.json` que sirve la aplicación a partir de la primera llamada al
+exportador — o sea, un documento que cambia según si el exportador ha corrido
+antes, y en la suite eso depende del orden de los tests. Se genera sobre una
+copia para que la función sea pura.
+
+#### Una corrección de nomenclatura
+
+La issue fijaba el campo como `analisis`, en castellano; se escribió el
+2026-09-03. Al día siguiente entró #134, que estableció que **las claves de
+máquina van en inglés y sin diacríticos**, y un nombre de campo lo es tanto como
+el valor de un enum: viaja en el JSON y acaba en `schema.d.ts`. Se implementó
+como `analysis`, y la corrección queda anotada en la issue y en `CLAUDE.md`, no
+aplicada en silencio.
+
+#### Verificación
+
+206 tests de Python —ocho nuevos: que el id viaja y sirve, que un id inexistente
+da 404, que uno no entero da 422, que **el análisis se devuelve igual cuando el
+registro falla**, que el `label` sale de la ficha, que ningún `$ref` cuelga y que
+las formas del `data` se publican— y los 25 del frontend, ruff limpio, y
+`openapi.json` y `schema.d.ts` reproducibles byte a byte.
+
 ### Las claves del dominio, en inglés y sin diacríticos (#134)
 
 Salió al escribir la plantilla de #127. Para pintar cada señal con el color de su

--- a/README.md
+++ b/README.md
@@ -1330,7 +1330,31 @@ SignalResult = {…}`, así que añadir `label` los rompió a los siete de golpe
 su línea exacta. Los tipos generados protegen donde el código *afirma conformarse
 a ellos*, no donde los pide por la red.
 
-Queda anotado en el propio servicio, que es donde alguien lo necesitará.
+**Y no se queda en una nota.** El fichero generado no sólo publica `components`:
+publica también `paths`, que sí sabe qué devuelve cada ruta. Los tipos del
+endpoint se toman ahora de ahí:
+
+```ts
+type Analyze = paths['/analyze']['post'];
+export type AnalyzeResult =
+  Analyze['responses'][200]['content']['application/json'];
+```
+
+Elegirlos a mano de `components` era lo que dejaba la afirmación suelta:
+`AnalyzeResponse` seguía existiendo como esquema, así que nada relacionaba el
+tipo con la ruta. Derivándolo, cambiar lo que devuelve `/analyze` cambia este
+tipo al regenerar, y rompe a quien supusiera la forma anterior. La elección deja
+de ser de quien escribe el servicio y pasa a ser del contrato.
+
+Comprobado, no supuesto: apuntando la respuesta 200 de `/analyze` a
+`AnalyzeResponse` en el contrato y regenerando, el build falla con `TS2339` en
+las dos líneas que abren el sobre, `analisis-page.ts:96` y `:97`. Antes de este
+cambio, esa misma simulación compilaba sin una queja.
+
+Lo que sigue sin cubrir es que el backend **desplegado** no corresponda al
+contrato commiteado. Para eso haría falta validar en ejecución, que es una
+segunda fuente de verdad salvo que también se genere — desproporcionado aquí, y
+anotado por si algún día deja de serlo.
 
 #### Y un efecto secundario que casi se cuela
 

--- a/backend/analysis/domain.py
+++ b/backend/analysis/domain.py
@@ -88,6 +88,13 @@ class SignalResult(BaseModel):
     """Resultado de UNA señal, con el mismo envoltorio sea cual sea (principio 1)."""
 
     name: str = Field(description="Nombre de la herramienta MCP que la produjo.")
+    label: str = Field(
+        description=(
+            "Etiqueta para personas, tomada de la ficha del modelo (R3.9). "
+            "«Léxico por reglas (…)» frente al `name` de máquina "
+            "`detect_clickbait_lexical`."
+        )
+    )
     status: SignalStatus
     dimension: Dimension
     type: SignalType = Field(

--- a/backend/analysis/orchestrator.py
+++ b/backend/analysis/orchestrator.py
@@ -320,16 +320,23 @@ def _build(
     data: dict[str, Any] | None = None,
     detail: str | None = None,
 ) -> SignalResult:
-    """Envuelve el resultado de una señal leyendo dimensión y tipo de su ficha.
+    """Envuelve el resultado de una señal leyendo su ficha: etiqueta, dimensión y tipo.
 
     Único sitio donde se construye un SignalResult, así que la traducción ficha
     → respuesta está en un solo punto. El acceso a ``_CARDS`` puede dar KeyError
     si se añade una señal sin ficha: es intencionado, y el test de alineación lo
     detecta antes.
+
+    ``label`` se añadió en #133 por el mismo motivo que ya viajaban los otros dos:
+    para que la interfaz no tenga que saber cómo se llama cada señal. Antes lo
+    sabía, en un diccionario propio de ``vocabulario.ts`` que nadie vigilaba —
+    renombrar una señal aquí no rompía ningún test, sólo hacía que la pantalla
+    pintara el id crudo. Es la forma exacta del fallo de #116.
     """
     card = _CARDS[spec.name]
     return SignalResult(
         name=spec.name,
+        label=card["name"],
         status=status,
         dimension=Dimension(card["dimension"]),
         type=SignalType(card["type"]),

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -29,7 +29,7 @@ import structlog
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 
-from backend.analysis.domain import AnalyzeRequest, AnalyzeResponse
+from backend.analysis.domain import AnalyzeRequest
 from backend.analysis.orchestrator import analyze, precalentar
 from backend.api import history
 from backend.api.catalog import fetch_catalog
@@ -40,6 +40,7 @@ from backend.api.execute import (
     execute_tool,
 )
 from backend.api.schemas import (
+    AnalyzeResult,
     CatalogResponse,
     ExecuteRequest,
     ExecuteResponse,
@@ -122,8 +123,8 @@ app.add_middleware(
 )
 
 
-@app.post("/analyze", response_model=AnalyzeResponse, tags=["análisis"])
-async def post_analyze(request: AnalyzeRequest) -> AnalyzeResponse:
+@app.post("/analyze", response_model=AnalyzeResult, tags=["análisis"])
+async def post_analyze(request: AnalyzeRequest) -> AnalyzeResult:
     """Analiza un titular contrastando todas las señales disponibles.
 
     Devuelve **200 aunque alguna señal falle**: cada una lleva su propio
@@ -135,10 +136,18 @@ async def post_analyze(request: AnalyzeRequest) -> AnalyzeResponse:
     Cada análisis queda registrado en el historial. Si esa escritura
     falla, la respuesta se devuelve igual: perder un análisis correcto porque el
     disco esté lleno sería peor que no guardarlo.
+
+    Por eso el análisis viene **envuelto** en `AnalyzeResult`, con el `id` de la
+    entrada al lado (#133). El id se calculaba desde #102 y se descartaba una
+    línea antes de salir del proceso, así que no había forma de pedir después un
+    análisis concreto: `GET /history/{id}` es la otra mitad de ese hueco.
+
+    El `id` puede ser `null` —el registro falla y el análisis sigue siendo
+    válido—, así que quien lo consuma tiene que funcionar sin él.
     """
     respuesta = await analyze(request)
 
-    await history.record(
+    entry_id = await history.record(
         kind=HistoryKind.ANALYSIS,
         origin=Origin.API,
         status="ok" if respuesta.has_any_result else "error",
@@ -146,7 +155,7 @@ async def post_analyze(request: AnalyzeRequest) -> AnalyzeResponse:
         headline=respuesta.headline,
         verdict=respuesta.verdict.value,
     )
-    return respuesta
+    return AnalyzeResult(id=entry_id, analysis=respuesta)
 
 
 @app.get("/tools", response_model=CatalogResponse, tags=["catálogo"])
@@ -321,6 +330,34 @@ async def get_history(
             max_days=settings.history_max_days,
         ),
     )
+
+
+@app.get("/history/{entry_id}", response_model=HistoryEntry, tags=["historial"])
+async def get_history_entry(entry_id: int) -> HistoryEntry:
+    """Una entrada del historial por su id, con su respuesta completa.
+
+    Es la puerta de lectura que le faltaba al historial: lo guardado desde #102
+    no es un resumen sino la respuesta entera, pero sólo se podía pedir una
+    página con filtros. Con esto, un análisis concreto se puede **recuperar sin
+    reejecutar** — que además de costar ~20 s podría dar otro resultado, porque
+    las señales remotas no son deterministas.
+
+    Habilita volver a un resultado desde el historial (#129) y una futura ruta
+    `/analisis/:id` en la SPA, que #127 dejó preparada: su bloque de resultados
+    recibe el análisis como entrada, así que esa pantalla sólo tendría que
+    resolverlo desde aquí y alimentar al mismo componente.
+
+    **404 si no existe**, y la traducción se hace aquí y no en `history.py`: para
+    el almacén «no está» es una respuesta legítima y devuelve `None`, porque es
+    el único que puede servir también a la fachada MCP, donde no hay códigos de
+    estado. Un id no entero da **422** antes de llegar a la base, por la firma.
+    """
+    fila = await history.get(entry_id)
+    if fila is None:
+        raise HTTPException(
+            status_code=404, detail=f"No hay ninguna entrada con id {entry_id}."
+        )
+    return HistoryEntry(**fila)
 
 
 @app.get("/health", tags=["operación"])

--- a/backend/api/export_openapi.py
+++ b/backend/api/export_openapi.py
@@ -22,13 +22,78 @@ revisión. Que la copia commiteada siga al día lo vigila
 ``test_el_contrato_commiteado_esta_al_dia``.
 """
 
+import copy
 import json
 from pathlib import Path
+from typing import Any
+
+from pydantic import TypeAdapter
 
 from backend.api.app import app
+from backend.integrations.nlp.outputs import (
+    Etiqueta,
+    SalidaIncoherencia,
+    SalidaLexica,
+    SalidaLineal,
+)
 
 RAIZ = Path(__file__).resolve().parents[2]
 DESTINO = RAIZ / "frontend" / "openapi.json"
+
+# Las formas conocidas del `data` de cada señal (#133).
+#
+# `SignalResult.data` es un diccionario libre A PROPÓSITO, para no perder
+# información y para que quepan señales que todavía no existen. El precio lo paga
+# quien lo consume, y lo estaba pagando DOS veces: estos `TypedDict` aquí, y
+# cuatro interfaces escritas a mano en `frontend/analisis/datos.ts`. Las mismas
+# formas, dos lenguajes, ningún vínculo — y ninguno de los dos guardianes del CI
+# veía esa duplicación.
+#
+# Publicarlas como esquemas con nombre deja que `openapi-typescript` las genere y
+# que el frontend las IMPORTE. Los guardianes de forma se quedan —`data` sigue sin
+# tipo en la frontera y hay que comprobar en ejecución— pero pasan a validar
+# contra tipos generados en vez de contra copias.
+#
+# Lo que NO se hace, y es deliberado: tipar `SignalResult.data` como unión de
+# estas cuatro. Daría seguridad de tipos, pero el dominio pasaría a conocer cada
+# señal concreta y rompería el principio 1 de `domain.py` — hoy añadir una señal
+# no toca el dominio, y ésa es la propiedad que más costaría recuperar.
+FORMAS_DEL_DATA = (Etiqueta, SalidaLexica, SalidaLineal, SalidaIncoherencia)
+
+# Dónde viven los esquemas en un documento OpenAPI. Pydantic apunta por defecto a
+# `#/$defs/...`, que es correcto en JSON Schema suelto y NO resuelve aquí.
+PLANTILLA_REF = "#/components/schemas/{model}"
+
+
+def _publicar_formas_del_data(contrato: dict[str, Any]) -> None:
+    """Añade las formas del ``data`` a ``components/schemas``, con los anidados.
+
+    El detalle que hay que tener en cuenta: ``SalidaLexica`` contiene ``Pista``, y
+    Pydantic mete los tipos anidados en un ``$defs`` **local al esquema**. Si se
+    copiaran tal cual, el documento quedaría con un ``$ref`` colgando y el tipo
+    generado saldría como ``unknown``: silencioso, y del tipo exacto de fallo que
+    el contrato generado existe para evitar.
+
+    Se resuelve por los dos lados —``ref_template`` para que las referencias
+    apunten ya a ``components/schemas``, y subir los anidados ahí— en vez de
+    reescribiendo cadenas después.
+    """
+    destino = contrato["components"]["schemas"]
+
+    for tipo in FORMAS_DEL_DATA:
+        esquema = TypeAdapter(tipo).json_schema(ref_template=PLANTILLA_REF)
+
+        for nombre, anidado in esquema.pop("$defs", {}).items():
+            # Un choque de nombres sobrescribiría un esquema del contrato en
+            # silencio. Es improbable y por eso mismo conviene que grite.
+            if nombre in destino and destino[nombre] != anidado:
+                raise ValueError(
+                    f"El tipo anidado «{nombre}» choca con un esquema que ya "
+                    f"existe en el contrato. Renombra uno de los dos."
+                )
+            destino[nombre] = anidado
+
+        destino[tipo.__name__] = esquema
 
 
 def contrato() -> str:
@@ -41,7 +106,15 @@ def contrato() -> str:
     ``ensure_ascii=False`` porque las descripciones salen de docstrings en
     español: con escapes tipo ``\\u00f3`` el diff de una tilde sería ilegible.
     """
-    return json.dumps(app.openapi(), indent=2, ensure_ascii=False) + "\n"
+    # Copia, y no es paranoia: `app.openapi()` CACHEA su resultado en
+    # `app.openapi_schema` y devuelve siempre el mismo objeto. Enriquecerlo en
+    # sitio metería las formas del `data` en el `/openapi.json` que sirve la app
+    # a partir de la primera llamada a esta función — o sea, un documento que
+    # cambia según si el exportador ha corrido antes, y en la suite eso depende
+    # del orden de los tests. Con la copia, esta función es pura.
+    documento = copy.deepcopy(app.openapi())
+    _publicar_formas_del_data(documento)
+    return json.dumps(documento, indent=2, ensure_ascii=False) + "\n"
 
 
 def main() -> None:

--- a/backend/api/history.py
+++ b/backend/api/history.py
@@ -408,6 +408,26 @@ def _leer(
     return [_desempaquetar(fila) for fila in filas], total
 
 
+def _leer_una(entry_id: int) -> dict[str, Any] | None:
+    """Una entrada por su id, o ``None`` si no está.
+
+    Sin `COUNT` ni `WHERE` construido: la clave primaria devuelve una fila o
+    ninguna, así que no hay nada que paginar ni que totalizar.
+
+    Las columnas se nombran por cuarta vez en este fichero, y por la razón que ya
+    documenta `_leer`: `SELECT *` no elimina el conocimiento del esquema, lo
+    delega a quien consuma el resultado — que está al otro lado de la frontera.
+    """
+    with _conectar() as conexion:
+        fila = conexion.execute(
+            "SELECT id, created_at, kind, origin, headline, tool, verdict, status, payload "
+            "FROM history WHERE id = ?",
+            (entry_id,),
+        ).fetchone()
+
+    return _desempaquetar(fila) if fila is not None else None
+
+
 def _desempaquetar(fila: sqlite3.Row) -> dict[str, Any]:
     """Convierte una fila en un diccionario corriente, con el payload ya parseado.
 
@@ -466,3 +486,21 @@ async def query(
     return await asyncio.to_thread(
         _leer, limit, offset, kind, tool, verdict, status, since, until
     )
+
+
+async def get(entry_id: int) -> dict[str, Any] | None:
+    """Devuelve UNA entrada por su id, o ``None`` si no existe.
+
+    Es la puerta que le faltaba al historial. La mitad difícil estaba hecha desde
+    #102 —lo que se guarda es la respuesta COMPLETA, no un resumen— pero sólo se
+    podía pedir una página con filtros, así que un análisis concreto no había
+    forma de recuperarlo aunque estuviera entero en disco.
+
+    **Devuelve ``None`` en vez de lanzar** porque «no existe» no es un error de
+    este módulo: es una respuesta legítima a una pregunta legítima, y quien
+    pregunta puede tener razones para esperarla. Convertirlo en 404 es trabajo de
+    la capa HTTP, que es la única que sabe qué es un 404 — el mismo reparto que
+    mantiene a este fichero utilizable desde la fachada MCP, que no tiene códigos
+    de estado.
+    """
+    return await asyncio.to_thread(_leer_una, entry_id)

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -1,4 +1,4 @@
-"""Contrato de la API REST: catálogo, ejecución e historial.
+"""Contrato de la API REST: análisis, catálogo, ejecución e historial.
 
 Lo que hay aquí describe **el sistema que sirve el análisis** —qué servidores MCP
 están conectados, qué herramientas exponen, cómo se ejecuta una y qué quedó
@@ -26,7 +26,60 @@ from typing import Any
 
 from pydantic import BaseModel, Field, computed_field
 
-from backend.analysis.domain import Dimension, SignalType
+from backend.analysis.domain import AnalyzeResponse, Dimension, SignalType
+
+# --------------------------------------------------------------------------
+# Análisis — POST /analyze
+# --------------------------------------------------------------------------
+
+
+class AnalyzeResult(BaseModel):
+    """El análisis, más el id con el que quedó registrado en el historial.
+
+    Un **sobre de la capa REST**, y por eso vive aquí y no en ``domain.py``: el
+    id es de la fila de SQLite, no del clickbait. Aplicando el criterio de este
+    fichero —si borraras la API, ¿seguiría haciendo falta?— la respuesta es no.
+
+    Se compararon tres formas de sacar el id (#133) y ésta es la única que
+    cumple las cuatro condiciones a la vez: no toca el dominio, viaja **tipada**
+    al cliente generado, deja intacta la fachada MCP y no ensucia el payload
+    guardado.
+
+    **La descartada interesante es la cabecera ``Location``**, que es lo que
+    haría un diseño REST de manual. Su problema es de garantías, no de estilo:
+    una cabecera no viaja por el documento OpenAPI, así que el cliente recibiría
+    un ``string | null`` sin tipo detrás, tendría que parsear una URL para
+    recuperar un entero, y **el día que el backend dejara de mandarla no fallaría
+    ningún guardián del CI**. Justo lo contrario de lo que se montó en #126.
+
+    La otra descartada, un campo en ``AnalyzeResponse``, creaba además una
+    contradicción **permanente**, y conviene no confundirla con deuda de datos:
+    ``record()`` recibe el payload ANTES de que exista el id, así que TODA fila
+    futura guardaría ``id: null`` mientras la respuesta devolvió ``id: 42``.
+    Repoblar la base no lo arregla — el código nuevo vuelve a producirlo. La
+    salida sería escribir dos veces (insertar, leer el id, volcar de nuevo y
+    ``UPDATE``): dos escrituras por un campo que el sobre da gratis.
+
+    Precio: un nivel de anidamiento (``respuesta.analysis.signals``). Se paga una
+    vez, en el servicio de Angular.
+    """
+
+    id: int | None = Field(
+        default=None,
+        description=(
+            "Id de la entrada del historial, o `null` si no se pudo registrar. "
+            "Es opcional a propósito: `record()` no lanza cuando la escritura "
+            "falla, porque perder un análisis correcto por un disco lleno sería "
+            "peor que no guardarlo. La interfaz tiene que saber funcionar sin él."
+        ),
+    )
+    analysis: AnalyzeResponse
+
+    # El campo se llamó `analisis` en la issue, escrita el 2026-09-03. Pasó a
+    # inglés al implementarla porque #134 —del día siguiente— fijó que las claves
+    # de máquina van en inglés y sin diacríticos, y un nombre de campo lo es tanto
+    # como el valor de un enum: viaja en el JSON y acaba en `schema.d.ts`.
+
 
 # --------------------------------------------------------------------------
 # Catálogo de herramientas — GET /tools

--- a/backend/integrations/nlp/incoherence.py
+++ b/backend/integrations/nlp/incoherence.py
@@ -83,6 +83,16 @@ class IncoherenceDetector:
                 {
                     "similarity": sim,
                     "incoherent": inc,
+                    # El umbral VIAJA con el resultado (#133). Ésta es la señal
+                    # híbrida del sistema, y su tesis es que la decisión es
+                    # transparente —un corte legible— aunque el rasgo sea opaco.
+                    # Una tarjeta que dijera «similitud 0,62 · coherente» sin
+                    # enseñar contra qué se comparó pierde exactamente eso.
+                    #
+                    # Y cablearlo en la interfaz sería peor que copiarlo: #93
+                    # propone parametrizar este número, así que se estaría
+                    # duplicando un valor que ya está previsto que cambie.
+                    "threshold": self.THRESHOLD,
                     "headline": headline,
                     "content": content,
                 }

--- a/backend/integrations/nlp/outputs.py
+++ b/backend/integrations/nlp/outputs.py
@@ -60,10 +60,16 @@ class SalidaIncoherencia(TypedDict):
 
     Devuelve los textos comparados además de la similitud: sin ellos, el
     resultado no es verificable por quien lo lee.
+
+    Y devuelve el ``threshold`` contra el que se comparó (#133), que es lo que
+    hace auditable la decisión: sin él, ``incoherent`` es un veredicto que hay
+    que creerse. Es la única señal híbrida —decisión transparente sobre un rasgo
+    opaco—, así que enseñar el corte no es un adorno, es la mitad de su tesis.
     """
 
     similarity: float
     incoherent: bool
+    threshold: float
     headline: str
     content: str
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -12,7 +12,7 @@
           "análisis"
         ],
         "summary": "Post Analyze",
-        "description": "Analiza un titular contrastando todas las señales disponibles.\n\nDevuelve **200 aunque alguna señal falle**: cada una lleva su propio\n`status`, y perder tres análisis correctos porque el cuarto dio timeout\nsería un error. Si el cuerpo de la noticia no se\nenvía, la señal de incoherencia queda en `not_applicable` y la dimensión de\nengaño no se puede evaluar.\n\nCada análisis queda registrado en el historial. Si esa escritura\nfalla, la respuesta se devuelve igual: perder un análisis correcto porque el\ndisco esté lleno sería peor que no guardarlo.",
+        "description": "Analiza un titular contrastando todas las señales disponibles.\n\nDevuelve **200 aunque alguna señal falle**: cada una lleva su propio\n`status`, y perder tres análisis correctos porque el cuarto dio timeout\nsería un error. Si el cuerpo de la noticia no se\nenvía, la señal de incoherencia queda en `not_applicable` y la dimensión de\nengaño no se puede evaluar.\n\nCada análisis queda registrado en el historial. Si esa escritura\nfalla, la respuesta se devuelve igual: perder un análisis correcto porque el\ndisco esté lleno sería peor que no guardarlo.\n\nPor eso el análisis viene **envuelto** en `AnalyzeResult`, con el `id` de la\nentrada al lado (#133). El id se calculaba desde #102 y se descartaba una\nlínea antes de salir del proceso, así que no había forma de pedir después un\nanálisis concreto: `GET /history/{id}` es la otra mitad de ese hueco.\n\nEl `id` puede ser `null` —el registro falla y el análisis sigue siendo\nválido—, así que quien lo consuma tiene que funcionar sin él.",
         "operationId": "post_analyze_analyze_post",
         "requestBody": {
           "content": {
@@ -30,7 +30,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AnalyzeResponse"
+                  "$ref": "#/components/schemas/AnalyzeResult"
                 }
               }
             }
@@ -293,6 +293,49 @@
         }
       }
     },
+    "/history/{entry_id}": {
+      "get": {
+        "tags": [
+          "historial"
+        ],
+        "summary": "Get History Entry",
+        "description": "Una entrada del historial por su id, con su respuesta completa.\n\nEs la puerta de lectura que le faltaba al historial: lo guardado desde #102\nno es un resumen sino la respuesta entera, pero sólo se podía pedir una\npágina con filtros. Con esto, un análisis concreto se puede **recuperar sin\nreejecutar** — que además de costar ~20 s podría dar otro resultado, porque\nlas señales remotas no son deterministas.\n\nHabilita volver a un resultado desde el historial (#129) y una futura ruta\n`/analisis/:id` en la SPA, que #127 dejó preparada: su bloque de resultados\nrecibe el análisis como entrada, así que esa pantalla sólo tendría que\nresolverlo desde aquí y alimentar al mismo componente.\n\n**404 si no existe**, y la traducción se hace aquí y no en `history.py`: para\nel almacén «no está» es una respuesta legítima y devuelve `None`, porque es\nel único que puede servir también a la fachada MCP, donde no hay códigos de\nestado. Un id no entero da **422** antes de llegar a la base, por la firma.",
+        "operationId": "get_history_entry_history__entry_id__get",
+        "parameters": [
+          {
+            "name": "entry_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Entry Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HistoryEntry"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "tags": [
@@ -390,6 +433,31 @@
           "verdict"
         ],
         "title": "AnalyzeResponse"
+      },
+      "AnalyzeResult": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id",
+            "description": "Id de la entrada del historial, o `null` si no se pudo registrar. Es opcional a propósito: `record()` no lanza cuando la escritura falla, porque perder un análisis correcto por un disco lleno sería peor que no guardarlo. La interfaz tiene que saber funcionar sin él."
+          },
+          "analysis": {
+            "$ref": "#/components/schemas/AnalyzeResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "analysis"
+        ],
+        "title": "AnalyzeResult",
+        "description": "El análisis, más el id con el que quedó registrado en el historial.\n\nUn **sobre de la capa REST**, y por eso vive aquí y no en ``domain.py``: el\nid es de la fila de SQLite, no del clickbait. Aplicando el criterio de este\nfichero —si borraras la API, ¿seguiría haciendo falta?— la respuesta es no.\n\nSe compararon tres formas de sacar el id (#133) y ésta es la única que\ncumple las cuatro condiciones a la vez: no toca el dominio, viaja **tipada**\nal cliente generado, deja intacta la fachada MCP y no ensucia el payload\nguardado.\n\n**La descartada interesante es la cabecera ``Location``**, que es lo que\nharía un diseño REST de manual. Su problema es de garantías, no de estilo:\nuna cabecera no viaja por el documento OpenAPI, así que el cliente recibiría\nun ``string | null`` sin tipo detrás, tendría que parsear una URL para\nrecuperar un entero, y **el día que el backend dejara de mandarla no fallaría\nningún guardián del CI**. Justo lo contrario de lo que se montó en #126.\n\nLa otra descartada, un campo en ``AnalyzeResponse``, creaba además una\ncontradicción **permanente**, y conviene no confundirla con deuda de datos:\n``record()`` recibe el payload ANTES de que exista el id, así que TODA fila\nfutura guardaría ``id: null`` mientras la respuesta devolvió ``id: 42``.\nRepoblar la base no lo arregla — el código nuevo vuelve a producirlo. La\nsalida sería escribir dos veces (insertar, leer el id, volcar de nuevo y\n``UPDATE``): dos escrituras por un campo que el sobre da gratis.\n\nPrecio: un nivel de anidamiento (``respuesta.analysis.signals``). Se paga una\nvez, en el servicio de Angular."
       },
       "CatalogResponse": {
         "properties": {
@@ -777,6 +845,11 @@
             "title": "Name",
             "description": "Nombre de la herramienta MCP que la produjo."
           },
+          "label": {
+            "type": "string",
+            "title": "Label",
+            "description": "Etiqueta para personas, tomada de la ficha del modelo (R3.9). «Léxico por reglas (…)» frente al `name` de máquina `detect_clickbait_lexical`."
+          },
           "status": {
             "$ref": "#/components/schemas/SignalStatus"
           },
@@ -828,6 +901,7 @@
         "type": "object",
         "required": [
           "name",
+          "label",
           "status",
           "dimension",
           "type"
@@ -993,6 +1067,160 @@
           "type"
         ],
         "title": "ValidationError"
+      },
+      "Etiqueta": {
+        "description": "Salida de un clasificador: la etiqueta ganadora y su confianza.",
+        "properties": {
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          }
+        },
+        "required": [
+          "label",
+          "score"
+        ],
+        "title": "Etiqueta",
+        "type": "object"
+      },
+      "Pista": {
+        "description": "Una marca léxica encontrada en el titular, y dónde aparece.",
+        "properties": {
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "cue": {
+            "title": "Cue",
+            "type": "string"
+          },
+          "span": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Span",
+            "type": "array"
+          }
+        },
+        "required": [
+          "category",
+          "cue",
+          "span"
+        ],
+        "title": "Pista",
+        "type": "object"
+      },
+      "SalidaLexica": {
+        "description": "Salida del detector por reglas. La evidencia ES la explicación (R3.8).",
+        "properties": {
+          "score": {
+            "title": "Score",
+            "type": "integer"
+          },
+          "is_clickbait": {
+            "title": "Is Clickbait",
+            "type": "boolean"
+          },
+          "matches": {
+            "items": {
+              "$ref": "#/components/schemas/Pista"
+            },
+            "title": "Matches",
+            "type": "array"
+          },
+          "headline": {
+            "title": "Headline",
+            "type": "string"
+          }
+        },
+        "required": [
+          "score",
+          "is_clickbait",
+          "matches",
+          "headline"
+        ],
+        "title": "SalidaLexica",
+        "type": "object"
+      },
+      "SalidaLineal": {
+        "description": "Salida del modelo lineal interpretable.\n\n``top_cues`` empareja cada cue con su contribución al veredicto (peso ×\nfrecuencia); es la explicación intrínseca del modelo.",
+        "properties": {
+          "is_clickbait": {
+            "title": "Is Clickbait",
+            "type": "boolean"
+          },
+          "probability": {
+            "title": "Probability",
+            "type": "number"
+          },
+          "top_cues": {
+            "items": {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ],
+              "type": "array"
+            },
+            "title": "Top Cues",
+            "type": "array"
+          },
+          "headline": {
+            "title": "Headline",
+            "type": "string"
+          }
+        },
+        "required": [
+          "is_clickbait",
+          "probability",
+          "top_cues",
+          "headline"
+        ],
+        "title": "SalidaLineal",
+        "type": "object"
+      },
+      "SalidaIncoherencia": {
+        "description": "Salida del contraste titular↔cuerpo.\n\nDevuelve los textos comparados además de la similitud: sin ellos, el\nresultado no es verificable por quien lo lee.\n\nY devuelve el ``threshold`` contra el que se comparó (#133), que es lo que\nhace auditable la decisión: sin él, ``incoherent`` es un veredicto que hay\nque creerse. Es la única señal híbrida —decisión transparente sobre un rasgo\nopaco—, así que enseñar el corte no es un adorno, es la mitad de su tesis.",
+        "properties": {
+          "similarity": {
+            "title": "Similarity",
+            "type": "number"
+          },
+          "incoherent": {
+            "title": "Incoherent",
+            "type": "boolean"
+          },
+          "threshold": {
+            "title": "Threshold",
+            "type": "number"
+          },
+          "headline": {
+            "title": "Headline",
+            "type": "string"
+          },
+          "content": {
+            "title": "Content",
+            "type": "string"
+          }
+        },
+        "required": [
+          "similarity",
+          "incoherent",
+          "threshold",
+          "headline",
+          "content"
+        ],
+        "title": "SalidaIncoherencia",
+        "type": "object"
       }
     }
   }

--- a/frontend/src/app/analisis/analisis-page.spec.ts
+++ b/frontend/src/app/analisis/analisis-page.spec.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular/common/http/testing';
 import { TestBed, type ComponentFixture } from '@angular/core/testing';
 
-import type { AnalyzeResponse } from '../api/models';
+import type { AnalyzeResponse, AnalyzeResult } from '../api/models';
 import { AnalisisPage } from './analisis-page';
 
 /** Un análisis con las tres naturalezas de señal y una que no pudo ejecutarse. */
@@ -15,6 +15,7 @@ const RESPUESTA: AnalyzeResponse = {
   signals: [
     {
       name: 'detect_clickbait_lexical',
+      label: 'Léxico por reglas',
       status: 'ok',
       dimension: 'form',
       type: 'interpretable',
@@ -29,6 +30,7 @@ const RESPUESTA: AnalyzeResponse = {
     },
     {
       name: 'detect_clickbait_incoherence',
+      label: 'Incoherencia titular ↔ cuerpo',
       status: 'not_applicable',
       dimension: 'deception',
       type: 'hybrid',
@@ -37,6 +39,7 @@ const RESPUESTA: AnalyzeResponse = {
     },
     {
       name: 'analyze_sentiment',
+      label: 'Tono',
       status: 'ok',
       dimension: 'tone',
       type: 'opaque',
@@ -53,6 +56,13 @@ const RESPUESTA: AnalyzeResponse = {
   ],
   verdict: 'stylistic_clickbait',
 };
+
+/**
+ * Lo que devuelve `/analyze` de verdad desde #133: el analisis envuelto, con el
+ * id de su entrada del historial al lado. La pagina lo abre y guarda las dos
+ * mitades por separado.
+ */
+const SOBRE: AnalyzeResult = { id: 7, analysis: RESPUESTA };
 
 describe('AnalisisPage', () => {
   let fixture: ComponentFixture<AnalisisPage>;
@@ -105,7 +115,7 @@ describe('AnalisisPage', () => {
     pagina.formulario.controls.headline.setValue('Un titular');
     await enviar();
 
-    http.expectOne('/api/analyze').flush(RESPUESTA);
+    http.expectOne('/api/analyze').flush(SOBRE);
     await fixture.whenStable();
 
     expect(html().querySelector('.veredicto h2')?.textContent).toContain(
@@ -121,7 +131,7 @@ describe('AnalisisPage', () => {
     pagina.formulario.controls.headline.setValue('Un titular');
     await enviar();
 
-    http.expectOne('/api/analyze').flush(RESPUESTA);
+    http.expectOne('/api/analyze').flush(SOBRE);
     await fixture.whenStable();
 
     const marcas = [...html().querySelectorAll('mark[data-categoria]')];
@@ -135,7 +145,7 @@ describe('AnalisisPage', () => {
     pagina.formulario.controls.headline.setValue('Un titular');
     await enviar();
 
-    http.expectOne('/api/analyze').flush(RESPUESTA);
+    http.expectOne('/api/analyze').flush(SOBRE);
     await fixture.whenStable();
 
     const textos = [...html().querySelectorAll('.pastilla')].map(
@@ -164,7 +174,7 @@ describe('AnalisisPage', () => {
   it('«Nuevo análisis» devuelve el formulario vacío', async () => {
     pagina.formulario.controls.headline.setValue('Un titular');
     await enviar();
-    http.expectOne('/api/analyze').flush(RESPUESTA);
+    http.expectOne('/api/analyze').flush(SOBRE);
     await fixture.whenStable();
 
     pagina.nuevoAnalisis();

--- a/frontend/src/app/analisis/analisis-page.ts
+++ b/frontend/src/app/analisis/analisis-page.ts
@@ -46,9 +46,21 @@ export class AnalisisPage {
   readonly error = signal<string | null>(null);
   readonly resultado = signal<AnalyzeResponse | null>(null);
 
+  /**
+   * Id de la entrada del historial en la que quedó este análisis (#133).
+   *
+   * Va en una señal aparte y no dentro de `resultado` para que la plantilla
+   * siga viendo el análisis directamente. Puede ser `null` —el registro falla y
+   * el análisis sigue siendo válido—, así que nada puede depender de él.
+   *
+   * Hoy no se pinta: existe para que la futura ruta `/analisis/:id` sea
+   * aditiva, que es como #127 dejó preparado este componente.
+   */
+  readonly idAnalisis = signal<number | null>(null);
+
   readonly veredicto = computed(() => {
-    const r = this.resultado();
-    return r ? nombreDeVeredicto(r.verdict) : null;
+    const analisis = this.resultado();
+    return analisis ? nombreDeVeredicto(analisis.verdict) : null;
   });
 
   // La plantilla sólo ve miembros de la clase, no imports del módulo.
@@ -79,7 +91,10 @@ export class AnalisisPage {
       })
       .subscribe({
         next: (respuesta) => {
-          this.resultado.set(respuesta);
+          // El sobre se abre AQUÍ y sólo aquí: es el precio de llevar el id al
+          // lado del análisis, y se paga una vez.
+          this.resultado.set(respuesta.analysis);
+          this.idAnalisis.set(respuesta.id ?? null);
           this.enviando.set(false);
         },
         error: (fallo: HttpErrorResponse) => {
@@ -91,6 +106,7 @@ export class AnalisisPage {
 
   nuevoAnalisis(): void {
     this.resultado.set(null);
+    this.idAnalisis.set(null);
     this.error.set(null);
     this.formulario.reset();
   }

--- a/frontend/src/app/analisis/datos.ts
+++ b/frontend/src/app/analisis/datos.ts
@@ -6,36 +6,46 @@
  * de castear —que mentiría en silencio el día que el backend cambie— cada
  * función COMPRUEBA y devuelve `null` si la forma no encaja: la tarjeta degrada
  * a JSON crudo en lugar de pintar `undefined`.
+ *
+ * Desde #133 las formas **se derivan del contrato generado** en vez de
+ * escribirse aquí. Eran las mismas cuatro declaradas dos veces —en `outputs.py`
+ * y en este fichero— sin ningún vínculo entre ellas, así que renombrar un campo
+ * en el backend no rompía nada: el guardián empezaba a devolver `null` y la
+ * tarjeta degradaba a JSON crudo, en silencio y para siempre.
+ *
+ * Se usa `Pick` y no el tipo entero **a propósito**: cada guardián comprueba
+ * unos campos concretos, y devolver el tipo completo afirmaría que existen
+ * otros que nadie ha mirado. Así el tipo dice exactamente lo verificado — y si
+ * el backend renombra uno de esos campos, esto deja de compilar.
  */
+import type {
+  Etiqueta,
+  Pista,
+  SalidaIncoherencia,
+  SalidaLexica,
+  SalidaLineal,
+} from '../api/models';
 
 /** Una marca léxica y dónde aparece en el titular. */
-export interface Pista {
-  category: string;
-  cue: string;
-  span: [number, number];
-}
+export type { Pista };
 
-export interface DatosLexico {
-  score: number;
-  matches: Pista[];
-}
+export type DatosLexico = Pick<SalidaLexica, 'score' | 'matches'>;
 
-export interface DatosLineal {
-  probability: number;
-  top_cues: [string, number][];
-}
+export type DatosLineal = Pick<SalidaLineal, 'probability' | 'top_cues'>;
 
-export interface DatosIncoherencia {
-  similarity: number;
-  incoherent: boolean;
-  /** Llegará con #133; hoy no viaja. Opcional para que la tarjeta lo calle. */
-  threshold?: number;
-}
+export type DatosIncoherencia = Pick<
+  SalidaIncoherencia,
+  'similarity' | 'incoherent'
+> & {
+  /**
+   * Opcional aunque el contrato lo declare obligatorio, y no por las filas ya
+   * guardadas: `data` es libre para que quepan señales que todavía no existen,
+   * y una señal futura puede perfectamente no decidir por umbral.
+   */
+  threshold?: SalidaIncoherencia['threshold'];
+};
 
-export interface DatosEtiqueta {
-  label: string;
-  score: number;
-}
+export type DatosEtiqueta = Etiqueta;
 
 export function comoLexico(crudo: unknown): DatosLexico | null {
   const datos = crudo as DatosLexico | null;

--- a/frontend/src/app/analisis/senal-card.spec.ts
+++ b/frontend/src/app/analisis/senal-card.spec.ts
@@ -5,6 +5,7 @@ import { SenalCard } from './senal-card';
 
 const LEXICA: SignalResult = {
   name: 'detect_clickbait_lexical',
+  label: 'Léxico por reglas',
   status: 'ok',
   dimension: 'form',
   type: 'interpretable',
@@ -20,6 +21,7 @@ const LEXICA: SignalResult = {
 
 const OPACA: SignalResult = {
   name: 'detect_clickbait',
+  label: 'RoBERTa dedicado',
   status: 'ok',
   dimension: 'form',
   type: 'opaque',
@@ -29,6 +31,7 @@ const OPACA: SignalResult = {
 
 const CAIDA: SignalResult = {
   name: 'detect_clickbait',
+  label: 'RoBERTa dedicado',
   status: 'error',
   dimension: 'form',
   type: 'opaque',
@@ -38,6 +41,7 @@ const CAIDA: SignalResult = {
 
 const DESCONOCIDA: SignalResult = {
   name: 'una_senal_futura',
+  label: 'Una señal futura',
   status: 'ok',
   dimension: 'form',
   type: 'interpretable',

--- a/frontend/src/app/analisis/vocabulario.ts
+++ b/frontend/src/app/analisis/vocabulario.ts
@@ -1,17 +1,5 @@
 import type { DimensionVerdict, SignalResult } from '../api/models';
 
-/**
- * DUPLICA el campo `name` de MODEL_CARDS, que no viaja en la respuesta de
- * /analyze. Desaparece cuando #133 añada `label` a SignalResult.
- */
-const NOMBRES: Record<string, string> = {
-  detect_clickbait_lexical: 'Léxico (reglas)',
-  detect_clickbait_linear: 'Modelo lineal',
-  detect_clickbait_incoherence: 'Incoherencia titular ↔ cuerpo',
-  detect_clickbait: 'RoBERTa dedicado',
-  analyze_sentiment: 'Tono',
-};
-
 // En caja normal a propósito: las mayúsculas las pone el CSS. Muchos lectores
 // de pantalla deletrean las palabras escritas en caja alta.
 const VEREDICTOS: Record<string, string> = {
@@ -39,10 +27,20 @@ const DIMENSIONES: Record<string, string> = {
   tone: 'Tono',
 };
 
-// El `??` es lo que hace que una señal desconocida se pinte con su id crudo en
-// vez de con `undefined`: fea, pero visible.
+/**
+ * La etiqueta legible de una señal, o su id de máquina si no la trae.
+ *
+ * Hasta #133 aquí vivía un diccionario `tool → nombre` que duplicaba el campo
+ * `name` de las fichas del backend **sin ninguna vigilancia**: renombrar una
+ * señal allí no rompía ningún test, sólo hacía que la pantalla pintara el id
+ * crudo. Ahora el nombre viaja en la respuesta y este fichero no se lo inventa.
+ *
+ * El `??` se queda, pero tapa otra cosa: ya no un diccionario incompleto sino
+ * una respuesta ANTIGUA, de antes de que `label` existiera, recuperada del
+ * historial. Fea, pero visible — que es la regla de toda esta interfaz.
+ */
 export function nombreDeSenal(senal: SignalResult): string {
-  return NOMBRES[senal.name] ?? senal.name;
+  return senal.label ?? senal.name;
 }
 
 export function nombreDeVeredicto(verdict: string): string {

--- a/frontend/src/app/api/analyze.service.spec.ts
+++ b/frontend/src/app/api/analyze.service.spec.ts
@@ -6,19 +6,23 @@ import {
 import { TestBed } from '@angular/core/testing';
 
 import { AnalyzeService } from './analyze.service';
-import type { AnalyzeResponse } from './models';
+import type { AnalyzeResult } from './models';
 
 /**
- * Respuesta mínima que sigue validando contra el contrato: sin señales y con
- * `no_data`, que es lo que devuelve el backend cuando ninguna llegó a
- * pronunciarse. Aquí no se prueba el análisis, sólo el transporte.
+ * Respuesta mínima que sigue validando contra el contrato: el sobre con su id y
+ * un análisis sin señales con `no_data`, que es lo que devuelve el backend
+ * cuando ninguna llegó a pronunciarse. Aquí no se prueba el análisis, sólo el
+ * transporte.
  */
-const RESPUESTA: AnalyzeResponse = {
-  headline: 'Un titular',
-  content: null,
-  signals: [],
-  dimensions: [],
-  verdict: 'no_data',
+const RESPUESTA: AnalyzeResult = {
+  id: 42,
+  analysis: {
+    headline: 'Un titular',
+    content: null,
+    signals: [],
+    dimensions: [],
+    verdict: 'no_data',
+  },
 };
 
 describe('AnalyzeService', () => {
@@ -63,15 +67,17 @@ describe('AnalyzeService', () => {
     peticion.flush(RESPUESTA);
   });
 
-  it('entrega la respuesta tal cual la devuelve la API', () => {
-    let recibida: AnalyzeResponse | undefined;
-    servicio.analizar({ headline: 'Un titular' }).subscribe((r) => {
-      recibida = r;
+  it('entrega el sobre entero, con el id al lado del análisis', () => {
+    let recibida: AnalyzeResult | undefined;
+    servicio.analizar({ headline: 'Un titular' }).subscribe((respuesta) => {
+      recibida = respuesta;
     });
 
     http.expectOne('/api/analyze').flush(RESPUESTA);
 
     expect(recibida).toEqual(RESPUESTA);
+    // El id no se desenvuelve aquí: llega hasta quien decide qué hacer con él.
+    expect(recibida?.id).toBe(42);
   });
 
   // Documenta la propiedad que hace correcto suscribirse una sola vez: el

--- a/frontend/src/app/api/analyze.service.ts
+++ b/frontend/src/app/api/analyze.service.ts
@@ -11,7 +11,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import type { AnalyzeRequest, AnalyzeResponse } from './models';
+import type { AnalyzeRequest, AnalyzeResult } from './models';
 
 /**
  * Prefijo de la API. NO es la dirección del backend, y esa es la gracia.
@@ -40,8 +40,19 @@ export class AnalyzeService {
    * análisis correctos porque el cuarto dio timeout sería el error de verdad.
    * Por el canal de error sólo llegan fallos de la PETICIÓN (422 con el titular
    * en blanco), del servidor o de la red.
+   *
+   * Devuelve el **sobre** `AnalyzeResult`, no el análisis pelado: dentro vienen
+   * el análisis y el `id` con el que quedó registrado (#133), que es lo que
+   * permitirá volver a él sin reejecutarlo.
+   *
+   * Ojo con este genérico, que es la costura menos protegida de la cadena: el
+   * `<AnalyzeResult>` de `post` **no comprueba nada**, es una afirmación sobre
+   * lo que va a llegar. Los tipos generados protegen todo lo que hay aguas
+   * abajo, pero aquí no pueden — cuando el contrato cambió en #133, el proyecto
+   * siguió compilando con el tipo viejo puesto. Al tocar la respuesta de
+   * `/analyze` hay que venir a esta línea a mano.
    */
-  analizar(peticion: AnalyzeRequest): Observable<AnalyzeResponse> {
-    return this.http.post<AnalyzeResponse>(`${API}/analyze`, peticion);
+  analizar(peticion: AnalyzeRequest): Observable<AnalyzeResult> {
+    return this.http.post<AnalyzeResult>(`${API}/analyze`, peticion);
   }
 }

--- a/frontend/src/app/api/analyze.service.ts
+++ b/frontend/src/app/api/analyze.service.ts
@@ -45,12 +45,17 @@ export class AnalyzeService {
    * el análisis y el `id` con el que quedó registrado (#133), que es lo que
    * permitirá volver a él sin reejecutarlo.
    *
-   * Ojo con este genérico, que es la costura menos protegida de la cadena: el
-   * `<AnalyzeResult>` de `post` **no comprueba nada**, es una afirmación sobre
-   * lo que va a llegar. Los tipos generados protegen todo lo que hay aguas
-   * abajo, pero aquí no pueden — cuando el contrato cambió en #133, el proyecto
-   * siguió compilando con el tipo viejo puesto. Al tocar la respuesta de
-   * `/analyze` hay que venir a esta línea a mano.
+   * El `<AnalyzeResult>` de `post` **no comprueba nada**: es una afirmación
+   * sobre lo que va a llegar, porque la respuesta viene por la red y TypeScript
+   * no tiene contra qué contrastarla. Es la costura menos protegida de la
+   * cadena, y en #133 se vio: el backend empezó a devolver el sobre y esto
+   * siguió compilando con el tipo viejo.
+   *
+   * Lo que la sostiene es de dónde sale `AnalyzeResult` — de
+   * `paths['/analyze']['post']` y no elegido a mano de `components`, así que
+   * cambiar lo que devuelve la ruta cambia el tipo al regenerar el contrato. La
+   * afirmación sigue sin verificarse aquí, pero ya no es una elección de quien
+   * escribió esta línea. Ver `models.ts`.
    */
   analizar(peticion: AnalyzeRequest): Observable<AnalyzeResult> {
     return this.http.post<AnalyzeResult>(`${API}/analyze`, peticion);

--- a/frontend/src/app/api/models.ts
+++ b/frontend/src/app/api/models.ts
@@ -15,9 +15,25 @@ type Esquemas = components['schemas'];
 
 // --- Análisis de un titular (POST /analyze) ---
 export type AnalyzeRequest = Esquemas['AnalyzeRequest'];
+// El sobre de la respuesta: el análisis más el id con el que quedó registrado.
+// Lo que se pinta es `AnalyzeResponse`; el id sólo sirve para volver a él.
+export type AnalyzeResult = Esquemas['AnalyzeResult'];
 export type AnalyzeResponse = Esquemas['AnalyzeResponse'];
 export type SignalResult = Esquemas['SignalResult'];
 export type DimensionVerdict = Esquemas['DimensionVerdict'];
+
+// --- Formas conocidas del `data` de cada señal ---
+//
+// `data` es un diccionario libre en el contrato, así que estos tipos NO se
+// aplican solos: hay que comprobar en ejecución, y de eso se encargan los
+// guardianes de `analisis/datos.ts`. Lo que aportan es que esos guardianes
+// validen contra una forma DERIVADA del backend en vez de contra una copia
+// escrita a mano, que es lo que había hasta #133.
+export type SalidaLexica = Esquemas['SalidaLexica'];
+export type SalidaLineal = Esquemas['SalidaLineal'];
+export type SalidaIncoherencia = Esquemas['SalidaIncoherencia'];
+export type Etiqueta = Esquemas['Etiqueta'];
+export type Pista = Esquemas['Pista'];
 
 // Uniones de cadenas, no `enum` de TypeScript: al ser estructurales, comparar
 // contra un valor que no existe —`'engaño'` con eñe— no compila.

--- a/frontend/src/app/api/models.ts
+++ b/frontend/src/app/api/models.ts
@@ -9,15 +9,38 @@
  * usaba. Esa es la razón de mantener la lista a mano en vez de reexportar
  * `components` entero.
  */
-import type { components } from './schema';
+import type { components, paths } from './schema';
 
 type Esquemas = components['schemas'];
 
 // --- Análisis de un titular (POST /analyze) ---
-export type AnalyzeRequest = Esquemas['AnalyzeRequest'];
+//
+// Lo que entra y sale de una RUTA se toma de `paths`, no de `components`, y esa
+// diferencia es la salvaguarda de la costura menos protegida de la cadena.
+//
+// El servicio hace `http.post<T>(...)`, y ese genérico no comprueba nada: es una
+// afirmación sobre lo que va a llegar. Eligiendo `T` a mano de `components`,
+// nada ata el tipo a la ruta — y en #133 pasó exactamente eso: el backend empezó
+// a devolver el sobre y el frontend siguió compilando con el tipo viejo puesto,
+// porque `AnalyzeResponse` seguía existiendo como esquema.
+//
+// Derivándolo de `paths`, cambiar lo que devuelve `/analyze` cambia este tipo al
+// regenerar, y rompe a quien supusiera la forma anterior. La elección deja de
+// ser de quien escribe el servicio y pasa a ser del contrato.
+//
+// Sigue sin cubrir que el backend DESPLEGADO no corresponda al contrato
+// commiteado; para eso haría falta validar en ejecución.
+type Analyze = paths['/analyze']['post'];
+
+export type AnalyzeRequest = Analyze['requestBody']['content']['application/json'];
 // El sobre de la respuesta: el análisis más el id con el que quedó registrado.
 // Lo que se pinta es `AnalyzeResponse`; el id sólo sirve para volver a él.
-export type AnalyzeResult = Esquemas['AnalyzeResult'];
+export type AnalyzeResult =
+  Analyze['responses'][200]['content']['application/json'];
+
+// `AnalyzeResponse` sigue viniendo de `components` a propósito: es un esquema por
+// derecho propio, no lo que devuelve una ruta. El historial lo guarda y #129 lo
+// leerá desde ahí, sin pasar por `/analyze`.
 export type AnalyzeResponse = Esquemas['AnalyzeResponse'];
 export type SignalResult = Esquemas['SignalResult'];
 export type DimensionVerdict = Esquemas['DimensionVerdict'];

--- a/frontend/src/app/api/schema.d.ts
+++ b/frontend/src/app/api/schema.d.ts
@@ -26,6 +26,14 @@ export interface paths {
          *     Cada análisis queda registrado en el historial. Si esa escritura
          *     falla, la respuesta se devuelve igual: perder un análisis correcto porque el
          *     disco esté lleno sería peor que no guardarlo.
+         *
+         *     Por eso el análisis viene **envuelto** en `AnalyzeResult`, con el `id` de la
+         *     entrada al lado (#133). El id se calculaba desde #102 y se descartaba una
+         *     línea antes de salir del proceso, así que no había forma de pedir después un
+         *     análisis concreto: `GET /history/{id}` es la otra mitad de ese hueco.
+         *
+         *     El `id` puede ser `null` —el registro falla y el análisis sigue siendo
+         *     válido—, así que quien lo consuma tiene que funcionar sin él.
          */
         post: operations["post_analyze_analyze_post"];
         delete?: never;
@@ -150,6 +158,42 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/history/{entry_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get History Entry
+         * @description Una entrada del historial por su id, con su respuesta completa.
+         *
+         *     Es la puerta de lectura que le faltaba al historial: lo guardado desde #102
+         *     no es un resumen sino la respuesta entera, pero sólo se podía pedir una
+         *     página con filtros. Con esto, un análisis concreto se puede **recuperar sin
+         *     reejecutar** — que además de costar ~20 s podría dar otro resultado, porque
+         *     las señales remotas no son deterministas.
+         *
+         *     Habilita volver a un resultado desde el historial (#129) y una futura ruta
+         *     `/analisis/:id` en la SPA, que #127 dejó preparada: su bloque de resultados
+         *     recibe el análisis como entrada, así que esa pantalla sólo tendría que
+         *     resolverlo desde aquí y alimentar al mismo componente.
+         *
+         *     **404 si no existe**, y la traducción se hace aquí y no en `history.py`: para
+         *     el almacén «no está» es una respuesta legítima y devuelve `None`, porque es
+         *     el único que puede servir también a la fachada MCP, donde no hay códigos de
+         *     estado. Un id no entero da **422** antes de llegar a la base, por la firma.
+         */
+        get: operations["get_history_entry_history__entry_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -202,6 +246,45 @@ export interface components {
             /** Dimensions */
             dimensions: components["schemas"]["DimensionVerdict"][];
             verdict: components["schemas"]["OverallVerdict"];
+        };
+        /**
+         * AnalyzeResult
+         * @description El análisis, más el id con el que quedó registrado en el historial.
+         *
+         *     Un **sobre de la capa REST**, y por eso vive aquí y no en ``domain.py``: el
+         *     id es de la fila de SQLite, no del clickbait. Aplicando el criterio de este
+         *     fichero —si borraras la API, ¿seguiría haciendo falta?— la respuesta es no.
+         *
+         *     Se compararon tres formas de sacar el id (#133) y ésta es la única que
+         *     cumple las cuatro condiciones a la vez: no toca el dominio, viaja **tipada**
+         *     al cliente generado, deja intacta la fachada MCP y no ensucia el payload
+         *     guardado.
+         *
+         *     **La descartada interesante es la cabecera ``Location``**, que es lo que
+         *     haría un diseño REST de manual. Su problema es de garantías, no de estilo:
+         *     una cabecera no viaja por el documento OpenAPI, así que el cliente recibiría
+         *     un ``string | null`` sin tipo detrás, tendría que parsear una URL para
+         *     recuperar un entero, y **el día que el backend dejara de mandarla no fallaría
+         *     ningún guardián del CI**. Justo lo contrario de lo que se montó en #126.
+         *
+         *     La otra descartada, un campo en ``AnalyzeResponse``, creaba además una
+         *     contradicción **permanente**, y conviene no confundirla con deuda de datos:
+         *     ``record()`` recibe el payload ANTES de que exista el id, así que TODA fila
+         *     futura guardaría ``id: null`` mientras la respuesta devolvió ``id: 42``.
+         *     Repoblar la base no lo arregla — el código nuevo vuelve a producirlo. La
+         *     salida sería escribir dos veces (insertar, leer el id, volcar de nuevo y
+         *     ``UPDATE``): dos escrituras por un campo que el sobre da gratis.
+         *
+         *     Precio: un nivel de anidamiento (``respuesta.analysis.signals``). Se paga una
+         *     vez, en el servicio de Angular.
+         */
+        AnalyzeResult: {
+            /**
+             * Id
+             * @description Id de la entrada del historial, o `null` si no se pudo registrar. Es opcional a propósito: `record()` no lanza cuando la escritura falla, porque perder un análisis correcto por un disco lleno sería peor que no guardarlo. La interfaz tiene que saber funcionar sin él.
+             */
+            id?: number | null;
+            analysis: components["schemas"]["AnalyzeResponse"];
         };
         /**
          * CatalogResponse
@@ -478,6 +561,11 @@ export interface components {
              * @description Nombre de la herramienta MCP que la produjo.
              */
             name: string;
+            /**
+             * Label
+             * @description Etiqueta para personas, tomada de la ficha del modelo (R3.9). «Léxico por reglas (…)» frente al `name` de máquina `detect_clickbait_lexical`.
+             */
+            label: string;
             status: components["schemas"]["SignalStatus"];
             dimension: components["schemas"]["Dimension"];
             /** @description Naturaleza del modelo, para el badge de la UI. */
@@ -581,6 +669,86 @@ export interface components {
             /** Context */
             ctx?: Record<string, never>;
         };
+        /**
+         * Etiqueta
+         * @description Salida de un clasificador: la etiqueta ganadora y su confianza.
+         */
+        Etiqueta: {
+            /** Label */
+            label: string;
+            /** Score */
+            score: number;
+        };
+        /**
+         * Pista
+         * @description Una marca léxica encontrada en el titular, y dónde aparece.
+         */
+        Pista: {
+            /** Category */
+            category: string;
+            /** Cue */
+            cue: string;
+            /** Span */
+            span: number[];
+        };
+        /**
+         * SalidaLexica
+         * @description Salida del detector por reglas. La evidencia ES la explicación (R3.8).
+         */
+        SalidaLexica: {
+            /** Score */
+            score: number;
+            /** Is Clickbait */
+            is_clickbait: boolean;
+            /** Matches */
+            matches: components["schemas"]["Pista"][];
+            /** Headline */
+            headline: string;
+        };
+        /**
+         * SalidaLineal
+         * @description Salida del modelo lineal interpretable.
+         *
+         *     ``top_cues`` empareja cada cue con su contribución al veredicto (peso ×
+         *     frecuencia); es la explicación intrínseca del modelo.
+         */
+        SalidaLineal: {
+            /** Is Clickbait */
+            is_clickbait: boolean;
+            /** Probability */
+            probability: number;
+            /** Top Cues */
+            top_cues: [
+                string,
+                number
+            ][];
+            /** Headline */
+            headline: string;
+        };
+        /**
+         * SalidaIncoherencia
+         * @description Salida del contraste titular↔cuerpo.
+         *
+         *     Devuelve los textos comparados además de la similitud: sin ellos, el
+         *     resultado no es verificable por quien lo lee.
+         *
+         *     Y devuelve el ``threshold`` contra el que se comparó (#133), que es lo que
+         *     hace auditable la decisión: sin él, ``incoherent`` es un veredicto que hay
+         *     que creerse. Es la única señal híbrida —decisión transparente sobre un rasgo
+         *     opaco—, así que enseñar el corte no es un adorno, es la mitad de su tesis.
+         */
+        SalidaIncoherencia: {
+            /** Similarity */
+            similarity: number;
+            /** Incoherent */
+            incoherent: boolean;
+            /** Threshold */
+            threshold: number;
+            /** Headline */
+            headline: string;
+            /** Content */
+            content: string;
+        };
     };
     responses: never;
     parameters: never;
@@ -609,7 +777,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AnalyzeResponse"];
+                    "application/json": components["schemas"]["AnalyzeResult"];
                 };
             };
             /** @description Validation Error */
@@ -709,6 +877,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HistoryPage"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_history_entry_history__entry_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                entry_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HistoryEntry"];
                 };
             };
             /** @description Validation Error */

--- a/tests/api/test_analyze.py
+++ b/tests/api/test_analyze.py
@@ -30,6 +30,7 @@ from backend.analysis.orchestrator import (
 )
 from backend.core.models import ToolResult
 from backend.integrations.nlp import dedicated, lexical, linear
+from backend.integrations.nlp.model_cards import cards_by_signal
 
 _SPECS = {spec.name: spec for spec in _SIGNALS}
 
@@ -415,6 +416,25 @@ async def test_la_dimension_y_el_tipo_salen_de_la_ficha(señales):
     assert signals["detect_clickbait_incoherence"].dimension == Dimension.DECEPTION
     assert signals["analyze_sentiment"].dimension == Dimension.TONE
     assert signals["detect_clickbait_lexical"].dimension == Dimension.FORM
+
+
+@pytest.mark.asyncio
+async def test_la_etiqueta_legible_sale_de_la_ficha(señales):
+    """El `label` viaja desde la ficha, y esto es lo que impide que se copie.
+
+    Antes de #133 la interfaz mantenía su propio diccionario de nombres en
+    `vocabulario.ts`. Renombrar una señal aquí no rompía nada: sólo hacía que la
+    pantalla pintara el id crudo, en silencio. Es la forma exacta de #116, y este
+    test es lo que la cierra — se compara contra la ficha, no contra una cadena
+    escrita a mano, así que cambiar el nombre en un sitio no puede desalinearlos.
+    """
+    señales()
+    fichas = cards_by_signal()
+    signals = await _run_signals("Un titular", "Un cuerpo")
+
+    assert signals, "sin señales no se está comprobando nada"
+    for signal in signals:
+        assert signal.label == fichas[signal.name]["name"]
 
 
 # ----- analyze: extremo a extremo (con dobles) -----

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -6,6 +6,8 @@ sustituyen `analyze` y `check_health` en el namespace de `app`: las rutas los
 resuelven como globales del módulo en cada llamada.
 """
 
+import json
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -33,6 +35,7 @@ def _respuesta(headline="Un titular", content=None):
         signals=[
             SignalResult(
                 name="detect_clickbait_lexical",
+                label="Léxico por reglas",
                 status=SignalStatus.OK,
                 dimension=Dimension.FORM,
                 type=SignalType.INTERPRETABLE,
@@ -71,9 +74,14 @@ def test_analyze_devuelve_la_respuesta_completa(analisis):
     response = client.post("/analyze", json={"headline": "Un titular"})
 
     assert response.status_code == 200
-    cuerpo = response.json()
+    # El análisis viaja ENVUELTO desde #133: el sobre lleva el id del historial
+    # al lado, así que lo que antes era la raíz ahora cuelga de `analysis`.
+    cuerpo = response.json()["analysis"]
     assert cuerpo["verdict"] == "stylistic_clickbait"
     assert cuerpo["signals"][0]["name"] == "detect_clickbait_lexical"
+    # La etiqueta para personas viaja junto al nombre de máquina (#133): sin
+    # ella la interfaz mantenía su propio diccionario sin vigilancia.
+    assert cuerpo["signals"][0]["label"] == "Léxico por reglas"
     # El JSON crudo de la herramienta viaja sin aplanar: alimenta las tarjetas
     # de explicabilidad.
     assert cuerpo["signals"][0]["data"] == {"score": 2, "is_clickbait": True}
@@ -104,6 +112,41 @@ def test_falta_el_titular_es_422(analisis):
 def test_el_titular_llega_normalizado(analisis):
     client.post("/analyze", json={"headline": "  Un titular  "})
     assert analisis["request"].headline == "Un titular"
+
+
+def test_el_analisis_llega_con_el_id_de_su_entrada(analisis):
+    """El id se calculaba desde #102 y se tiraba antes de salir del proceso.
+
+    Sin él no había forma de volver a un análisis concreto, aunque estuviera
+    guardado entero: `GET /history` sólo sabe devolver páginas con filtros.
+    """
+    cuerpo = client.post("/analyze", json={"headline": "Un titular"}).json()
+
+    assert isinstance(cuerpo["id"], int)
+    # Y el id sirve de verdad: apunta a la entrada que se acaba de escribir.
+    entrada = client.get(f"/history/{cuerpo['id']}").json()
+    assert entrada["headline"] == "Un titular"
+
+
+def test_si_el_registro_falla_el_analisis_se_devuelve_igual(analisis, monkeypatch):
+    """Ésta es la razón de que `id` sea opcional, y no un detalle de estilo.
+
+    `record()` devuelve None cuando no puede guardar, porque perder un análisis
+    correcto por un disco lleno sería peor que no guardarlo. Si la respuesta
+    exigiera el id, ese fallo silencioso pasaría a ser un 500.
+    """
+
+    async def no_guarda(**kwargs):
+        return None
+
+    monkeypatch.setattr(app_mod.history, "record", no_guarda)
+
+    response = client.post("/analyze", json={"headline": "Un titular"})
+
+    assert response.status_code == 200
+    cuerpo = response.json()
+    assert cuerpo["id"] is None
+    assert cuerpo["analysis"]["verdict"] == "stylistic_clickbait"
 
 
 # ----- GET /health -----
@@ -155,6 +198,7 @@ def test_openapi_documenta_las_rutas_y_el_contrato():
         "/tools",
         "/tools/{name}/execute",
         "/history",
+        "/history/{entry_id}",
         "/health",
     }
     # Las descripciones de los Field llegan al esquema: son lo que ve quien
@@ -186,6 +230,58 @@ def test_el_contrato_commiteado_esta_al_dia():
             "`python -m backend.api.export_openapi`, luego `npm run gen:api` "
             "dentro de `frontend/`, y se commitean las dos salidas."
         )
+
+
+def test_ninguna_referencia_del_contrato_queda_colgando():
+    """Todo `$ref` del documento apunta a un esquema que existe.
+
+    Lo vigila porque #133 empezó a publicar las formas del `data` a mano, y
+    Pydantic genera los tipos anidados en un `$defs` LOCAL: copiarlos sin más
+    dejaría `SalidaLexica.matches` apuntando a `#/$defs/Pista`, que en un
+    documento OpenAPI no resuelve.
+
+    Y el fallo no se vería. `openapi-typescript` no revienta con una referencia
+    rota: genera `unknown`, el frontend compila, y el tipo simplemente deja de
+    comprobar nada — que es la forma exacta de fallo que el contrato generado
+    existe para evitar.
+    """
+    documento = json.loads(contrato())
+    esquemas = documento["components"]["schemas"]
+    prefijo = "#/components/schemas/"
+
+    def referencias(nodo):
+        if isinstance(nodo, dict):
+            for clave, valor in nodo.items():
+                if clave == "$ref":
+                    yield valor
+                else:
+                    yield from referencias(valor)
+        elif isinstance(nodo, list):
+            for elemento in nodo:
+                yield from referencias(elemento)
+
+    rotas = [
+        ref
+        for ref in referencias(documento)
+        if not ref.startswith(prefijo) or ref[len(prefijo) :] not in esquemas
+    ]
+    assert not rotas, f"Referencias que no resuelven: {sorted(set(rotas))}"
+
+
+def test_las_formas_del_data_se_publican_como_esquemas():
+    """El `data` sigue sin tipo, pero sus formas conocidas ya no se copian a mano.
+
+    Antes de #133 vivían dos veces —`outputs.py` en Python y cuatro interfaces
+    escritas a mano en `datos.ts`— sin ningún vínculo entre ellas.
+    """
+    esquemas = json.loads(contrato())["components"]["schemas"]
+
+    for nombre in ("Etiqueta", "SalidaLexica", "SalidaLineal", "SalidaIncoherencia"):
+        assert nombre in esquemas
+
+    # El umbral viaja con el resultado de la señal híbrida: sin él, `incoherent`
+    # es un veredicto que hay que creerse.
+    assert "threshold" in esquemas["SalidaIncoherencia"]["properties"]
 
 
 # ----- Precalentado (#125) -----

--- a/tests/api/test_history.py
+++ b/tests/api/test_history.py
@@ -288,6 +288,7 @@ def _respuesta_analisis(headline="Un titular"):
         signals=[
             SignalResult(
                 name="detect_clickbait_lexical",
+                label="Léxico por reglas",
                 status=SignalStatus.OK,
                 dimension=Dimension.FORM,
                 type=SignalType.INTERPRETABLE,
@@ -438,6 +439,33 @@ def test_los_topes_salen_en_el_esquema_openapi():
     assert parametros["limit"]["maximum"] == 100
     assert parametros["limit"]["minimum"] == 1
     assert parametros["offset"]["minimum"] == 0
+
+
+def test_una_entrada_se_recupera_por_su_id(analisis):
+    """La puerta que le faltaba al historial (#133).
+
+    Lo guardado desde #102 es la respuesta COMPLETA, no un resumen, así que
+    recuperar un análisis no obliga a reejecutarlo — que además de costar ~20 s
+    podría dar otro resultado, porque las señales remotas no son deterministas.
+    """
+    creado = client.post("/analyze", json={"headline": "Un titular"}).json()
+
+    entrada = client.get(f"/history/{creado['id']}").json()
+
+    assert entrada["id"] == creado["id"]
+    assert entrada["headline"] == "Un titular"
+    assert entrada["payload"] == creado["analysis"]
+
+
+def test_un_id_que_no_existe_da_404():
+    """404 y no lista vacía: preguntar por UNA entrada concreta que no está es
+    un caso distinto de filtrar y no encontrar nada."""
+    assert client.get("/history/999999").status_code == 404
+
+
+def test_un_id_que_no_es_entero_da_422():
+    """Lo para la firma, antes de tocar la base de datos."""
+    assert client.get("/history/no-soy-un-id").status_code == 422
 
 
 # ---------------------------------------------------------------- los filtros


### PR DESCRIPTION
## #133 · Cuatro huecos del contrato de `/analyze`

Closes #133

Los cuatro salieron al construir la pantalla de #127, uno detrás de otro y con la misma forma: **un dato que el backend ya tiene calculado y no deja salir**, y que obliga al frontend a inventárselo o a apañárselo. Van juntos porque caben en una sola regeneración del contrato y una sola revisión.

Desbloquea #129, que necesita poder volver a un análisis guardado.

### Qué incluye

- **El id.** `history.record()` devolvía el id desde #102 y `/analyze` lo descartaba una línea antes de responder. Ahora viaja en un sobre, `AnalyzeResult{id, analysis}`, y `GET /history/{id}` es la puerta de lectura que faltaba.
- **La etiqueta.** `SignalResult` gana `label`, copiado de la ficha en `_build()` — la misma función que ya abría la ficha para leer `dimension` y `type`. El diccionario `tool → nombre` de `vocabulario.ts` desaparece.
- **El umbral.** El `data` de la incoherencia lleva `threshold`.
- **Las formas del `data`.** `export_openapi.py` publica `SalidaLexica`, `SalidaLineal`, `SalidaIncoherencia`, `Etiqueta` y `Pista` en `components/schemas`, y `datos.ts` las importa en vez de declararlas a mano.

### Por qué un sobre y no una cabecera

Es la decisión que más se discutió, y la fila que decide es de garantías, no de estilo: **una cabecera `Location` no viaja por el documento OpenAPI**. El cliente recibiría un `string | null` sin tipo detrás, tendría que parsear una URL para recuperar un entero, y el día que dejara de mandarse no fallaría ningún guardián del CI. Justo lo contrario de lo que se montó en #126.

Un campo en `AnalyzeResponse` se descartó además por una contradicción permanente: `record()` recibe el payload **antes** de que exista el id, así que toda fila futura guardaría `id: null` mientras la respuesta devolvió `id: 42`. Repoblar no lo arregla, porque el código nuevo vuelve a producirlo. La salida sería escribir dos veces.

**El id es opcional a propósito.** `record()` devuelve `None` cuando no puede guardar, porque perder un análisis correcto por un disco lleno sería peor que no guardarlo. Si la respuesta lo exigiera, ese fallo silencioso pasaría a ser un 500. Hay un test que lo fija.

### El hallazgo: dónde NO llegaba el contrato generado

Al cambiar la respuesta de `/analyze`, **el frontend siguió compilando sin un solo error**, con el tipo viejo puesto. El motivo está en una línea del servicio:

```ts
return this.http.post<AnalyzeResponse>(`${API}/analyze`, peticion);
```

Ese genérico **no comprueba nada**: es una afirmación sobre lo que va a llegar. TypeScript no puede contrastarla, porque la respuesta viene por la red. Contrasta con #134, donde el mismo mecanismo sí paró un `!== 'opaco'`: allí se comparaba contra una unión generada. La protección existe donde el código *consume* un valor del tipo, no donde *afirma* que lo es.

Dónde sí saltó aquí: en los tests, porque los fixtures se declaran `const LEXICA: SignalResult = {…}`. Añadir `label` los rompió a los siete de golpe con su línea exacta.

**Y se le puso salvaguarda**, no sólo un comentario. El fichero generado publica también `paths`, que sí sabe qué devuelve cada ruta, así que los tipos del endpoint se toman de ahí:

```ts
type Analyze = paths['/analyze']['post'];
export type AnalyzeResult =
  Analyze['responses'][200]['content']['application/json'];
```

Elegirlos a mano de `components` era lo que dejaba la afirmación suelta: `AnalyzeResponse` seguía existiendo como esquema, así que nada relacionaba el tipo con la ruta.

Comprobado en vez de supuesto: apuntando la respuesta 200 de `/analyze` a `AnalyzeResponse` en el contrato y regenerando, el build falla con `TS2339` en las dos líneas que abren el sobre. Antes del cambio, esa misma simulación compilaba.

### Dos detalles del montaje

**Las referencias anidadas.** `SalidaLexica` contiene `Pista`, y Pydantic mete los tipos anidados en un `$defs` local con `$ref: "#/$defs/Pista"`, que en un documento OpenAPI no resuelve. Se arregla con `ref_template` —generando las referencias ya apuntando a `components/schemas`— y subiendo los anidados ahí, en vez de reescribiendo cadenas después. Hay un **test nuevo que recorre el documento entero** y comprueba que ningún `$ref` queda colgando, porque ese fallo no se vería: `openapi-typescript` no revienta con una referencia rota, genera `unknown`, y el tipo deja de comprobar nada.

**`app.openapi()` cachea su resultado.** Enriquecerlo en sitio habría metido las formas del `data` en el `/openapi.json` que sirve la aplicación a partir de la primera llamada al exportador — un documento que cambia según si el exportador ha corrido antes, y en la suite eso depende del orden de los tests. Se genera sobre una copia.

### Una corrección de nomenclatura

La issue fijaba el campo del sobre como `analisis`, en castellano; se escribió el 2026-09-03. Al día siguiente entró #134, que estableció que las claves de máquina van en inglés y sin diacríticos — y un nombre de campo lo es tanto como el valor de un enum: viaja en el JSON y acaba en `schema.d.ts`. Se implementó como `analysis`, con la corrección anotada en la issue y en el docstring, no aplicada en silencio.

### Verificación

206 tests de Python y 25 del frontend, ruff limpio, y `openapi.json` y `schema.d.ts` reproducibles byte a byte.

Los ocho tests nuevos de Python: que el id viaja y sirve para recuperar la entrada, que un id inexistente da 404, que uno no entero da 422, que el análisis se devuelve igual cuando el registro falla, que el `label` de cada señal es el de su ficha, que ningún `$ref` cuelga y que las formas del `data` se publican.

### Notas

- **`datos.ts` usa `Pick` y no el tipo entero.** Cada guardián verifica unos campos concretos, y devolver el tipo completo afirmaría que existen otros que nadie ha mirado. `DatosLexico = Pick<SalidaLexica, 'score' | 'matches'>` dice exactamente lo verificado, y si el backend renombra uno de esos dos campos deja de compilar.
- **`SignalResult.data` NO se tipa como unión de las cuatro formas.** Daría seguridad de tipos, pero el dominio pasaría a conocer cada señal concreta y rompería el principio 1 de `domain.py`: hoy añadir una señal no toca el dominio.
- **El `threshold` no necesitó tocar la plantilla.** #127 ya había dejado el `@if (datos.threshold !== undefined)` puesto, anticipando esta issue.
- **Sigue sin cubrirse** que el backend desplegado no corresponda al contrato commiteado. Para eso haría falta validar en ejecución, que es una segunda fuente de verdad salvo que también se genere.
- `var/history.db` no se ha repoblado: las filas viejas no rompen nada, porque `HistoryEntry.verdict` es `str` y no un enum.
