### PR TITLE
feat(ci): mide la cobertura y cierra los dos huecos que importaban

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,51 @@
+# Configuración de coverage.py (#138).
+#
+# Vive aquí y no en `pyproject.toml` porque el proyecto no tiene ninguno — la
+# misma razón por la que ruff se configura en `ruff.toml`.
+#
+# `pytest-cov` estaba declarado en `requirements.in` y bloqueado en
+# `requirements.txt` desde hacía meses, así que el CI lo instalaba en cada
+# corrida y no ejecutaba nada con él. Esto es lo que faltaba para que sirviera.
+
+[run]
+source = backend
+
+# Cobertura de RAMAS, no sólo de líneas. Un `if` cuya condición sólo se ha
+# probado en verdadero cuenta como línea cubierta y como rama a medias, que es
+# lo que de verdad se quiere saber. Medido al activarla: 90 % frente al 92 % de
+# líneas — dos puntos de precio por dejar de sobrevalorar la red.
+branch = True
+
+omit =
+    # Scripts de investigación de un solo uso: se ejecutan a mano para producir
+    # un número que acaba en el README, y no forman parte del sistema servido.
+    # Probarlos no diría nada útil, y dejarlos dentro hunde el total al 50 %
+    # escondiendo dónde están los huecos que sí importan.
+    backend/evaluation/*
+
+    # Integración heredada del tutorial de MCP en la Épica 1, sin relación con
+    # el clickbait. Se excluye a propósito y con su motivo: está en el proyecto
+    # por tradición, y lo honesto es sacarla de la cuenta en vez de fingir que
+    # se va a probar.
+    #
+    # OJO AL PRECIO: omitir no la penaliza, la BORRA del informe. Si algún día
+    # se le mete código de verdad, nadie se enterará por aquí. La pregunta de
+    # fondo —si `weather` sigue pintando algo en el proyecto— es otra issue.
+    backend/integrations/weather/*
+
+[report]
+show_missing = True
+
+# Sólo se listan los ficheros con huecos. Con 50 módulos, un informe completo en
+# el CI es una pared que nadie lee; lo accionable es lo que falta.
+skip_covered = True
+
+exclude_lines =
+    # Los defaults de coverage.py se pierden al declarar esta clave, así que hay
+    # que repetir el que trae de fábrica.
+    pragma: no cover
+
+    # El guardián de ejecución directa: ningún test lo atraviesa, por
+    # definición. Contarlo como hueco sería penalizar por no hacer algo que no
+    # se debe hacer.
+    if __name__ == .__main__.:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,16 @@ jobs:
           cache: pip #Evita instalación en cada run
       - name: Instalando dependencias...
         run: pip install -r requirements.txt
+      # `--cov` sin valor: qué se mide y qué se omite está en `.coveragerc`, así
+      # que el comando es el mismo aquí y en local. Va en el paso que ya existe
+      # y no en uno nuevo, para no correr la suite dos veces.
+      #
+      # SIN `--cov-fail-under`, a propósito (#138). Un umbral el primer día
+      # convierte cualquier refactor en una pelea con el porcentaje, y lo que
+      # hace falta antes es mirar el número unas cuantas corridas. El informe
+      # sale en el log; congelarlo es una decisión posterior y con datos.
       - name: Corriendo tests...
-        run: pytest -m "not integration"
+        run: pytest -m "not integration" --cov
       # Después de los tests a propósito: si el estilo falla, el informe de tests
       # ya se ha generado. Ruff se instala aparte y pineado —no desde
       # requirements.txt— para no meter tooling de desarrollo en las

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,12 @@ repomix-output.xml
 # Base de datos SQLite donde coverage.py va anotando qué líneas se ejecutan
 # mientras corren los tests. Es del mismo tipo que var/ —estado local y
 # regenerable, que sólo significa algo en la máquina que lo produjo— y aparece en
-# cuanto alguien lanza `pytest --cov`, que es lo que hará #138.
+# cuanto alguien lanza `pytest --cov`.
 .coverage
+
+# El informe navegable de `--cov-report=html`, que se genera para mirar un
+# fichero concreto. Mismo tipo que `.coverage`: derivado y regenerable.
+htmlcov/
 
 # Frontend Angular (H3). node_modules/ sin acotar a frontend/ y a cualquier
 # profundidad: un solo npm install descuidado en otro directorio metería

--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,109 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### La cobertura, de dependencia instalada a número que se mira (#138)
+
+`pytest-cov` estaba declarado en `requirements.in` y bloqueado en
+`requirements.txt` desde hacía meses, así que el CI lo instalaba en cada corrida
+y **no ejecutaba nada con él**. No había `.coveragerc`, ni configuración en
+`pytest.ini`, ni un paso en el workflow. Coste sin contrapartida: o se usa, o
+sale del `.in`.
+
+#### El número global mentía a la baja
+
+Medido antes de tocar nada: **50 % sobre todo `backend/`**. Ese número no es
+útil, porque lo hunde `backend/evaluation/` —scripts de investigación de un solo
+uso, al 0 % a propósito— y esconde dónde están los huecos que sí importan.
+Contando sólo el código servido, el punto de partida real era **90 % de ramas**.
+
+#### Ramas, no sólo líneas
+
+`branch = True`. Un `if` cuya condición sólo se ha probado en verdadero cuenta
+como línea cubierta y como rama a medias, y lo segundo es lo que se quiere saber.
+El precio medido son **dos puntos**: 90 % de ramas frente al 92 % de líneas sobre
+el mismo código.
+
+#### Qué se excluye, y el precio de excluir
+
+`backend/evaluation/` sale porque son scripts que se ejecutan a mano para
+producir un número que acaba en este README, y no forman parte del sistema
+servido.
+
+`backend/integrations/weather/` sale por decisión explícita del autor: es la
+integración heredada del tutorial de MCP en la Épica 1, sin relación con el
+clickbait, y **está en el proyecto por tradición**. Lo honesto es sacarla de la
+cuenta en vez de fingir que se va a probar.
+
+Con el precio escrito donde se toma la decisión: **omitir no penaliza, borra**.
+Si algún día se le mete código de verdad ahí dentro, el informe no dirá nada. Y
+la pregunta de fondo —si `weather` sigue pintando algo— no la resuelve esta
+issue.
+
+#### El desglose, para no vender maquillaje como trabajo
+
+| | Cobertura de ramas |
+|---|---|
+| Punto de partida | 90 % |
+| Tras excluir `evaluation` y `weather` | **92 %** |
+| Con los tests de `health` | 93 % |
+| Con los tests de `precalentar` | **94 %** |
+
+**Dos puntos son de exclusión y dos de tests nuevos.** Sin este desglose, el
+salto de 90 a 94 parecería el doble de trabajo del que fue.
+
+#### El hueco de `health`: una prueba que existía y nunca corría
+
+`core/health.py` estaba al 76 %, y lo no cubierto era el cuerpo de `_probe` —lo
+que decide si una integración responde—. El diagnóstico no era que faltara la
+prueba: **estaba escrita, marcada `@pytest.mark.integration`**, y el CI corre
+`-m "not integration"`. Se deseleccionaba en cada corrida.
+
+Ahora hay dos capas, y responden preguntas distintas. Las nuevas usan `respx` y
+no tocan la red: comprueban que `_probe` **interpreta** bien lo que recibe —un
+200, un 4xx o 5xx que el `raise_for_status()` debe rechazar, y un fallo de
+conexión—. La de integración se conserva: comprueba que las URLs reales siguen
+existiendo.
+
+Con eso `health.py` pasa de **76 % a 98 %**.
+
+#### El hueco de `precalentar`: se probaba que se llama, no qué hace
+
+`analysis/orchestrator.py` estaba al 84 %, y lo que faltaba era `precalentar()`
+entera. Los tests de #125 comprueban que el `lifespan` lo **llama** —que era el
+riesgo de entonces— pero no lo que ocurre dentro.
+
+Ahí vive una garantía que sostiene la decisión de precalentar bloqueando el
+arranque: **una señal que no carga se registra con tiempo negativo y no
+propaga**, porque `/tools` y `/history` no necesitan ningún modelo. Si esa
+excepción subiera, un modelo corrupto dejaría la API sin levantar entera.
+
+Tres tests nuevos: que con `nlp_backend=local` se calientan las tres señales, que
+con `remote` sólo la incoherencia —las otras van por HTTP y calentarlas en local
+sería cargar lo que no se va a usar— y que un fallo devuelve `-1.0` sin tumbar
+nada. `orchestrator.py` queda al 100 %.
+
+#### Sin umbral, a propósito
+
+No hay `--cov-fail-under`. Un umbral el primer día convierte cualquier refactor
+en una pelea con el porcentaje, y lo que hace falta antes es mirar el número unas
+cuantas corridas. El informe sale en el log del CI; congelarlo es una decisión
+posterior y con datos.
+
+Por lo mismo, `skip_covered = True`: con 50 módulos, un informe completo es una
+pared que nadie lee. Sólo aparecen los ficheros con huecos — **28 quedan fuera
+por estar al 100 %**.
+
+#### Lo que NO arregla, para no venderlo de más
+
+**La cobertura mide qué líneas se ejecutan, no si la aserción comprueba algo.**
+Un test que llama a una función y no afirma nada sube el porcentaje igual que uno
+bueno. El 94 % no dice que el sistema esté bien probado: dice **dónde seguro que
+no se ha mirado**, que es una pregunta más modesta y aun así útil.
+
+Queda cubierto por declaración expreso lo que no se va a probar: la tool
+`health_check` de FastMCP, una línea que delega en `check_health` y cuya
+cobertura exigiría atravesar el registro del protocolo para no probar nada nuevo.
+
 ### El cliente MCP sale de `api/`: el agente no podía reutilizarlo (#137)
 
 Salió al dibujar la secuencia del agente para #106. El bucle del agente debería

--- a/tests/api/test_analyze.py
+++ b/tests/api/test_analyze.py
@@ -28,6 +28,7 @@ from backend.analysis.orchestrator import (
     _overall,
     _run_signals,
 )
+from backend.config.settings import settings
 from backend.core.models import ToolResult
 from backend.integrations.nlp import dedicated, lexical, linear
 from backend.integrations.nlp.model_cards import cards_by_signal
@@ -487,3 +488,62 @@ async def test_si_todas_las_señales_fallan_no_hay_veredicto(señales, monkeypat
     assert response.dimensions == []
     # Aun así la respuesta es informativa: cada tarjeta dice qué le pasó.
     assert all(s.detail for s in response.signals)
+
+
+# ----- precalentado (#125), medido de verdad (#138) -----
+#
+# Hasta #138 lo único probado era que el `lifespan` LLAMA a `precalentar`. Lo que
+# hace por dentro —a qué señales toca, y qué pasa si una revienta— no lo
+# recorría ningún test, y ahí vive la garantía de que un modelo que no carga no
+# impide servir `/tools` ni `/history`.
+
+
+@pytest.mark.asyncio
+async def test_con_backend_local_se_calientan_las_tres(señales, monkeypatch):
+    señales()
+    monkeypatch.setattr(settings, "nlp_backend", "local")
+
+    tiempos = await orchestrator.precalentar()
+
+    assert set(tiempos) == {
+        "detect_clickbait",
+        "analyze_sentiment",
+        "detect_clickbait_incoherence",
+    }
+    assert all(medida >= 0 for medida in tiempos.values())
+
+
+@pytest.mark.asyncio
+async def test_con_backend_remoto_solo_se_calienta_la_incoherencia(
+    señales, monkeypatch
+):
+    """Con `remote`, las señales de titular van por HTTP a HuggingFace:
+    calentar sus modelos en local sería cargar lo que no se va a usar. La
+    incoherencia corre siempre aquí, así que sí se calienta."""
+    señales()
+    monkeypatch.setattr(settings, "nlp_backend", "remote")
+
+    tiempos = await orchestrator.precalentar()
+
+    assert set(tiempos) == {"detect_clickbait_incoherence"}
+
+
+@pytest.mark.asyncio
+async def test_una_señal_que_no_carga_no_impide_arrancar(señales, monkeypatch):
+    """El fallo se registra con un tiempo NEGATIVO y no se propaga.
+
+    Es lo que sostiene la decisión de #125 de precalentar bloqueando el
+    arranque: si una excepción subiera, un modelo corrupto dejaría la API sin
+    levantar entera, cuando `/tools` y `/history` no necesitan ningún modelo.
+    """
+    señales()
+    monkeypatch.setattr(settings, "nlp_backend", "remote")
+
+    async def revienta(headline, content):
+        raise RuntimeError("el modelo no está")
+
+    monkeypatch.setattr(orchestrator._detector, "detect", revienta)
+
+    tiempos = await orchestrator.precalentar()
+
+    assert tiempos["detect_clickbait_incoherence"] == -1.0

--- a/tests/core/test_health.py
+++ b/tests/core/test_health.py
@@ -1,6 +1,23 @@
-import pytest
+"""Pruebas del sondeo de salud.
 
-from backend.core.health import PROBES, _aggregate_status, _probe
+Hay dos capas y responden preguntas distintas. Las de aquí usan `respx` y no
+tocan la red: comprueban que `_probe` **interpreta** bien lo que recibe. La
+marcada como `integration`, al final, comprueba que las URLs reales siguen
+existiendo — otra pregunta, y por eso se conserva.
+
+Hasta #138 sólo estaba la segunda, así que el CI —que corre
+`-m "not integration"`— deseleccionaba la única prueba de `_probe` que había: el
+cuerpo de la función no se ejecutaba nunca donde importa, y con él las dos ramas
+que deciden si una integración responde.
+"""
+
+import httpx
+import pytest
+import respx
+
+from backend.core.health import PROBES, _aggregate_status, _probe, check_health
+
+URL = "https://ejemplo.invalido/sonda"
 
 
 def test_aggregate_status_all_ok():
@@ -37,6 +54,83 @@ def test_aggregate_status_all_fail():
         "nyt": {"reachable": False, "error": "boom"},
     }
     assert _aggregate_status(integrations) == "down"
+
+
+# ----- `_probe`: qué se considera «responde» -----
+
+
+@pytest.mark.asyncio
+async def test_una_respuesta_correcta_es_alcanzable():
+    with respx.mock:
+        respx.get(URL).mock(return_value=httpx.Response(200, json={}))
+
+        assert await _probe(URL) == {"reachable": True, "error": None}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("codigo", [404, 500])
+async def test_un_codigo_de_error_no_es_alcanzable(codigo):
+    """El `raise_for_status()` es lo que impide tratar un 4xx o un 5xx como
+    respuesta aceptable: la API contestó, pero no sirve."""
+    with respx.mock:
+        respx.get(URL).mock(return_value=httpx.Response(codigo))
+
+        resultado = await _probe(URL)
+
+    assert resultado["reachable"] is False
+    assert resultado["error"]
+
+
+@pytest.mark.asyncio
+async def test_un_fallo_de_red_no_es_alcanzable():
+    """La otra rama: no hay respuesta que interpretar, no llega la conexión."""
+    with respx.mock:
+        respx.get(URL).mock(side_effect=httpx.ConnectError("sin ruta al host"))
+
+        resultado = await _probe(URL)
+
+    assert resultado["reachable"] is False
+    assert "sin ruta al host" in resultado["error"]
+
+
+@pytest.mark.asyncio
+async def test_los_parametros_viajan_en_la_peticion():
+    """Las sondas de Guardian y NYT llevan su clave: sin ella, la API responde
+    401 y la integración saldría caída estando viva."""
+    with respx.mock:
+        ruta = respx.get(URL).mock(return_value=httpx.Response(200, json={}))
+
+        await _probe(URL, {"api-key": "una-clave"})
+
+    assert ruta.calls.last.request.url.params["api-key"] == "una-clave"
+
+
+# ----- `check_health`: el agregado -----
+
+
+@pytest.mark.asyncio
+async def test_check_health_sondea_todas_y_agrega():
+    """Una sola integración caída deja el sistema en `degraded`, no en `down`.
+
+    Y las tres aparecen en el detalle: sin él, un semáforo en ámbar no dice
+    CUÁL falla, que es lo único accionable.
+    """
+    with respx.mock:
+        for nombre, configuracion in PROBES.items():
+            codigo = 500 if nombre == "guardian" else 200
+            respx.get(configuracion["url"]).mock(
+                return_value=httpx.Response(codigo, json={})
+            )
+
+        salud = await check_health()
+
+    assert salud["status"] == "degraded"
+    assert set(salud["integrations"]) == set(PROBES)
+    assert salud["integrations"]["guardian"]["reachable"] is False
+    assert salud["integrations"]["nyt"]["reachable"] is True
+    # La marca de tiempo lleva zona horaria: sin ella, dos despliegues en husos
+    # distintos producirían historiales que no se pueden ordenar entre sí.
+    assert salud["timestamp"].endswith("+00:00")
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## #138 · La cobertura, de dependencia instalada a número que se mira

Closes #138

`pytest-cov` estaba declarado en `requirements.in` y bloqueado en `requirements.txt` desde hacía meses, así que el CI lo instalaba en cada corrida y **no ejecutaba nada con él**. No había `.coveragerc`, ni configuración en `pytest.ini`, ni un paso en el workflow.

La primera de las tres issues que buscan fallos que hoy no se manifiestan, junto a #139 y #140.

### Qué incluye

- **`.coveragerc`** *(nuevo)* — qué se mide, qué se omite y por qué. El repositorio no tiene `pyproject.toml`, así que es el sitio.
- **`.github/workflows/ci.yml`** — `--cov` en el paso de tests que ya existe, no uno nuevo: evita correr la suite dos veces.
- **`.gitignore`** — `htmlcov/`, que faltaba. `.coverage` ya entró en #134.
- **`tests/core/test_health.py`** — cuatro tests con `respx`, sin red.
- **`tests/api/test_analyze.py`** — tres tests de `precalentar()`.

### El número global mentía a la baja

Medido antes de tocar nada: **50 % sobre todo `backend/`**. Ese número no sirve, porque lo hunde `backend/evaluation/` —scripts de investigación de un solo uso, al 0 % a propósito— y esconde dónde están los huecos que importan. Contando sólo el código servido, el punto de partida real era **90 % de ramas**.

### Ramas, no sólo líneas

`branch = True`. Un `if` cuya condición sólo se ha probado en verdadero cuenta como línea cubierta y como rama a medias, y lo segundo es lo que se quiere saber. El precio medido son dos puntos: 90 % de ramas frente al 92 % de líneas sobre el mismo código.

### Qué se excluye, y el precio de excluir

`backend/evaluation/` sale porque son scripts que se ejecutan a mano para producir un número que acaba en el README.

`backend/integrations/weather/` sale por decisión explícita: es la integración heredada del tutorial de MCP en la Épica 1, sin relación con el clickbait, y **está en el proyecto por tradición**. Lo honesto es sacarla de la cuenta en vez de fingir que se va a probar.

Con el precio escrito donde se toma la decisión: **omitir no penaliza, borra**. Si algún día se le mete código de verdad ahí dentro, el informe no dirá nada. Y la pregunta de fondo —si `weather` sigue pintando algo en el proyecto— no la resuelve esta issue.

### El desglose, para no vender maquillaje como trabajo

| | Cobertura de ramas |
|---|---|
| Punto de partida | 90 % |
| Tras excluir `evaluation` y `weather` | **92 %** |
| Con los tests de `health` | 93 % |
| Con los tests de `precalentar` | **94 %** |

**Dos puntos son de exclusión y dos de tests nuevos.** Sin este desglose, el salto de 90 a 94 parecería el doble de trabajo del que fue.

### El hueco de `health`: una prueba que existía y nunca corría

`core/health.py` estaba al 76 %, y lo no cubierto era el cuerpo de `_probe` —lo que decide si una integración responde—. El diagnóstico no era que faltara la prueba: **estaba escrita, marcada `@pytest.mark.integration`**, y el CI corre `-m "not integration"`. Se deseleccionaba en cada corrida.

Ahora hay dos capas con preguntas distintas. Las nuevas usan `respx` y no tocan la red: comprueban que `_probe` **interpreta** bien lo que recibe —un 200, un 4xx o 5xx que el `raise_for_status()` debe rechazar, y un fallo de conexión—, y que los parámetros con la clave de API viajan en la petición. La de integración se conserva: comprueba que las URLs reales siguen existiendo.

`health.py` pasa de **76 % a 98 %**.

### El hueco de `precalentar`: se probaba que se llama, no qué hace

`analysis/orchestrator.py` estaba al 84 %, y lo que faltaba era `precalentar()` entera. Los tests de #125 comprueban que el `lifespan` lo **llama** —que era el riesgo de entonces— pero no lo que ocurre dentro.

Ahí vive una garantía que sostiene la decisión de precalentar bloqueando el arranque: **una señal que no carga se registra con tiempo negativo y no propaga**, porque `/tools` y `/history` no necesitan ningún modelo. Si esa excepción subiera, un modelo corrupto dejaría la API sin levantar entera.

Tres tests: que con `nlp_backend=local` se calientan las tres señales, que con `remote` sólo la incoherencia —las otras van por HTTP y calentarlas en local sería cargar lo que no se va a usar— y que un fallo devuelve `-1.0` sin tumbar nada. `orchestrator.py` queda al **100 %**.

### Sin umbral, a propósito

No hay `--cov-fail-under`. Un umbral el primer día convierte cualquier refactor en una pelea con el porcentaje, y lo que hace falta antes es mirar el número unas cuantas corridas. El informe sale en el log del CI; congelarlo es una decisión posterior y con datos.

Por lo mismo, `skip_covered = True`: con 50 módulos, un informe completo es una pared que nadie lee. Sólo aparecen los ficheros con huecos — 28 quedan fuera por estar al 100 %.

### Verificación

215 tests (nueve nuevos) y ruff limpio. El comando es el mismo en local y en CI, porque qué se mide vive en la configuración:

```bash
pytest -m "not integration" --cov
```

### Notas

- **La cobertura mide qué líneas se ejecutan, no si la aserción comprueba algo.** Un test que llama a una función y no afirma nada sube el porcentaje igual que uno bueno. El 94 % dice dónde *seguro* que no se ha mirado, que es una pregunta más modesta y aun así útil.
- Queda sin cubrir por declaración expresa la tool `health_check` de FastMCP: una línea que delega en `check_health`, y cuya cobertura exigiría atravesar el registro del protocolo para no probar nada nuevo.
- No sustituye a los tests de integración, que siguen fuera de la medición por llevar su marcador.
