### PR TITLE
refactor(core): el cliente MCP sale de api/ a core/mcp/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,143 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### El cliente MCP sale de `api/`: el agente no podía reutilizarlo (#137)
+
+Salió al dibujar la secuencia del agente para #106. El bucle del agente debería
+reutilizar `execute_tool` —ya existe, y ya valida los argumentos contra el
+`inputSchema` de la herramienta— pero vivía en `backend/api/execute.py`, y el
+agente no va en `api/`.
+
+Importarlo desde fuera **habría hecho fallar `tests/test_arquitectura.py`**, que
+desde #106 vigila que ninguna capa del núcleo importe de las fachadas. O sea que
+la invariante ya estaba trabajando: en vez de que alguien cruzara la frontera sin
+darse cuenta dentro de tres meses, la decisión salió al dibujar el diagrama.
+
+#### No era una función, eran tres módulos
+
+| Módulo | Qué importaba | Diagnóstico |
+|---|---|---|
+| `api/mcp_session.py` | sólo `httpx` y `mcp` | **Cero acoplamiento a `api/`.** Un cliente MCP puro en el sitio equivocado |
+| `api/execute.py` | `mcp_session`, `schemas`, `settings` | El mecanismo es neutro; sólo el envoltorio es REST |
+| `api/catalog.py` | `mcp_session`, `schemas`, `domain`, `model_cards` | **También lo necesita el agente**: R13.2 exige que descubra las herramientas por MCP |
+
+Acabaron dentro de la fachada REST por el orden en que se construyó el sistema,
+no por diseño.
+
+#### `core/`, no `integrations/`
+
+La primera propuesta fue `integrations/mcp/`, y **era incorrecta**. Lo dice
+`docs/estructura.md`, que existe justamente para no re-derivar esto:
+
+- El criterio de `integrations/` es *«¿envuelve algo **externo al proyecto**?»*, y
+  los servidores MCP son nuestros. Su cláusula de exclusión es casi literal sobre
+  este caso: «no va aquí la maquinaria que **descubre** o **describe** las
+  integraciones; ésa opera *sobre* ellas, no *es* una».
+- El criterio de `core/` es *«¿lo usa más de una capa **y** no sabe nada del
+  dominio del clickbait?»*. Lo usarán `api/` y `agent/`, y dentro no aparece un
+  titular ni una señal.
+
+Y la **tensión 3** ya había resuelto el caso idéntico para `discovery` y
+`metadata`: «cumplen el criterio de `core/` mejor que el de `integrations/`».
+Meterlo en `integrations/` habría sido añadir un tercer caso del olor que el
+documento ya tiene fichado.
+
+La corrección vino de leer `estructura.md`, que es el primer paso de la
+orientación del repositorio y no se había dado.
+
+#### El resultado neutro necesitaba casa
+
+La issue dejaba abierto si bastaba `ToolResult`, el modelo que ya viaja dentro
+del proceso. **No basta:** tiene `success`, `data` y `error`, pero
+`ExecuteResponse` publica además **qué servidor** sirvió la herramienta.
+
+Añadirle un campo `server` lo habría ensuciado para las cinco señales NLP, que no
+tienen ninguno. De ahí un envoltorio de dos campos:
+
+```python
+@dataclass(frozen=True)
+class Invocation:
+    server: str
+    result: ToolResult
+```
+
+Los otros tres finales de `/execute` —404, 422 y 504— siguen siendo excepciones,
+y ésa es la línea: **una excepción interrumpe, un resultado fallido es una
+respuesta**. Por eso el 200 con `status: error` viaja dentro de `Invocation` y
+los demás no.
+
+#### La degradación se va con el mecanismo
+
+`fetch_catalog` consultaba los servidores con `gather(return_exceptions=True)`
+para que uno caído saliera degradado y los demás se sirvieran igual. Esa política
+se mudó entera a `discover_all`, no sólo la consulta de un servidor: **el agente
+va a querer un catálogo parcial por el mismo motivo**, y dejarla en la fachada
+habría obligado a reescribirla.
+
+Lo que se queda en `api/catalog.py` es la traducción a `ServerInfo`/`ToolInfo` y
+la ficha de modelo de cada señal — lo único de todo esto que conoce el dominio, y
+por tanto lo único que no puede bajar a `core/`.
+
+#### La lista de capas se invierte
+
+`tests/test_arquitectura.py` enumeraba los paquetes del núcleo:
+`("analysis", "integrations", "core")`. Eso deja un agujero silencioso: **un
+paquete nuevo queda fuera de la regla sin que nadie lo note**, y `backend/agent/`
+llega con R13 siendo exactamente el caso donde la tentación de reutilizar `api/`
+es real.
+
+Ahora se recorre todo `backend/` salvo `api/` y `main.py`. Es el mismo criterio
+que ya usaba la otra prueba del fichero, que lista excepciones en vez de
+incluidos: lo nuevo entra cubierto por defecto, y sacarlo exige editar la línea a
+mano.
+
+Medido: la regla pasa de tres paquetes a **52 módulos y seis entradas**, porque
+añade `config/` y `evaluation/`, que tampoco estaban vigilados.
+
+Comprobado en negativo, creando el paquete que motiva el cambio:
+
+```
+AssertionError: El núcleo importa de las fachadas:
+  agent/bucle.py importa backend.api.execute
+```
+
+Con la lista vieja eso habría pasado en silencio. Y la prueba lleva ahora un
+`assert modulos` delante: si el recorrido se rompiera, sería un `assert not []`
+que pasa siempre.
+
+#### Una regla del linter que no aplicaba
+
+Sacar el timeout a parámetro —lo pedía la issue, para que el mecanismo se pruebe
+sin montar un entorno— disparó `ASYNC109`, que desaconseja un parámetro
+`timeout` en una función asíncrona. Su argumento es bueno: si la función sólo
+envuelve su cuerpo en `asyncio.timeout`, el llamante puede hacerlo igual y el
+parámetro sobra.
+
+Aquí la premisa no se cumple. El valor hace **dos trabajos con un solo número**:
+acota la operación entera con `asyncio.timeout` **y** se le pasa a
+`open_session` como corte de inactividad de httpx, que el llamante no puede
+reproducir desde fuera.
+
+Se silencia en `ruff.toml` con el motivo escrito, acotado a ese fichero y a los
+tests —cuyos dobles copian la firma de lo que sustituyen—, en vez de apagar la
+regla en todo el repositorio.
+
+#### Verificación
+
+206 tests y ruff limpio, **sin tocar una sola aserción de comportamiento**: los
+tests de catálogo y ejecución que ya existían son la red de este movimiento, y
+sólo cambiaron rutas de importación en seis ficheros.
+
+La prueba más limpia de que no cambia nada: **regenerar el contrato OpenAPI no
+produce diff**. Ni una ruta, ni un código de estado, ni un campo.
+
+#### El efecto secundario que interesa
+
+Con el cliente MCP fuera de `api/`, **`/analyze` queda a un paso de poder ir por
+el protocolo** en vez de importar el núcleo. No era el objetivo, pero abarata la
+decisión aplazada de separar las tools de clickbait en su propio contenedor, que
+espera a saber la RAM de la máquina de despliegue.
+
 ### Cuatro huecos del contrato de `/analyze` (#133)
 
 Salieron al construir la pantalla de #127, uno detrás de otro y con la misma

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -33,12 +33,7 @@ from backend.analysis.domain import AnalyzeRequest
 from backend.analysis.orchestrator import analyze, precalentar
 from backend.api import history
 from backend.api.catalog import fetch_catalog
-from backend.api.execute import (
-    InvalidArguments,
-    ToolNotFound,
-    ToolTimeout,
-    execute_tool,
-)
+from backend.api.execute import execute_tool
 from backend.api.schemas import (
     AnalyzeResult,
     CatalogResponse,
@@ -53,6 +48,10 @@ from backend.api.schemas import (
 from backend.config.settings import settings
 from backend.core.health import check_health
 from backend.core.logging import configure_logging
+
+# Las tres excepciones son vocabulario del MECANISMO, no de la fachada: viven
+# donde se lanzan (#137). Importarlas de `api.execute` las haría parecer suyas.
+from backend.core.mcp.tools import InvalidArguments, ToolNotFound, ToolTimeout
 
 log = structlog.get_logger()
 

--- a/backend/api/catalog.py
+++ b/backend/api/catalog.py
@@ -22,15 +22,17 @@ en el momento de la llamada.
 **Un servidor caído no rompe la respuesta.** Sale en ``servers`` con estado
 ``unreachable`` y su motivo, y las herramientas de los demás se sirven igual.
 Es el mismo patrón que las señales de ``/analyze``.
-"""
 
-import asyncio
+Desde #137 el descubrimiento en sí vive en ``core/mcp/tools.py``, junto con esa
+degradación: el agente de R13 querrá un catálogo parcial por el mismo motivo, y
+no puede importar de una fachada. Aquí queda la **traducción** al contrato —y la
+ficha de modelo de cada señal, que es lo único de esto que conoce el dominio.
+"""
 
 import structlog
 from mcp.types import Tool
 
 from backend.analysis.domain import Dimension, SignalType
-from backend.api.mcp_session import open_session
 from backend.api.schemas import (
     CatalogResponse,
     ServerInfo,
@@ -39,23 +41,29 @@ from backend.api.schemas import (
     ToolModelCard,
 )
 from backend.config.settings import settings
+from backend.core.mcp import tools as mcp_tools
 from backend.integrations.nlp.model_cards import cards_by_signal
 
 log = structlog.get_logger()
 
 
 async def fetch_catalog() -> CatalogResponse:
-    """Consulta todos los servidores configurados y funde sus catálogos."""
-    resultados = await asyncio.gather(
-        *(_consultar(url) for url in settings.mcp_servers),
-        return_exceptions=True,
+    """Consulta todos los servidores configurados y funde sus catálogos.
+
+    Es quien **lee la configuración y la pasa**: el mecanismo recibe los
+    servidores y el corte por parámetro. Aquí se usa ``mcp_timeout`` y no
+    ``mcp_execute_timeout`` porque descubrir tarda milésimas — lo que necesita
+    margen es ejecutar.
+    """
+    resultados = await mcp_tools.discover_all(
+        settings.mcp_servers, settings.mcp_timeout
     )
 
     servers: list[ServerInfo] = []
     tools: list[ToolInfo] = []
 
-    # gather conserva el orden de entrada, así que cada resultado corresponde a
-    # la URL de su misma posición.
+    # `discover_all` devuelve una lista del mismo largo y en el mismo orden que
+    # las URLs, así que cada resultado corresponde al servidor de su posición.
     for url, resultado in zip(settings.mcp_servers, resultados, strict=True):
         if isinstance(resultado, BaseException):
             log.warning(
@@ -70,47 +78,18 @@ async def fetch_catalog() -> CatalogResponse:
             )
             continue
 
-        info, del_servidor = resultado
-        servers.append(info)
-        tools.extend(del_servidor)
+        herramientas = [_envolver(tool, resultado.server) for tool in resultado.tools]
+        servers.append(
+            ServerInfo(
+                url=resultado.url,
+                name=resultado.server,
+                status=ServerStatus.OK,
+                tool_count=len(herramientas),
+            )
+        )
+        tools.extend(herramientas)
 
     return CatalogResponse(servers=servers, tools=tools)
-
-
-async def _consultar(url: str) -> tuple[ServerInfo, list[ToolInfo]]:
-    """Abre una sesión MCP, se presenta y pide el catálogo de ese servidor.
-
-    El ``asyncio.timeout`` es el que hace verdad la promesa de ``mcp_timeout``:
-    que un servidor lento salga como ``unreachable`` en vez de dejar ``/tools``
-    colgado. El ``timeout`` de httpx no basta —mide inactividad entre bytes, no
-    duración— y sin esto un servidor que acepta la conexión y tarda en responder
-    cuelga la petición para siempre.
-
-    Lo que sí cubría httpx, y sigue cubriendo, es el servidor **caído**: ahí la
-    conexión se rechaza y falla rápido.
-
-    Al agotarse, la excepción sube al ``gather(return_exceptions=True)`` de
-    ``fetch_catalog`` como cualquier otro fallo, así que este servidor sale
-    degradado y los demás se sirven igual. No hace falta tratarla aquí.
-    """
-    async with (
-        asyncio.timeout(settings.mcp_timeout),
-        open_session(url, settings.mcp_timeout) as (session, inicializacion),
-    ):
-        listado = await session.list_tools()
-
-    nombre = inicializacion.serverInfo.name
-    herramientas = [_envolver(tool, nombre) for tool in listado.tools]
-
-    return (
-        ServerInfo(
-            url=url,
-            name=nombre,
-            status=ServerStatus.OK,
-            tool_count=len(herramientas),
-        ),
-        herramientas,
-    )
 
 
 def _envolver(tool: Tool, servidor: str) -> ToolInfo:

--- a/backend/api/execute.py
+++ b/backend/api/execute.py
@@ -4,13 +4,12 @@ Sus dos consumidores son ejecutar **una señal suelta** —sólo el sentimiento,
 lanzar las cuatro— y **traer una noticia** desde la pantalla de análisis. No un
 catálogo que haga de lanzador.
 
-**Los parámetros se validan antes de invocar** (R4.5), contra el ``inputSchema``
-que el propio servidor publica. Se podría dejar que validara MCP, pero entonces
-un argumento mal escrito llegaría como fallo de ejecución y sería
-indistinguible de un análisis que salió mal: validando aquí, la API puede
-responder 422 y decir qué campo falla.
+Desde #137 aquí sólo queda la **traducción**: localizar, validar e invocar vive
+en ``core/mcp/tools.py``, porque el agente de R13 necesita ese mecanismo y no
+puede importarlo de una fachada. Lo que se queda es lo que sólo tiene sentido
+por HTTP — los cuatro finales y su código de estado.
 
-**Tres errores, tres categorías distintas:**
+**Cuatro finales, cuatro categorías distintas:**
 
 - La herramienta no existe → **404**. La petición pide algo que no hay.
 - Los argumentos no encajan en su esquema → **422**. La petición está mal
@@ -20,184 +19,48 @@ responder 422 y decir qué campo falla.
   Mismo criterio que en ``/analyze``, donde una señal caída no tumba la
   respuesta.
 - El servidor tarda más de la cuenta → **504**. Ver ``ToolTimeout``.
+
+Los tres primeros los distingue quien llama por el tipo de excepción; el cuarto
+llega como un resultado fallido. Esa separación es del mecanismo, no de aquí:
+una excepción interrumpe, un resultado fallido es una respuesta.
 """
 
-import asyncio
-
-import structlog
-from jsonschema import Draft7Validator
-from mcp.types import CallToolResult, Tool
-
-from backend.api.mcp_session import open_session
 from backend.api.schemas import ExecuteResponse, ExecuteStatus
 from backend.config.settings import settings
-
-log = structlog.get_logger()
-
-
-class ToolNotFound(Exception):
-    """La herramienta no está en ningún servidor configurado."""
-
-
-class InvalidArguments(Exception):
-    """Los argumentos no encajan en el esquema que publica la herramienta."""
-
-
-class ToolTimeout(Exception):
-    """El servidor MCP no respondió dentro de ``mcp_execute_timeout``.
-
-    Es su **propia** categoría y no un ``ExecuteResponse`` con ``status`` en
-    ``error``, porque no son lo mismo: aquel significa «la herramienta se ejecutó
-    y falló», y aquí puede haber salido perfectamente.
-
-    Lo que ha fallado es la espera, no el análisis. Decirle a quien mira que «el
-    análisis falló» sería mentirle; un 504 le dice que está tardando demasiado,
-    que es lo que pasa de verdad.
-    """
+from backend.core.mcp import tools
 
 
 async def execute_tool(name: str, arguments: dict) -> ExecuteResponse:
-    """Localiza la herramienta, valida los argumentos y la invoca.
+    """Invoca la herramienta y traduce el resultado al contrato de la API.
 
-    **Nada se lanza desde dentro de la sesión.** La sesión MCP abre un *task
-    group* de anyio, y anyio envuelve en un ``ExceptionGroup`` lo que se lance
-    ahí dentro: el ``except InvalidArguments`` de la ruta no lo capturaría y
-    saldría un 500 donde toca un 422. Por eso ``_intentar`` **devuelve** lo que
-    ha pasado y es aquí, ya fuera, donde se decide qué excepción sale.
+    Es quien **lee la configuración y la pasa**: el mecanismo recibe los
+    servidores y el corte por parámetro para poder probarse sin montar un
+    entorno. Aquí se usa ``mcp_execute_timeout`` y no ``mcp_timeout`` porque
+    ejecutar necesita mucho más margen que descubrir — una señal NLP puede tener
+    que cargar su modelo la primera vez.
     """
-    for url in settings.mcp_servers:
-        try:
-            intento = await _intentar(url, name, arguments)
-
-        # `except*` y no `except`: lo que sale de la sesión viene envuelto DOS
-        # veces —un task group de anyio por capa, `streamable_http_client` y
-        # `ClientSession`— y un `except TimeoutError` no casa con un grupo:
-        #
-        #     ExceptionGroup: 'unhandled errors in a TaskGroup'
-        #       ExceptionGroup: 'unhandled errors in a TaskGroup'
-        #         TimeoutError          <- lo que de verdad pasó
-        #
-        # Ese envoltorio no se puede desactivar: es la semántica de los task
-        # groups, donde pueden fallar VARIAS tareas a la vez y no existe «la»
-        # excepción que devolver.
-        #
-        # `except*` (Python 3.11+) desmonta el grupo y compara por tipo a
-        # CUALQUIER profundidad, así que cubre también el caso sin envolver y no
-        # depende de cuántas capas ponga la librería el día de mañana.
-        #
-        # Diferencia con un `except` normal, comprobada: `except*` puede entrar
-        # en VARIAS ramas, porque un grupo admite fallos de tipos distintos. Si
-        # llegara un timeout JUNTO A otro fallo, saldría un grupo con el
-        # `ToolTimeout` dentro y la ruta respondería 500 en lugar de 504. Se
-        # asume: un timeout más un fallo independiente no es realmente «no
-        # respondió a tiempo».
-        #
-        # Si esa robustez llegara a hacer falta, la alternativa —descartada por
-        # ser maquinaria a mano donde el lenguaje ya trae herramienta— era
-        # recorrer el árbol y quedarse con el 504 siempre:
-        #
-        #     def _hay_timeout(exc: BaseException) -> bool:
-        #         if isinstance(exc, BaseExceptionGroup):
-        #             return any(_hay_timeout(hija) for hija in exc.exceptions)
-        #         return isinstance(exc, TimeoutError)
-        #
-        #     except BaseExceptionGroup as grupo:
-        #         if not _hay_timeout(grupo):
-        #             raise
-        #         raise ToolTimeout(name) from grupo
-        except* TimeoutError:
-            log.warning("tool.execute.timeout", tool=name, url=url)
-            raise ToolTimeout(name) from None
-
-        if intento is None:
-            continue  # esta herramienta no está en este servidor
-
-        problemas, resultado, servidor = intento
-        if problemas:
-            raise InvalidArguments(problemas)
-        return _envolver(resultado, name, servidor)
-
-    raise ToolNotFound(name)
-
-
-async def _intentar(
-    url: str, name: str, arguments: dict
-) -> tuple[str | None, CallToolResult | None, str] | None:
-    """Busca la herramienta en un servidor y, si está, la valida y la invoca.
-
-    Devuelve ``None`` si no la tiene. Si la tiene, ``(problemas, resultado,
-    servidor)``: con ``problemas`` los argumentos no pasaron la validación y no
-    se llegó a invocar nada.
-
-    El ``asyncio.timeout`` acota **la operación entera** —handshake, catálogo y
-    llamada— y no sólo ``call_tool``, para que un servidor lento en presentarse
-    tampoco deje la petición sin techo.
-
-    Es el que de verdad corta. El ``timeout`` de httpx que se le pasa a
-    ``open_session`` mide **inactividad entre bytes**, no duración: con una tool
-    que tarda más de la cuenta no salta, y la petición se queda colgada para
-    siempre en vez de fallar (#113, reproducido — 25 s de espera con un corte
-    pedido de 2). Se conserva igualmente porque sí cubre lo suyo: un servidor que
-    acepta la conexión y deja de enviar.
-    """
-    async with (
-        asyncio.timeout(settings.mcp_execute_timeout),
-        open_session(url, settings.mcp_execute_timeout) as (
-            session,
-            inicializacion,
-        ),
-    ):
-        tools = {t.name: t for t in (await session.list_tools()).tools}
-        if name not in tools:
-            return None
-
-        servidor = inicializacion.serverInfo.name
-        problemas = _problemas(arguments, tools[name])
-        if problemas:
-            return problemas, None, servidor
-
-        return None, await session.call_tool(name, arguments), servidor
-
-
-def _problemas(arguments: dict, tool: Tool) -> str | None:
-    """Valida los argumentos contra el ``inputSchema``; None si están bien.
-
-    Se acumulan **todos** los problemas en vez de parar en el primero: quien
-    rellena un formulario prefiere corregirlo de una vez a descubrirlos de uno
-    en uno.
-    """
-    errores = sorted(
-        Draft7Validator(tool.inputSchema).iter_errors(arguments),
-        key=lambda e: list(e.path),
+    invocacion = await tools.execute_tool(
+        name,
+        arguments,
+        servers=settings.mcp_servers,
+        timeout=settings.mcp_execute_timeout,
     )
-    if not errores:
-        return None
-
-    return "; ".join(
-        f"{'.'.join(str(p) for p in e.path) or '(raíz)'}: {e.message}" for e in errores
-    )
+    return _envolver(invocacion, name)
 
 
-def _envolver(resultado: CallToolResult, name: str, servidor: str) -> ExecuteResponse:
-    """Traduce la respuesta del protocolo al contrato de la API.
-
-    ``isError`` es fiable desde que las herramientas **lanzan** en vez de
-    devolver el mensaje de error: antes un fallo llegaba por el mismo canal que
-    un resultado válido y aquí no habría forma de distinguirlos.
-    """
-    if resultado.isError:
-        motivo = resultado.content[0].text if resultado.content else "Error desconocido"
-        log.warning("tool.execute.failed", tool=name, motivo=motivo)
+def _envolver(invocacion: tools.Invocation, name: str) -> ExecuteResponse:
+    """Traduce el resultado neutro al contrato del endpoint."""
+    if not invocacion.result.success:
         return ExecuteResponse(
             tool=name,
-            server=servidor,
+            server=invocacion.server,
             status=ExecuteStatus.ERROR,
-            detail=motivo,
+            detail=invocacion.result.error,
         )
 
     return ExecuteResponse(
         tool=name,
-        server=servidor,
+        server=invocacion.server,
         status=ExecuteStatus.OK,
-        data=resultado.structuredContent,
+        data=invocacion.result.data,
     )

--- a/backend/core/mcp/session.py
+++ b/backend/core/mcp/session.py
@@ -1,8 +1,14 @@
-"""Apertura de sesiones MCP desde la API.
+"""Apertura de sesiones MCP.
 
 Extraído porque lo comparten dos consumidores —el catálogo y la ejecución de
 herramientas— y duplicar el montaje de tres gestores de contexto anidados era
 pedir que se desincronizaran.
+
+Vive en ``core/`` desde #137. Estuvo en ``api/`` por el orden en que se
+construyó el sistema, no por diseño: no importa nada de la fachada REST, y el
+agente de R13 necesita exactamente esto para descubrir herramientas. Desde
+``api/`` no podía usarlo — ``tests/test_arquitectura.py`` prohíbe que el núcleo
+importe de las fachadas.
 
 **Sesión por petición, no persistente.** Ni el catálogo ni la ejecución son
 endpoints calientes: se consultan cuando alguien abre una pantalla o pulsa un

--- a/backend/core/mcp/tools.py
+++ b/backend/core/mcp/tools.py
@@ -1,0 +1,261 @@
+"""Descubrir e invocar herramientas MCP, sin saber quién pregunta.
+
+Este módulo es el mecanismo; la traducción al contrato REST vive en ``api/``.
+La frontera está puesta donde deja de ser genérico: aquí se habla de servidores,
+herramientas y esquemas de entrada, y no de códigos de estado ni de fichas de
+modelo.
+
+**Por qué en ``core/`` y no en ``integrations/``** (#137). El criterio de
+``integrations/`` es «¿envuelve algo *externo al proyecto*?», y los servidores
+MCP son nuestros; su cláusula de exclusión añade que la maquinaria que descubre
+o describe las integraciones opera *sobre* ellas y no *es* una. El criterio de
+``core/`` —«¿lo usa más de una capa y no sabe nada del dominio del clickbait?»—
+lo cumple: lo usarán la API REST y el agente de R13, y aquí dentro no aparece un
+titular ni una señal.
+
+**El timeout entra por parámetro**, no leyendo ``settings``. Misma regla que
+mantiene a los detectores NLP ignorantes de la configuración: se prueban sin
+montar un entorno, y quien decide el corte es quien conoce el caso de uso — la
+API tiene dos distintos, uno para descubrir y otro para ejecutar.
+"""
+
+import asyncio
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import structlog
+from jsonschema import Draft7Validator
+from mcp.types import CallToolResult, Tool
+
+from backend.core.mcp.session import open_session
+from backend.core.models import ToolResult
+
+log = structlog.get_logger()
+
+
+class ToolNotFound(Exception):
+    """La herramienta no está en ningún servidor consultado."""
+
+
+class InvalidArguments(Exception):
+    """Los argumentos no encajan en el esquema que publica la herramienta."""
+
+
+class ToolTimeout(Exception):
+    """El servidor MCP no respondió dentro del corte pedido.
+
+    Es su **propia** categoría y no un resultado fallido, porque no son lo
+    mismo: un resultado fallido significa «la herramienta se ejecutó y falló», y
+    aquí puede haber salido perfectamente.
+
+    Lo que ha fallado es la espera, no el trabajo. Quien traduzca esto a HTTP
+    debe distinguirlo: decir «el análisis falló» sería mentir.
+    """
+
+
+@dataclass(frozen=True)
+class Invocation:
+    """Lo que devolvió una herramienta, y qué servidor la sirvió.
+
+    ``ToolResult`` por sí solo no basta —no lleva el servidor, y el contrato de
+    ``/tools/{name}/execute`` lo publica— pero añadirle el campo lo ensuciaría
+    para las cinco señales NLP, que no tienen ninguno. De ahí este envoltorio.
+
+    Los otros tres finales posibles de una invocación no viajan aquí: son
+    excepciones, porque interrumpen el flujo en vez de ser un resultado.
+    """
+
+    server: str
+    result: ToolResult
+
+
+@dataclass(frozen=True)
+class ServerCatalog:
+    """Lo que publica un servidor MCP: cómo se llama y qué herramientas trae.
+
+    Las herramientas van como ``Tool`` del protocolo, sin traducir. Quien lo
+    consuma decide qué campos necesita — la API construye su ``ToolInfo`` con
+    ficha de modelo incluida, y el agente querrá el ``inputSchema`` y poco más.
+    """
+
+    url: str
+    server: str
+    tools: list[Tool]
+
+
+async def execute_tool(
+    name: str,
+    arguments: dict,
+    *,
+    servers: Sequence[str],
+    timeout: float,
+) -> Invocation:
+    """Localiza la herramienta, valida los argumentos y la invoca.
+
+    **Nada se lanza desde dentro de la sesión.** La sesión MCP abre un *task
+    group* de anyio, y anyio envuelve en un ``ExceptionGroup`` lo que se lance
+    ahí dentro: un ``except InvalidArguments`` de quien llame no lo capturaría.
+    Por eso ``_intentar`` **devuelve** lo que ha pasado y es aquí, ya fuera,
+    donde se decide qué excepción sale.
+    """
+    for url in servers:
+        try:
+            intento = await _intentar(url, name, arguments, timeout)
+
+        # `except*` y no `except`: lo que sale de la sesión viene envuelto DOS
+        # veces —un task group de anyio por capa, `streamable_http_client` y
+        # `ClientSession`— y un `except TimeoutError` no casa con un grupo:
+        #
+        #     ExceptionGroup: 'unhandled errors in a TaskGroup'
+        #       ExceptionGroup: 'unhandled errors in a TaskGroup'
+        #         TimeoutError          <- lo que de verdad pasó
+        #
+        # Ese envoltorio no se puede desactivar: es la semántica de los task
+        # groups, donde pueden fallar VARIAS tareas a la vez y no existe «la»
+        # excepción que devolver.
+        #
+        # `except*` (Python 3.11+) desmonta el grupo y compara por tipo a
+        # CUALQUIER profundidad, así que cubre también el caso sin envolver y no
+        # depende de cuántas capas ponga la librería el día de mañana.
+        #
+        # Diferencia con un `except` normal, comprobada: `except*` puede entrar
+        # en VARIAS ramas, porque un grupo admite fallos de tipos distintos. Si
+        # llegara un timeout JUNTO A otro fallo, saldría un grupo con el
+        # `ToolTimeout` dentro y quien llame vería un fallo genérico en lugar de
+        # un timeout. Se asume: un timeout más un fallo independiente no es
+        # realmente «no respondió a tiempo».
+        except* TimeoutError:
+            log.warning("tool.execute.timeout", tool=name, url=url)
+            raise ToolTimeout(name) from None
+
+        if intento is None:
+            continue  # esta herramienta no está en este servidor
+
+        problemas, resultado, servidor = intento
+        if problemas:
+            raise InvalidArguments(problemas)
+        return _leer(resultado, name, servidor)
+
+    raise ToolNotFound(name)
+
+
+async def discover_all(
+    servers: Sequence[str], timeout: float
+) -> list[ServerCatalog | BaseException]:
+    """Consulta todos los servidores a la vez; un fallo no tumba a los demás.
+
+    Devuelve una lista **del mismo largo y en el mismo orden** que ``servers``:
+    cada posición trae su catálogo o la excepción que impidió obtenerlo. Quien
+    llame decide qué hacer con el fallo — la API lo publica como servidor
+    inalcanzable, y el agente probablemente lo ignore y siga con el resto.
+
+    La degradación vive aquí y no en la fachada porque es política del
+    mecanismo, no del transporte: un catálogo parcial es útil, y el segundo
+    consumidor querrá lo mismo sin volver a escribirlo.
+    """
+    return await asyncio.gather(
+        *(_consultar(url, timeout) for url in servers),
+        return_exceptions=True,
+    )
+
+
+async def _consultar(url: str, timeout: float) -> ServerCatalog:
+    """Abre una sesión MCP, se presenta y pide el catálogo de ese servidor.
+
+    El ``asyncio.timeout`` es el que hace verdad el corte: que un servidor lento
+    salga como fallo en vez de dejar la consulta colgada. El ``timeout`` de
+    httpx no basta —mide inactividad entre bytes, no duración— y sin esto un
+    servidor que acepta la conexión y tarda en responder cuelga la petición para
+    siempre.
+
+    Lo que sí cubría httpx, y sigue cubriendo, es el servidor **caído**: ahí la
+    conexión se rechaza y falla rápido.
+    """
+    async with (
+        asyncio.timeout(timeout),
+        open_session(url, timeout) as (session, inicializacion),
+    ):
+        listado = await session.list_tools()
+
+    return ServerCatalog(
+        url=url,
+        server=inicializacion.serverInfo.name,
+        tools=list(listado.tools),
+    )
+
+
+async def _intentar(
+    url: str, name: str, arguments: dict, timeout: float
+) -> tuple[str | None, CallToolResult | None, str] | None:
+    """Busca la herramienta en un servidor y, si está, la valida y la invoca.
+
+    Devuelve ``None`` si no la tiene. Si la tiene, ``(problemas, resultado,
+    servidor)``: con ``problemas`` los argumentos no pasaron la validación y no
+    se llegó a invocar nada.
+
+    El ``asyncio.timeout`` acota **la operación entera** —handshake, catálogo y
+    llamada— y no sólo ``call_tool``, para que un servidor lento en presentarse
+    tampoco deje la petición sin techo.
+
+    Es el que de verdad corta. El ``timeout`` de httpx que se le pasa a
+    ``open_session`` mide **inactividad entre bytes**, no duración: con una tool
+    que tarda más de la cuenta no salta, y la petición se queda colgada para
+    siempre en vez de fallar (#113, reproducido — 25 s de espera con un corte
+    pedido de 2). Se conserva igualmente porque sí cubre lo suyo: un servidor que
+    acepta la conexión y deja de enviar.
+    """
+    async with (
+        asyncio.timeout(timeout),
+        open_session(url, timeout) as (session, inicializacion),
+    ):
+        tools = {t.name: t for t in (await session.list_tools()).tools}
+        if name not in tools:
+            return None
+
+        servidor = inicializacion.serverInfo.name
+        problemas = _problemas(arguments, tools[name])
+        if problemas:
+            return problemas, None, servidor
+
+        return None, await session.call_tool(name, arguments), servidor
+
+
+def _problemas(arguments: dict, tool: Tool) -> str | None:
+    """Valida los argumentos contra el ``inputSchema``; None si están bien.
+
+    **Se valida antes de invocar** (R4.5), contra el esquema que el propio
+    servidor publica. Se podría dejar que validara MCP, pero entonces un
+    argumento mal escrito llegaría como fallo de ejecución y sería
+    indistinguible de un análisis que salió mal.
+
+    Se acumulan **todos** los problemas en vez de parar en el primero: quien
+    rellena un formulario prefiere corregirlo de una vez a descubrirlos de uno
+    en uno.
+    """
+    errores = sorted(
+        Draft7Validator(tool.inputSchema).iter_errors(arguments),
+        key=lambda e: list(e.path),
+    )
+    if not errores:
+        return None
+
+    return "; ".join(
+        f"{'.'.join(str(p) for p in e.path) or '(raíz)'}: {e.message}" for e in errores
+    )
+
+
+def _leer(resultado: CallToolResult, name: str, servidor: str) -> Invocation:
+    """Traduce la respuesta del protocolo al resultado neutro.
+
+    ``isError`` es fiable desde que las herramientas **lanzan** en vez de
+    devolver el mensaje de error: antes un fallo llegaba por el mismo canal que
+    un resultado válido y aquí no habría forma de distinguirlos.
+    """
+    if resultado.isError:
+        motivo = resultado.content[0].text if resultado.content else "Error desconocido"
+        log.warning("tool.execute.failed", tool=name, motivo=motivo)
+        return Invocation(server=servidor, result=ToolResult.fail(motivo))
+
+    return Invocation(
+        server=servidor, result=ToolResult.ok(resultado.structuredContent)
+    )

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -123,11 +123,13 @@ sequenceDiagram
     autonumber
     participant C as Cliente
     participant API as FastAPI
-    participant EX as execute_tool
+    participant TR as api/execute · traduce
+    participant EX as core/mcp/tools · mecanismo
     participant M as Servidor MCP
 
     C->>API: POST a la ruta de ejecución
-    API->>EX: execute_tool(nombre, argumentos)
+    API->>TR: execute_tool(nombre, argumentos)
+    TR->>EX: execute_tool(nombre, argumentos, servers, timeout)
 
     loop por cada servidor de mcp_servers
         EX->>M: handshake y list_tools
@@ -142,9 +144,21 @@ sequenceDiagram
 
     Note over EX,M: todo va dentro de un asyncio.timeout<br/>que acota la operación ENTERA, no sólo call_tool
 
-    EX-->>API: 404 no existe / 422 argumentos / 504 tardó / 200 con status ok o error
-    API-->>C: respuesta
+    EX-->>TR: Invocation, o ToolNotFound / InvalidArguments / ToolTimeout
+    TR-->>API: ExecuteResponse con status ok o error
+    API-->>C: 200, o 404 / 422 / 504 según la excepción
 ```
+
+**El mecanismo y su traducción están separados** desde la issue 137. `core/mcp/tools.py`
+localiza, valida e invoca sin saber que existe HTTP; `api/execute.py` convierte lo
+que devuelve en un código de estado. El motivo no es estética: el agente de R13
+necesita ese mecanismo y no puede importar de una fachada sin que falle
+`tests/test_arquitectura.py`.
+
+Esa frontera explica la última pareja de flechas. Lo que sube del mecanismo son
+**excepciones o un resultado**, no códigos: una excepción interrumpe, un
+resultado fallido es una respuesta. Por eso el 200 con `status: error` viaja
+dentro de `Invocation` y los otros tres no.
 
 **La validación ocurre antes de invocar** (R4.5). Si se dejara a MCP, un argumento
 mal escrito llegaría como fallo de ejecución y sería indistinguible de un análisis
@@ -257,7 +271,7 @@ flowchart TD
     FACH["Fachadas<br/>api/ · main.py<br/>saben que sirven a alguien"]
     ANA["analysis/<br/>domain · orchestrator<br/>qué es el clickbait"]
     INT["integrations/<br/>nlp · nyt · guardian · weather"]
-    CORE["core/<br/>BaseAPI · ToolResult · logging"]
+    CORE["core/<br/>BaseAPI · ToolResult · mcp · logging"]
     CONF["config/<br/>settings"]
 
     FACH --> ANA --> INT --> CORE --> CONF
@@ -266,8 +280,12 @@ flowchart TD
 Las flechas son la **dirección permitida**, no cada import concreto. La regla que
 sostiene el diseño es la inversa, y no se dibuja porque no existe:
 
-- **Ninguna capa del núcleo importa de las fachadas.** Verificado: cero
-  coincidencias de `backend.api` en `analysis/`, `integrations/` y `core/`.
+- **Ninguna capa del núcleo importa de las fachadas.** Verificado sobre **todo
+  `backend/` salvo `api/` y `main.py`**: 52 módulos, cero coincidencias de
+  `backend.api`. La lista se invirtió en la issue 137 —antes enumeraba
+  `analysis`, `integrations` y `core`—, porque enumerar deja fuera en silencio a
+  cualquier paquete nuevo, y `backend/agent/` llega con R13 siendo justo el caso
+  donde reutilizar `api/` tienta.
 - **Los detectores no conocen la configuración.** `lexical`, `linear`,
   `incoherence` y `dedicated` no importan `settings`; sólo lo hacen `client.py`,
   que necesita el token, y `factory.py`, cuyo trabajo es leer configuración. Eso
@@ -283,10 +301,15 @@ culpables.
 Se comprobó **rompiendo las dos reglas a propósito** y verificando que fallan: un
 test de arquitectura que pasa, pero que nadie ha visto fallar, no demuestra nada.
 
-La segunda regla lista **excepciones, no detectores**. Así un detector nuevo queda
-cubierto sin tocar nada, y meter `settings` en un módulo de la capa NLP obliga a
-editar esa lista a mano — que es justo la decisión consciente que se quiere
-forzar al parametrizar los umbrales (issue 93).
+**Las dos reglas listan excepciones, no incluidos**, y por el mismo motivo: lo
+nuevo queda cubierto sin tocar nada, y sacarlo obliga a editar la lista a mano —
+que es la decisión consciente que se quiere forzar. Vale para meter `settings` en
+un módulo de la capa NLP al parametrizar los umbrales (issue 93), y para añadir
+un paquete que no debería hablar con las fachadas.
+
+La primera lleva además un `assert modulos` delante del recorrido: si la
+travesía del árbol se rompiera, la prueba se convertiría en un `assert not []`
+que pasa siempre.
 
 ## Los diagramas de la Fase A
 

--- a/docs/estructura.md
+++ b/docs/estructura.md
@@ -71,10 +71,16 @@ de historia, no una propiedad suya.
 |---|---|
 | `app.py` | La aplicación y sus cinco rutas. Segundo punto de entrada del backend, hermano de `main.py` y no capa sobre él |
 | `schemas.py` | El contrato: lo que entra y sale por HTTP, y los enums que lo acompañan |
-| `catalog.py` | Construye el catálogo agregando el `list_tools` de cada servidor MCP — `GET /tools` |
-| `execute.py` | Valida los argumentos contra el `inputSchema` e invoca — `POST /tools/{name}/execute` |
-| `mcp_session.py` | Abre sesiones MCP. Es donde la API actúa como **cliente**, no como servidor |
+| `catalog.py` | **Traduce** el descubrimiento al contrato del catálogo — `GET /tools` |
+| `execute.py` | **Traduce** una invocación a su código de estado — `POST /tools/{name}/execute` |
 | `history.py` | Almacén del historial sobre SQLite — ⚠️ [tensión 2](#2--el-almacén-del-historial-en-api) |
+
+Desde #137 `catalog.py` y `execute.py` son **traductores**: descubrir e invocar
+viven en `core/mcp/`, porque el agente de R13 necesita ese mecanismo y no puede
+importar de una fachada. Lo que queda aquí es lo que sólo tiene sentido por HTTP
+—los cuatro finales de `/execute` y sus códigos, el `ServerStatus` del
+catálogo— más la ficha de modelo de cada señal, que es lo único de esto que
+conoce el dominio.
 
 `/analyze` ya no orquesta nada: llama a `backend/analysis/orchestrator.py` y se
 limita a servir el resultado. `schemas.py` importa de allí los tipos del dominio
@@ -99,6 +105,16 @@ mismo que genérico.
 | `logging.py` | `configure_logging()` — structlog, en consola o JSON |
 | `observability.py` | `log_tool_invocation`, el decorador que registra cada invocación con parámetros y duración |
 | `health.py` | `check_health()` y su registro como tool MCP — ⚠️ [tensión 4](#4--health-conoce-mcp-desde-core) |
+| `mcp/session.py` | Abre sesiones MCP. Es donde el sistema actúa como **cliente**, no como servidor |
+| `mcp/tools.py` | Descubre e invoca herramientas, devolviendo un resultado neutro |
+
+`mcp/` llegó aquí en #137 desde `api/`, y el criterio lo decide sin empate: no
+envuelve nada externo —los servidores MCP son nuestros— y lo usan dos capas, la
+API REST hoy y el agente de R13 mañana. Es el mismo razonamiento de la
+[tensión 3](#3--discovery-y-metadata-no-envuelven-nada), aplicado a un caso que
+sí tenía que moverse: allí `discovery` y `metadata` se quedan donde están porque
+nada rompe; aquí el agente no podía importar de una fachada sin que fallara
+`tests/test_arquitectura.py`.
 
 ## `backend/integrations/`
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -69,4 +69,24 @@ ignore = [
 
 [lint.per-file-ignores]
 # Los tests importan fixtures y módulos por su efecto de registro.
-"tests/**" = ["F401"]
+#
+# Y ASYNC109 por lo mismo que en `core/mcp/tools.py`: los dobles que sustituyen
+# a `_intentar` COPIAN su firma. Si no la copiaran, monkeypatch instalaría algo
+# que no encaja y el test fallaría por el andamiaje en vez de por el código.
+"tests/**" = ["F401", "ASYNC109"]
+
+# ASYNC109 desaconseja el parámetro `timeout` en una función async, y su
+# argumento es bueno: si lo único que hace la función es envolver su cuerpo en
+# `asyncio.timeout`, el llamante puede hacerlo igual de bien y el parámetro
+# sobra.
+#
+# Aquí la premisa no se cumple. El valor hace DOS trabajos con un solo número:
+# acota la operación entera con `asyncio.timeout` **y** se le pasa a
+# `open_session` como corte de inactividad de httpx. Ese segundo uso el llamante
+# no puede reproducirlo desde fuera, así que el parámetro no es redundante.
+#
+# Y sale por parámetro a propósito (#137): leer `settings` aquí obligaría a
+# montar un entorno para probar el mecanismo, que es la misma regla que mantiene
+# limpios a los detectores NLP. Quien conoce el caso de uso elige el corte — la
+# API tiene dos distintos, uno para descubrir y otro para ejecutar.
+"backend/core/mcp/tools.py" = ["ASYNC109"]

--- a/tests/api/test_catalog.py
+++ b/tests/api/test_catalog.py
@@ -18,9 +18,10 @@ from contextlib import asynccontextmanager
 import httpx
 import pytest
 
-from backend.api import catalog, mcp_session
+from backend.api import catalog
 from backend.api.schemas import ServerStatus
 from backend.config.settings import settings
+from backend.core.mcp import session as mcp_session
 
 # El Host debe llevar puerto: la protección anti DNS-rebinding de FastMCP acepta
 # `127.0.0.1:*` y rechazaría con 421 un Host sin él.

--- a/tests/api/test_execute.py
+++ b/tests/api/test_execute.py
@@ -10,9 +10,11 @@ from contextlib import asynccontextmanager
 import httpx
 import pytest
 
-from backend.api import execute, mcp_session
+from backend.api import execute
 from backend.api.schemas import ExecuteStatus
 from backend.config.settings import settings
+from backend.core.mcp import session as mcp_session
+from backend.core.mcp.tools import InvalidArguments, ToolNotFound
 
 _BASE = "http://127.0.0.1:8765"
 _URL = f"{_BASE}/mcp"
@@ -114,19 +116,19 @@ async def test_un_fallo_de_la_tool_no_es_un_error_http(monkeypatch, servidor_mcp
 
 @pytest.mark.asyncio
 async def test_una_herramienta_inexistente_es_404(monkeypatch, servidor_mcp):
-    with pytest.raises(execute.ToolNotFound):
+    with pytest.raises(ToolNotFound):
         await _ejecutar(monkeypatch, servidor_mcp, "no_existe", {})
 
 
 @pytest.mark.asyncio
 async def test_un_argumento_que_falta_es_422(monkeypatch, servidor_mcp):
-    with pytest.raises(execute.InvalidArguments, match="headline"):
+    with pytest.raises(InvalidArguments, match="headline"):
         await _ejecutar(monkeypatch, servidor_mcp, "detect_clickbait_lexical", {})
 
 
 @pytest.mark.asyncio
 async def test_un_argumento_del_tipo_equivocado_es_422(monkeypatch, servidor_mcp):
-    with pytest.raises(execute.InvalidArguments):
+    with pytest.raises(InvalidArguments):
         await _ejecutar(
             monkeypatch, servidor_mcp, "detect_clickbait_lexical", {"headline": 42}
         )
@@ -136,7 +138,7 @@ async def test_un_argumento_del_tipo_equivocado_es_422(monkeypatch, servidor_mcp
 async def test_se_acumulan_todos_los_problemas_de_validacion(monkeypatch, servidor_mcp):
     """Quien rellena un formulario prefiere corregirlo de una vez a descubrir
     los errores de uno en uno."""
-    with pytest.raises(execute.InvalidArguments) as error:
+    with pytest.raises(InvalidArguments) as error:
         await _ejecutar(
             monkeypatch,
             servidor_mcp,
@@ -154,7 +156,7 @@ async def test_la_validacion_ocurre_antes_de_invocar(monkeypatch, servidor_mcp):
     llegaría como fallo de ejecución y sería indistinguible de un análisis que
     salió mal — 200 con status error en vez del 422 que corresponde.
     """
-    with pytest.raises(execute.InvalidArguments):
+    with pytest.raises(InvalidArguments):
         await _ejecutar(
             monkeypatch, servidor_mcp, "detect_clickbait_lexical", {"headline": None}
         )

--- a/tests/api/test_history.py
+++ b/tests/api/test_history.py
@@ -35,7 +35,6 @@ from backend.analysis.domain import (
 from backend.api import app as app_mod
 from backend.api import history
 from backend.api.app import app
-from backend.api.execute import ToolNotFound
 from backend.api.schemas import (
     ExecuteResponse,
     ExecuteStatus,
@@ -43,6 +42,7 @@ from backend.api.schemas import (
     Origin,
 )
 from backend.config.settings import settings
+from backend.core.mcp.tools import ToolNotFound
 
 client = TestClient(app)
 

--- a/tests/api/test_timeout.py
+++ b/tests/api/test_timeout.py
@@ -24,9 +24,10 @@ import pytest
 from fastapi.testclient import TestClient
 
 from backend.api import app as app_mod
-from backend.api import execute as execute_mod
 from backend.api.app import app
-from backend.api.execute import ToolTimeout, execute_tool
+from backend.api.execute import execute_tool
+from backend.core.mcp import tools as mcp_tools
+from backend.core.mcp.tools import ToolNotFound, ToolTimeout
 
 client = TestClient(app)
 
@@ -42,13 +43,13 @@ def sesion_lenta(monkeypatch):
     """
 
     def instalar(anidamiento: int = 2):
-        async def falso_intentar(url, name, arguments):
+        async def falso_intentar(url, name, arguments, timeout):
             exc: BaseException = TimeoutError()
             for _ in range(anidamiento):
                 exc = ExceptionGroup("unhandled errors in a TaskGroup", [exc])
             raise exc
 
-        monkeypatch.setattr(execute_mod, "_intentar", falso_intentar)
+        monkeypatch.setattr(mcp_tools, "_intentar", falso_intentar)
 
     return instalar
 
@@ -108,12 +109,12 @@ def test_otros_fallos_siguen_su_camino(monkeypatch):
     """El desenvuelto no puede tragarse cualquier cosa: un fallo que no sea de
     tiempo tiene que seguir subiendo tal cual."""
 
-    async def revienta(url, name, arguments):
+    async def revienta(url, name, arguments, timeout):
         raise ExceptionGroup(
             "unhandled errors in a TaskGroup", [ValueError("otra cosa")]
         )
 
-    monkeypatch.setattr(execute_mod, "_intentar", revienta)
+    monkeypatch.setattr(mcp_tools, "_intentar", revienta)
 
     with pytest.raises(BaseExceptionGroup):
         asyncio.run(execute_tool("detect_clickbait", {}))
@@ -126,7 +127,7 @@ def test_las_otras_categorias_no_cambian(monkeypatch):
     """404 y 422 seguían funcionando; el 504 se añade, no sustituye."""
 
     async def no_existe(name, arguments):
-        raise execute_mod.ToolNotFound(name)
+        raise ToolNotFound(name)
 
     monkeypatch.setattr(app_mod, "execute_tool", no_existe)
     assert (

--- a/tests/integration/test_timeout_real.py
+++ b/tests/integration/test_timeout_real.py
@@ -24,8 +24,9 @@ from typing import TypedDict
 import pytest
 from mcp.server.fastmcp import FastMCP
 
-from backend.api.execute import ToolTimeout, execute_tool
+from backend.api.execute import execute_tool
 from backend.config.settings import settings
+from backend.core.mcp.tools import ToolTimeout
 
 pytestmark = pytest.mark.integration
 

--- a/tests/test_arquitectura.py
+++ b/tests/test_arquitectura.py
@@ -29,8 +29,19 @@ BACKEND = Path(__file__).resolve().parents[1] / "backend"
 # Las fachadas: saben que están sirviendo a alguien. El núcleo no debe conocerlas.
 FACHADAS = ("backend.api", "backend.main")
 
-# Los paquetes que forman el núcleo.
-NUCLEO = ("analysis", "integrations", "core")
+# El núcleo se define por EXCLUSIÓN: todo `backend/` menos esto.
+#
+# Antes se enumeraban los paquetes incluidos —`analysis`, `integrations`,
+# `core`—, y eso dejaba un agujero silencioso: un paquete nuevo quedaba fuera de
+# la regla sin que nadie lo notara. `backend/agent/` llega con R13 y es
+# exactamente el caso, porque el agente orquesta herramientas y la tentación de
+# reutilizar lo que hay en `api/` es real (#137).
+#
+# Con la lista invertida, un paquete nuevo entra cubierto por defecto y sacarlo
+# exige editar esta línea a mano — que es la decisión consciente que se quiere
+# forzar. Mismo criterio que la otra prueba de este fichero, que lista
+# excepciones en vez de detectores.
+FUERA_DEL_NUCLEO = {"api", "main.py"}
 
 # Únicos módulos de la capa NLP a los que se les permite leer configuración:
 # `client.py` necesita el token y el trabajo de `factory.py` ES leer settings.
@@ -57,10 +68,12 @@ def _importes(fichero: Path) -> set[str]:
 
 
 def _modulos_del_nucleo() -> list[Path]:
-    ficheros: list[Path] = []
-    for paquete in NUCLEO:
-        ficheros.extend(sorted((BACKEND / paquete).rglob("*.py")))
-    return ficheros
+    """Todo módulo de ``backend/`` que no sea una fachada."""
+    return [
+        fichero
+        for fichero in sorted(BACKEND.rglob("*.py"))
+        if fichero.relative_to(BACKEND).parts[0] not in FUERA_DEL_NUCLEO
+    ]
 
 
 def test_el_nucleo_no_importa_de_las_fachadas():
@@ -69,9 +82,16 @@ def test_el_nucleo_no_importa_de_las_fachadas():
     Si `analysis/` importara de `api/`, servir el mismo análisis por MCP dejaría
     de ser posible sin arrastrar FastAPI detrás.
     """
+    modulos = _modulos_del_nucleo()
+
+    # Sin esto, un fallo del recorrido —una ruta mal puesta, un `parts[0]` que
+    # deja de casar— convertiría la prueba en un `assert not []` que pasa
+    # siempre. Vigila al vigilante.
+    assert modulos, "No se recorrió ningún módulo: la regla no comprueba nada."
+
     infracciones = [
         f"{fichero.relative_to(BACKEND)} importa {modulo}"
-        for fichero in _modulos_del_nucleo()
+        for fichero in modulos
         for modulo in _importes(fichero)
         if modulo.startswith(FACHADAS)
     ]


### PR DESCRIPTION
## #137 · El cliente MCP sale de `api/` a `core/mcp/`

Closes #137

Salió al dibujar la secuencia del agente para #106. El bucle del agente debería reutilizar `execute_tool` —ya existe, y ya valida los argumentos contra el `inputSchema` de la herramienta— pero vivía en `backend/api/execute.py`, y el agente no va en `api/`.

Importarlo desde fuera **habría hecho fallar `tests/test_arquitectura.py`**, que desde #106 vigila que ninguna capa del núcleo importe de las fachadas. O sea que la invariante ya estaba trabajando: en vez de que alguien cruzara la frontera sin darse cuenta dentro de tres meses, la decisión salió al dibujar el diagrama.

**Movimiento sin cambio de comportamiento.** La prueba más limpia: regenerar el contrato OpenAPI no produce diff. Ni una ruta, ni un código de estado, ni un campo.

### Qué incluye

- **`core/mcp/session.py`** ← `api/mcp_session.py`, movido intacto. El diff lo enseña como renombrado con 8 líneas cambiadas, que son el docstring.
- **`core/mcp/tools.py`** *(nuevo)* — el mecanismo: `execute_tool` y `discover_all`, más `ToolNotFound`, `InvalidArguments` y `ToolTimeout`.
- **`api/execute.py` y `api/catalog.py`** adelgazan a traductores del resultado neutro a `ExecuteResponse` y `CatalogResponse`.
- **`tests/test_arquitectura.py`** — la lista de capas se invierte.
- **`docs/estructura.md` y `docs/arquitectura.md`** — el movimiento cambia dónde vive cada cosa, que es lo que esos documentos declaran.

### `core/`, no `integrations/`

La primera propuesta fue `integrations/mcp/`, y era incorrecta. Lo dice `docs/estructura.md`, que existe justamente para no re-derivar esto:

- El criterio de `integrations/` es «¿envuelve algo **externo al proyecto**?», y los servidores MCP son nuestros. Su cláusula de exclusión es casi literal sobre este caso: «no va aquí la maquinaria que **descubre** o **describe** las integraciones; ésa opera *sobre* ellas, no *es* una».
- El criterio de `core/` es «¿lo usa más de una capa **y** no sabe nada del dominio del clickbait?». Lo usarán `api/` y `agent/`, y dentro no aparece un titular ni una señal.

Y la **tensión 3** ya había resuelto el caso idéntico para `discovery` y `metadata`. Meterlo en `integrations/` habría sido añadir un tercer caso del olor que el documento ya tiene fichado.

### El resultado neutro necesitaba casa

La issue dejaba abierto si bastaba `ToolResult`. **No basta:** tiene `success`, `data` y `error`, pero `ExecuteResponse` publica además qué servidor sirvió la herramienta. Añadirle un campo `server` lo habría ensuciado para las cinco señales NLP, que no tienen ninguno.

```python
@dataclass(frozen=True)
class Invocation:
    server: str
    result: ToolResult
```

Los otros tres finales de `/execute` —404, 422 y 504— siguen siendo excepciones, y ésa es la línea: **una excepción interrumpe, un resultado fallido es una respuesta**. Por eso el 200 con `status: error` viaja dentro de `Invocation` y los demás no.

### La degradación se va con el mecanismo

`fetch_catalog` consultaba los servidores con `gather(return_exceptions=True)` para que uno caído saliera degradado y los demás se sirvieran igual. Esa política se mudó entera a `discover_all`, no sólo la consulta de un servidor: **el agente va a querer un catálogo parcial por el mismo motivo**, y dejarla en la fachada habría obligado a reescribirla.

Lo que se queda en `api/catalog.py` es la traducción a `ServerInfo`/`ToolInfo` y la ficha de modelo de cada señal — lo único de todo esto que conoce el dominio, y por tanto lo único que no puede bajar a `core/`.

### La lista de capas se invierte

`tests/test_arquitectura.py` enumeraba los paquetes del núcleo: `("analysis", "integrations", "core")`. Eso deja un agujero silencioso: **un paquete nuevo queda fuera de la regla sin que nadie lo note**, y `backend/agent/` llega con R13 siendo exactamente el caso donde la tentación de reutilizar `api/` es real.

Ahora se recorre todo `backend/` salvo `api/` y `main.py`. Mismo criterio que ya usaba la otra prueba del fichero, que lista excepciones en vez de incluidos.

Medido: la regla pasa de tres paquetes a **52 módulos y seis entradas**, porque añade `config/` y `evaluation/`, que tampoco estaban vigilados.

Comprobado en negativo, creando el paquete que motiva el cambio:

```
AssertionError: El núcleo importa de las fachadas:
  agent/bucle.py importa backend.api.execute
```

Con la lista vieja eso habría pasado en silencio. Y la prueba lleva ahora un `assert modulos` delante: si el recorrido del árbol se rompiera, sería un `assert not []` que pasa siempre.

### Una regla del linter que no aplicaba

Sacar el timeout a parámetro —lo pedía la issue, para que el mecanismo se pruebe sin montar un entorno— disparó `ASYNC109`, que desaconseja un parámetro `timeout` en una función asíncrona. Su argumento es bueno: si la función sólo envuelve su cuerpo en `asyncio.timeout`, el llamante puede hacerlo igual y el parámetro sobra.

Aquí la premisa no se cumple. El valor hace **dos trabajos con un solo número**: acota la operación entera con `asyncio.timeout` **y** se le pasa a `open_session` como corte de inactividad de httpx, que el llamante no puede reproducir desde fuera.

Se silencia en `ruff.toml` con el motivo escrito, acotado a ese fichero y a los tests —cuyos dobles copian la firma de lo que sustituyen—, en vez de apagar la regla en todo el repositorio.

### Diagramas actualizados

- **§4, secuencia de `/execute`** — el participante se parte en `api/execute · traduce` y `core/mcp/tools · mecanismo`. La última pareja de flechas cambia de significado: del mecanismo suben excepciones o un resultado, no códigos de estado.
- **§7, capas** — `core/` gana `mcp`, y la regla verificada pasa de tres paquetes a «todo `backend/` salvo `api/` y `main.py`».

El §1 no cambia: habla de rutas, no de módulos.

### Verificación

206 tests y ruff limpio, **sin tocar una sola aserción de comportamiento**. Los tests de catálogo y ejecución que ya existían son la red de este movimiento; sólo cambiaron rutas de importación en seis ficheros, y las firmas de los dos dobles que sustituyen a `_intentar`, que ahora recibe el corte por parámetro.

### Notas

- **El efecto secundario que interesa:** con el cliente MCP fuera de `api/`, `/analyze` queda a un paso de poder ir por el protocolo en vez de importar el núcleo. No era el objetivo, pero abarata la decisión aplazada de separar las tools de clickbait en su propio contenedor.
- Las tres excepciones se importan ahora de `core.mcp.tools` y no se reexportan desde `api/execute.py`: son vocabulario del mecanismo, y reexportarlas las haría parecer de la fachada.
- **Precondición de R13.2**, no cambia ningún requisito.
