### PR TITLE
feat(ci): pyright en el CI, y los 26 avisos que tenía el código servido

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,24 @@ jobs:
           pip install ruff==0.16.1
           ruff check .
           ruff format --check .
+      # Los tipos van en un paso APARTE del estilo, y después, por lo mismo que
+      # el estilo va después de los tests: cada informe se genera aunque el
+      # siguiente falle. Son tres preguntas distintas y conviene poder leer las
+      # tres.
+      #
+      # Pyright es lo que ya corre en el editor a través de Pylance, así que el
+      # CI comprueba exactamente lo que ve quien escribe. Reglas y exclusiones,
+      # en `pyrightconfig.json`.
+      #
+      # `--pythonpath` es necesario: la configuración apunta al `.venv` para el
+      # trabajo local y el editor, y aquí no hay ninguno — las dependencias
+      # están en el intérprete del runner, instaladas por el paso de arriba. Sin
+      # esto, pyright no resuelve un solo import y produce decenas de avisos que
+      # no son errores de tipos.
+      - name: Comprobando tipos...
+        run: |
+          pip install pyright==1.1.411
+          pyright --pythonpath $(which python)
 
   # El frontend va en un job APARTE y no como pasos del de Python: son cadenas
   # de herramientas independientes y así un fallo de TypeScript no oculta el

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,17 @@ jobs:
       # están en el intérprete del runner, instaladas por el paso de arriba. Sin
       # esto, pyright no resuelve un solo import y produce decenas de avisos que
       # no son errores de tipos.
+      #
+      # Por eso el log lleva un `venv .venv subdirectory not found`: es esperado
+      # y no rompe nada. Pyright valida el `venvPath` de la configuración aunque
+      # la línea de órdenes lo sustituya, y quitarlo del fichero costaría 43
+      # avisos en local, que es donde sí existe ese `.venv`.
+      #
+      # Ojo con lo que el CI NO instala: `sentence-transformers` vive en
+      # `requirements-dev.txt` por arrastrar torch, así que su import no se
+      # resuelve aquí y lleva un `# pyright: ignore` con el motivo escrito. Es la
+      # diferencia de entorno que hace que este paso encuentre cosas que en local
+      # no aparecen.
       - name: Comprobando tipos...
         run: |
           pip install pyright==1.1.411

--- a/README.md
+++ b/README.md
@@ -1282,17 +1282,33 @@ seguían haciendo falta.
 
 Comprobado quitándolos: los cuatro suprimían errores de verdad. Tres eran el
 patrón de `.data` y desaparecieron al usar `unwrap()`. El cuarto —`Settings()`
-sin argumentos, que pydantic-settings rellena desde el entorno— se queda, pero
-acotado a `[call-arg]` en vez de a secas: **un `ignore` sin regla silencia
-también los errores futuros de esa línea**.
+sin argumentos, que pydantic-settings rellena desde el entorno— se queda.
 
-De cuatro ciegos a dos acotados, y los dos con su motivo escrito.
+Y ahí apareció algo que merece constar, porque **primero lo escribí mal**. Se dio
+por bueno que `# type: ignore[call-arg]` acotaba la supresión a esa regla. No lo
+hace: **pyright ignora el contenido del corchete** en esa forma. Medido poniendo
+una regla inventada —`# type: ignore[reglaInventada]`— y comprobando que suprime
+igual.
+
+La forma que sí acota es la suya: `# pyright: ignore[reportCallIssue]`. Medido
+también al revés, que es la prueba que vale: con una regla **equivocada pero
+real** el error vuelve a salir.
+
+La diferencia importa porque un `ignore` sin regla efectiva silencia **cualquier
+error futuro de esa línea**, incluido uno que no tenga nada que ver con el que se
+quería tapar.
 
 #### Lo que se silencia, y por qué
 
-Sólo queda uno más, en `nlp/local.py`: los *stubs* de `transformers` declaran una
-sobrecarga de `pipeline` por cada tarea concreta, y aquí la tarea llega como
-`str`. No es un fallo nuestro.
+Quedan dos más, y ninguno es un fallo nuestro. En `nlp/local.py`, los *stubs* de
+`transformers` declaran una sobrecarga de `pipeline` por cada tarea concreta y
+aquí la tarea llega como `str`.
+
+En `nlp/incoherence.py`, el import de `sentence-transformers`. Y ése lo destapó
+el CI, no el trabajo local: la dependencia vive en `requirements-dev.txt` porque
+arrastra torch y wheels de CUDA, y **el CI instala sólo `requirements.txt`**. En
+mi máquina resolvía; en el runner, no. Es la asimetría que hace que el import sea
+perezoso, y el `ignore` la declara en vez de esconderla.
 
 De paso apareció uno que sí lo era: la caché de pipelines se declaraba
 `dict[..., object]`, y `object` no es invocable — así que

--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,154 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### El comprobador de tipos ya corría, y el repositorio no se enteraba (#139)
+
+`CLAUDE.md` daba esta issue por pendiente desde hacía semanas. Al ir a escribirla
+se vio que la herramienta **ya estaba funcionando**: es Pylance —o sea Pyright—
+dentro del editor. Lo que faltaba no era el comprobador, era que el repositorio
+lo ejecutara.
+
+De ahí la decisión menos obvia: **Pyright y no mypy**. Adoptar en el CI lo mismo
+que ya corre en el editor significa que los avisos que aparecen al escribir son
+los que rompen la corrida, y no dos listas parecidas que hay que traducir.
+
+#### El número, otra vez distorsionado por `evaluation/`
+
+67 avisos en total. **41 estaban en `backend/evaluation/`**, y escondían los 26
+del código servido, que son los únicos accionables. Se excluye por el mismo
+criterio que en #138: lo que no se sirve, no distorsiona el número.
+
+Y `basic`, no `strict`. Con `strict` habría que anotar el proyecto entero antes
+de que el CI volviera a pasar, y lo que se enciende de golpe sobre código
+existente se acaba ignorando. `basic` encontró los 26, que era lo que se buscaba.
+
+#### Los 26 no eran ruido
+
+**Seis bugs latentes**, cada uno con su forma:
+
+| Dónde | Qué |
+|---|---|
+| `core/logging.py` | `if/elif` sin `else` sobre un `Literal`. Si algún día se añade un tercer formato, `renderer` queda **sin asignar** y la línea siguiente revienta con un `UnboundLocalError` que no dice nada del problema |
+| `core/base_api.py` | `make_request` declara `-> ToolResult` y tenía un camino que caía por el final devolviendo `None`. Quien llamara haría `.success` sobre él |
+| `api/history.py` | `cursor.lastrowid` es `int \| None` —None si la sentencia no fue un INSERT— y la firma prometía `int` |
+| `integrations/metadata.py` | `analysis/tool.py` usa la categoría `"Análisis completo"`, que **no estaba en el `Literal` `Categoria`**. El comentario de esa tool explica por qué no es «Señales de análisis»; el vocabulario declarado nunca se actualizó |
+| `model_cards.py` | `model_id` es `None` a propósito en el léxico y el lineal, y se pasaba a `classify(model: str)` sin comprobar. Una ficha sin id habría fallado dentro de una llamada HTTP, con una URL que lleva `None` dentro |
+| `core/mcp/tools.py` | el contenido de una respuesta MCP es una **unión** —texto, imagen, audio, recurso— y se leía `.text` a ciegas. Funcionaba porque nuestras tools sólo devuelven texto; un servidor ajeno que respondiera otra cosa habría reventado en vez de informar |
+
+Ninguno se manifiesta hoy. Todos se manifestarían el día que cambiara algo, y
+ninguno con un mensaje que apuntara a su causa.
+
+#### Un solo patrón explicaba diez avisos
+
+`ToolResult.data` es `Any | None`, porque un resultado fallido no trae ninguno.
+El precio lo pagaba quien lo consume: las tools hacían `return response.data`
+declarando devolver una forma concreta, y los clientes `response.data["clave"]`.
+Las dos cosas están bien **si el resultado fue bien**, y ninguna lo comprobaba en
+el mismo sitio donde leía.
+
+La respuesta es un método:
+
+```python
+def unwrap(self) -> Any:
+    if not self.success or self.data is None:
+        raise ValueError(self.error or "El resultado no trae datos.")
+    return self.data
+```
+
+Lo que cambia no es la seguridad de tipos —el dato sigue siendo `Any`— sino
+**dónde falla**. Antes un `None` inesperado daba un `TypeError` de subíndice tres
+marcos más abajo, o un modelo Pydantic quejándose de un campo que no existe.
+Ahora dice que el resultado venía vacío, y con el motivo del fallo original.
+
+Y en dos sitios había algo más que un tipo impreciso: `nlp/linear.py` leía
+`result.data["matches"]` **sin comprobar nada**, y `guardian/_find_tag`
+comprobaba `success` pero no el contenido, así que un éxito sin cuerpo llegaba al
+`.get` y reventaba sobre `None`.
+
+#### La invariante que vivía a noventa líneas de distancia
+
+El aviso que destapó todo esto —el que aparecía en el editor— era éste:
+
+> Argument of type `str | None` cannot be assigned to parameter `content` of
+> type `str` in function `detect`
+
+El código es correcto: el orquestador desvía la señal de incoherencia a
+`not_applicable` antes de llamarla, si no hay cuerpo. Pero **esa garantía vive en
+un `bool` de una tabla de constantes, comprobado noventa líneas por debajo del
+sitio que depende de él**. Ningún comprobador puede unir esos dos puntos, y
+ningún lector de un vistazo tampoco.
+
+Y el modo de fallo, si alguien pusiera `needs_content=False` en esa entrada, era
+el peor posible: el guardia dejaría de correr, el detector reventaría al medir la
+longitud de `None`, y el aislamiento de fallos lo convertiría en una señal en
+estado `error`. Sin excepción que suba, sin test rojo, sin nada.
+
+Ahora la garantía se escribe donde se usa, con un `_con_cuerpo()` que falla
+diciendo qué pasó.
+
+#### Los cuatro `# type: ignore` eran reales
+
+Había cuatro en el repositorio, puestos por alguien que veía los avisos en su
+editor. Sin comprobador instalado eran **comentarios inertes**, y nadie sabía si
+seguían haciendo falta.
+
+Comprobado quitándolos: los cuatro suprimían errores de verdad. Tres eran el
+patrón de `.data` y desaparecieron al usar `unwrap()`. El cuarto —`Settings()`
+sin argumentos, que pydantic-settings rellena desde el entorno— se queda, pero
+acotado a `[call-arg]` en vez de a secas: **un `ignore` sin regla silencia
+también los errores futuros de esa línea**.
+
+De cuatro ciegos a dos acotados, y los dos con su motivo escrito.
+
+#### Lo que se silencia, y por qué
+
+Sólo queda uno más, en `nlp/local.py`: los *stubs* de `transformers` declaran una
+sobrecarga de `pipeline` por cada tarea concreta, y aquí la tarea llega como
+`str`. No es un fallo nuestro.
+
+De paso apareció uno que sí lo era: la caché de pipelines se declaraba
+`dict[..., object]`, y `object` no es invocable — así que
+`asyncio.to_thread(pipe, text)` era un error de tipos que nadie veía. Con
+`Callable[..., Any]` desaparecen cuatro avisos y el tipo dice la verdad.
+
+#### Un cambio de contrato, dicho en voz alta
+
+`GET /health` declaraba devolver `dict` y devuelve un `Salud`. Corregirlo tiene
+una consecuencia buscada: **la forma pasa a publicarse en el contrato OpenAPI**,
+así que `openapi.json` gana `Salud` y `Sonda` —59 líneas— y el frontend recibirá
+el estado del sistema tipado en vez de como objeto libre cuando llegue #128.
+
+Es un cambio de contrato dentro de una PR de análisis estático, y por eso queda
+anotado en vez de pasar desapercibido entre las correcciones de tipos.
+
+#### Verificación
+
+**0 errores de pyright** sobre el código servido, 215 tests y ruff limpio. El
+comando es el mismo en local y en el editor, porque la configuración vive en
+`pyrightconfig.json`:
+
+```bash
+pyright
+```
+
+En el CI lleva `--pythonpath $(which python)`: la configuración apunta al `.venv`
+para el trabajo local, y en el runner no hay ninguno.
+
+#### Lo que NO arregla
+
+Un comprobador de tipos **no encuentra errores de lógica**. No habría detectado
+que dos señales de forma eran la misma (#109), ni que un umbral estaba a ojo
+(#92), ni que un corpus era otro reempaquetado (#121). Encuentra desajustes entre
+lo que una función promete y lo que recibe — una franja estrecha, pero es justo
+la que los tests no cubren, porque un test sólo recorre el camino que alguien
+pensó en escribir.
+
+Emparejado con #138 por eso: **los dos buscan fallos que hoy no se manifiestan**,
+por vías distintas. La cobertura señala caminos que nunca se ejecutan; los tipos,
+desajustes que el intérprete no llega a ver.
+
+El frontend queda fuera: no tiene linter, y eso es #140.
+
 ### La cobertura, de dependencia instalada a número que se mira (#138)
 
 `pytest-cov` estaba declarado en `requirements.in` y bloqueado en

--- a/backend/analysis/orchestrator.py
+++ b/backend/analysis/orchestrator.py
@@ -50,7 +50,7 @@ from backend.core.models import ToolResult
 from backend.integrations.nlp import dedicated, lexical, linear
 from backend.integrations.nlp.factory import get_nlp_backend
 from backend.integrations.nlp.incoherence import IncoherenceDetector
-from backend.integrations.nlp.model_cards import cards_by_signal
+from backend.integrations.nlp.model_cards import cards_by_signal, model_id_de
 
 log = structlog.get_logger()
 
@@ -79,7 +79,26 @@ _CARDS = cards_by_signal()
 # Sólo queda el del tono: la señal de clickbait pasó a `integrations/nlp/dedicated`
 # en #115, que es donde viven ya sus hermanas —léxico, lineal, incoherencia— y
 # donde el id y el mapeo de etiquetas tienen un único sitio.
-_SENTIMENT_MODEL = _CARDS["analyze_sentiment"]["model_id"]
+_SENTIMENT_MODEL = model_id_de("analyze_sentiment")
+
+
+def _con_cuerpo(content: str | None) -> str:
+    """El cuerpo de la noticia, exigiendo que esté.
+
+    ``needs_content`` garantiza que las señales que lo requieren no se ejecutan
+    sin él, pero esa garantía vive en ``_run_signals``, muy por debajo de esta
+    tabla: ningún tipador puede unir los dos puntos, y ningún lector de un
+    vistazo tampoco.
+
+    Si alguien pusiera ``needs_content=False`` en la entrada de la incoherencia,
+    el guardia dejaría de correr y el fallo saldría dentro del detector, como un
+    ``TypeError`` al medir la longitud de ``None`` — convertido después en una
+    señal en estado ``error`` por el aislamiento de fallos. Sin excepción que
+    suba, sin test rojo. Esto lo convierte en un mensaje que dice qué pasó.
+    """
+    if content is None:
+        raise ValueError("Esta señal requiere el cuerpo de la noticia.")
+    return content
 
 
 @dataclass(frozen=True)
@@ -157,7 +176,7 @@ _SIGNALS: tuple[_Signal, ...] = (
     ),
     _Signal(
         name="detect_clickbait_incoherence",
-        run=lambda h, c: _detector.detect(h, c),
+        run=lambda h, c: _detector.detect(h, _con_cuerpo(c)),
         verdict=lambda d: d["incoherent"],
         needs_content=True,
     ),
@@ -304,11 +323,12 @@ async def _run_one(spec: _Signal, headline: str, content: str | None) -> SignalR
             SignalStatus.ERROR,
             detail=outcome.error or "La señal no devolvió resultado.",
         )
+    datos = outcome.unwrap()
     return _build(
         spec,
         SignalStatus.OK,
-        is_clickbait=spec.verdict(outcome.data),
-        data=outcome.data,
+        is_clickbait=spec.verdict(datos),
+        data=datos,
     )
 
 

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -46,7 +46,7 @@ from backend.api.schemas import (
     RetentionPolicy,
 )
 from backend.config.settings import settings
-from backend.core.health import check_health
+from backend.core.health import Salud, check_health
 from backend.core.logging import configure_logging
 
 # Las tres excepciones son vocabulario del MECANISMO, no de la fachada: viven
@@ -360,7 +360,7 @@ async def get_history_entry(entry_id: int) -> HistoryEntry:
 
 
 @app.get("/health", tags=["operación"])
-async def get_health() -> dict:
+async def get_health() -> Salud:
     """Estado de las integraciones externas.
 
     Sondea cada API con una petición ligera y agrega: `ok` si todas responden,

--- a/backend/api/history.py
+++ b/backend/api/history.py
@@ -263,6 +263,12 @@ def _guardar(
         # evitaría, pero perdería el ahorro que justifica podar al escribir.
         _podar(conexion)
 
+        if identificador is None:
+            # Imposible tras un INSERT, y por eso mismo conviene que grite: si
+            # ocurriera, `record` devolvería None y la API publicaría `id: null`
+            # sin que nada explicara por qué.
+            raise RuntimeError("El INSERT no devolvió el id de la fila.")
+
         return identificador
 
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -135,4 +135,11 @@ class Settings(BaseSettings):
     history_max_days: int = 30
 
 
-settings = Settings()  # type: ignore #Activa la validación al importar
+# Activa la validación al importar: si falta una clave, el proceso no arranca.
+#
+# El `ignore` es acotado y necesario: pydantic-settings rellena los campos sin
+# valor por defecto desde el entorno o el `.env`, y el comprobador de tipos sólo
+# ve un constructor al que le faltan tres argumentos. Era un `# type: ignore` a
+# secas —que además silencia cualquier error FUTURO de esta línea— hasta que
+# #139 encendió pyright y se pudo comprobar qué suprimía de verdad.
+settings = Settings()  # type: ignore[call-arg]

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -137,9 +137,12 @@ class Settings(BaseSettings):
 
 # Activa la validación al importar: si falta una clave, el proceso no arranca.
 #
-# El `ignore` es acotado y necesario: pydantic-settings rellena los campos sin
-# valor por defecto desde el entorno o el `.env`, y el comprobador de tipos sólo
-# ve un constructor al que le faltan tres argumentos. Era un `# type: ignore` a
-# secas —que además silencia cualquier error FUTURO de esta línea— hasta que
-# #139 encendió pyright y se pudo comprobar qué suprimía de verdad.
-settings = Settings()  # type: ignore[call-arg]
+# El `ignore` es necesario: pydantic-settings rellena los campos sin valor por
+# defecto desde el entorno o el `.env`, y el comprobador sólo ve un constructor
+# al que le faltan tres argumentos.
+#
+# La sintaxis importa, y se comprobó (#139): pyright **ignora el contenido del
+# corchete** en `# type: ignore[...]` —una regla inventada suprime igual— así que
+# esa forma silencia cualquier error futuro de la línea. `# pyright: ignore[...]`
+# sí acota: puesta una regla equivocada, el error vuelve.
+settings = Settings()  # pyright: ignore[reportCallIssue]

--- a/backend/core/base_api.py
+++ b/backend/core/base_api.py
@@ -116,6 +116,18 @@ class BaseAPI:
                 except Exception as e:
                     return ToolResult.fail(f"An error occurred: {e!s}")
 
+        # El bucle siempre devuelve: en el último intento los tres manejadores
+        # retornan en vez de hacer `continue`. Salvo que `MAX_RETRIES` fuera
+        # negativo y `range()` saliera vacío — entonces esto caía por el final
+        # devolviendo `None`, y quien llamara haría `.success` sobre él.
+        #
+        # No es defensa paranoica: la firma promete un `ToolResult` y sin esto la
+        # promesa era falsa por un camino, aunque hoy nadie lo recorra. Lo
+        # detectó pyright en #139.
+        return ToolResult.fail(
+            f"No se intentó la llamada: MAX_RETRIES es {self.MAX_RETRIES}."
+        )
+
     # Luego reescribirmos en otra clase que herede de Base API y tenemos POLIMORFISMO!
 
     def _apply_auth(self, headers: dict, params: dict) -> None:

--- a/backend/core/health.py
+++ b/backend/core/health.py
@@ -46,7 +46,7 @@ PROBES = {
 }
 
 
-async def _probe(url: str, params: dict | None = None) -> dict:
+async def _probe(url: str, params: dict | None = None) -> Sonda:
     """Hace una petición ligera a una API y reporta si responde correctamente."""
     try:
         async with httpx.AsyncClient(timeout=PROBE_TIMEOUT) as client:

--- a/backend/core/logging.py
+++ b/backend/core/logging.py
@@ -16,10 +16,18 @@ def configure_logging():
     logging.getLogger("httpx").setLevel(
         logging.WARNING
     )  # Evita Filtraciones de API KEY por logs.
+    # El `else` que lanza no es defensa contra lo imposible: `log_format` es un
+    # `Literal` de dos valores, así que hoy no puede caer ahí. Existe para el día
+    # que se añada un tercero — sin él, `renderer` quedaría SIN ASIGNAR y la
+    # línea siguiente reventaría con un `UnboundLocalError` que no dice nada del
+    # problema real. Detectado por pyright en #139.
     if settings.log_format == "console":
         renderer = structlog.dev.ConsoleRenderer()
     elif settings.log_format == "json":
         renderer = structlog.processors.JSONRenderer()
+    else:
+        raise ValueError(f"Formato de log no soportado: {settings.log_format}")
+
     processors.append(renderer)
     structlog.configure(
         processors=processors,

--- a/backend/core/mcp/tools.py
+++ b/backend/core/mcp/tools.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 
 import structlog
 from jsonschema import Draft7Validator
-from mcp.types import CallToolResult, Tool
+from mcp.types import CallToolResult, TextContent, Tool
 
 from backend.core.mcp.session import open_session
 from backend.core.models import ToolResult
@@ -134,6 +134,12 @@ async def execute_tool(
         problemas, resultado, servidor = intento
         if problemas:
             raise InvalidArguments(problemas)
+        if resultado is None:
+            # `_intentar` devuelve resultado siempre que no haya problemas, pero
+            # eso es un acuerdo entre las dos funciones que la tupla no expresa.
+            # Si alguien rompe el acuerdo, mejor aquí que tres marcos más abajo.
+            raise RuntimeError(f"«{name}» no devolvió resultado ni problemas.")
+
         return _leer(resultado, name, servidor)
 
     raise ToolNotFound(name)
@@ -252,7 +258,14 @@ def _leer(resultado: CallToolResult, name: str, servidor: str) -> Invocation:
     un resultado válido y aquí no habría forma de distinguirlos.
     """
     if resultado.isError:
-        motivo = resultado.content[0].text if resultado.content else "Error desconocido"
+        # El contenido de MCP es una unión —texto, imagen, audio, recurso— y
+        # sólo el de texto tiene `.text`. Leerlo a ciegas funcionaba porque
+        # nuestras tools sólo devuelven texto, pero un servidor ajeno que
+        # respondiera con otra cosa habría reventado aquí en vez de informar.
+        primero = resultado.content[0] if resultado.content else None
+        motivo = (
+            primero.text if isinstance(primero, TextContent) else "Error desconocido"
+        )
         log.warning("tool.execute.failed", tool=name, motivo=motivo)
         return Invocation(server=servidor, result=ToolResult.fail(motivo))
 

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -19,3 +19,25 @@ class ToolResult(BaseModel):
 
     def has_content(self) -> bool:
         return self.success and self.data is not None
+
+    def unwrap(self) -> Any:
+        """El dato, o un fallo explícito si no lo hay.
+
+        `data` es `Any | None` porque un resultado fallido no trae ninguno. El
+        precio lo pagaba quien lo consume: las tools hacían `return
+        response.data` declarando devolver una forma concreta, y los clientes
+        `response.data["clave"]`. Las dos cosas están bien **si el resultado fue
+        bien**, y ninguna lo comprobaba en el mismo sitio donde leía.
+
+        Esto lo convierte en una condición explícita. Lo que cambia no es la
+        seguridad de tipos —el dato sigue siendo `Any`— sino DÓNDE falla: antes
+        un `None` inesperado daba un `TypeError` de subíndice tres marcos más
+        abajo, o un modelo Pydantic quejándose de un campo que no existe. Ahora
+        dice que el resultado venía vacío, y con el motivo del fallo original.
+
+        Añadido en #139, al encender pyright: era la causa de diez de sus
+        veintiséis avisos sobre código servido, todos la misma forma.
+        """
+        if not self.success or self.data is None:
+            raise ValueError(self.error or "El resultado no trae datos.")
+        return self.data

--- a/backend/integrations/discovery.py
+++ b/backend/integrations/discovery.py
@@ -44,6 +44,9 @@ def discover_and_register(mcp: FastMCP) -> DiscoveryResult:
     otras diez herramientas. Es la misma postura que en ``/analyze`` con las
     señales.
     """
+    if __package__ is None:
+        raise RuntimeError("El descubrimiento sólo funciona dentro de un paquete.")
+
     paquete = importlib.import_module(__package__)
     registrados: list[str] = []
     fallidos: dict[str, str] = {}

--- a/backend/integrations/guardian/client.py
+++ b/backend/integrations/guardian/client.py
@@ -63,7 +63,7 @@ class GuardianAPI(BaseAPI):
         if not response.success or not response.has_content():
             return ToolResult.fail("No articles found")
 
-        results = response.data.get("response", {}).get("results")
+        results = response.unwrap().get("response", {}).get("results")
 
         if not results:
             return ToolResult.fail("No articles found")
@@ -85,9 +85,11 @@ class GuardianAPI(BaseAPI):
     # Fix: No coger tags[0] ya que suelen ser niches, para tema principal sistema X/X
     async def _find_tag(self, topic: str) -> str | None:
         result = await self.make_request("tags", "get", {"q": topic, "page-size": 10})
-        if not result.success:
+        # `has_content()` y no `success`: un éxito sin cuerpo llegaba hasta el
+        # `.get` y reventaba con un AttributeError sobre None.
+        if not result.has_content():
             return None
-        tags = result.data.get("response", {}).get("results", [])
+        tags = result.unwrap().get("response", {}).get("results", [])
         if not tags:
             return None
 

--- a/backend/integrations/guardian/tool.py
+++ b/backend/integrations/guardian/tool.py
@@ -58,4 +58,4 @@ def register(mcp: FastMCP):
         response = await api.search_articles(topic, days)
         if not response.has_content():
             raise ToolError(response.error or "Error fetching news")
-        return response.data
+        return response.unwrap()

--- a/backend/integrations/metadata.py
+++ b/backend/integrations/metadata.py
@@ -27,7 +27,12 @@ from typing import Any, Literal
 #
 # Efecto secundario útil: «Señales de análisis» son exactamente las que llevan
 # ficha de modelo, así que la categoría predice si `model_card` viene o no.
-Categoria = Literal["Fuentes de contenido", "Señales de análisis", "Utilidades"]
+Categoria = Literal[
+    "Fuentes de contenido",
+    "Señales de análisis",
+    "Análisis completo",
+    "Utilidades",
+]
 
 # Prefijo de los paquetes de integración, para recortarlo al derivar el origen.
 _PREFIJO = "backend.integrations."

--- a/backend/integrations/nlp/client.py
+++ b/backend/integrations/nlp/client.py
@@ -21,8 +21,10 @@ class HFClient(BaseAPI, NLPBackend):
         if not result.success:
             return result
         try:
-            return ToolResult.ok(result.data[0][0])
-        except (IndexError, KeyError, TypeError):
+            return ToolResult.ok(result.unwrap()[0][0])
+        # `ValueError` lo aporta `unwrap()`: un éxito sin datos es otra forma de
+        # respuesta inesperada, y se informa igual que las demás en vez de subir.
+        except (IndexError, KeyError, TypeError, ValueError):
             return ToolResult.fail(f"Respuesta inesperada de HF: {result.data}")
 
     async def zero_shot(self, text: str, model: str, labels: list[str]) -> ToolResult:
@@ -39,6 +41,6 @@ class HFClient(BaseAPI, NLPBackend):
         if not result.success:
             return result
         try:
-            return ToolResult.ok(result.data[0])
-        except (IndexError, KeyError, TypeError):
+            return ToolResult.ok(result.unwrap()[0])
+        except (IndexError, KeyError, TypeError, ValueError):
             return ToolResult.fail(f"Respuesta inesperada de HF: {result.data}")

--- a/backend/integrations/nlp/dedicated.py
+++ b/backend/integrations/nlp/dedicated.py
@@ -36,9 +36,9 @@ Ver la ficha.
 """
 
 from backend.core.models import ToolResult
-from backend.integrations.nlp.model_cards import cards_by_signal
+from backend.integrations.nlp.model_cards import model_id_de
 
-MODEL = cards_by_signal()["detect_clickbait"]["model_id"]
+MODEL = model_id_de("detect_clickbait")
 
 # El vocabulario del modelo NO sale hacia fuera. La tool MCP publica
 # `clickbait`/`factual news`, que es contrato leído por el LLM (spike #82), y

--- a/backend/integrations/nlp/incoherence.py
+++ b/backend/integrations/nlp/incoherence.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from backend.core.models import ToolResult
-from backend.integrations.nlp.model_cards import cards_by_signal
+from backend.integrations.nlp.model_cards import model_id_de
 
 
 class IncoherenceDetector:
@@ -11,7 +11,7 @@ class IncoherenceDetector:
     # los nombres desnudos en su propia organización—, así que la divergencia no
     # rompía nada y podía sobrevivir indefinidamente mientras la divulgación
     # decía una cosa y el código cargaba otra. Es el caso exacto que motiva #116.
-    MODEL = cards_by_signal()["detect_clickbait_incoherence"]["model_id"]
+    MODEL = model_id_de("detect_clickbait_incoherence")
 
     # Similitud POR DEBAJO de esto = incoherente = posible clickbait. Ojo al
     # sentido, que es el contrario del habitual y confunde a quien lo lee rápido.

--- a/backend/integrations/nlp/incoherence.py
+++ b/backend/integrations/nlp/incoherence.py
@@ -44,7 +44,17 @@ class IncoherenceDetector:
 
     def _get_model(self):
         if self._model is None:
-            from sentence_transformers import SentenceTransformer
+            # `sentence-transformers` vive en `requirements-dev.txt`, no en
+            # `requirements.txt`, porque arrastra torch y wheels de CUDA. El CI
+            # instala sólo el segundo, así que ahí este import NO se puede
+            # resolver y pyright lo dice con razón — en local sí resuelve.
+            #
+            # El import es perezoso justamente por eso: la dependencia sólo hace
+            # falta cuando se usa esta señal, y el resto del sistema arranca sin
+            # ella. El `ignore` declara esa asimetría en vez de esconderla.
+            from sentence_transformers import (  # pyright: ignore[reportMissingImports]
+                SentenceTransformer,
+            )
 
             self._model = SentenceTransformer(self.MODEL)
         return self._model

--- a/backend/integrations/nlp/linear.py
+++ b/backend/integrations/nlp/linear.py
@@ -20,7 +20,7 @@ def featurize_cues(headline) -> list[int]:  # -> vector
 
     categories_list = []
     cue_list = []
-    for match in result.data["matches"]:
+    for match in result.unwrap()["matches"]:
         if match["category"] in lexical.PATTERNS:
             categories_list.append(match["category"])
         else:

--- a/backend/integrations/nlp/local.py
+++ b/backend/integrations/nlp/local.py
@@ -1,23 +1,36 @@
 import asyncio
+from collections.abc import Callable
+from typing import Any
 
 from backend.core.models import ToolResult
 from backend.integrations.nlp.base import NLPBackend
+
+# Lo que devuelve `transformers.pipeline`: algo que se llama con un texto y
+# devuelve su predicción. Se declara así y no como `object` porque `object` no es
+# invocable, y con él `asyncio.to_thread(pipe, text)` era un error de tipos que
+# nadie veía (#139). `Any` en el retorno es honesto: cada tarea devuelve una
+# forma distinta, y quien la lee ya la interpreta a su manera.
+Pipeline = Callable[..., Any]
 
 
 class LocalNLPClient(NLPBackend):
     # Evitamos cargar en cada llamada añadiendo permanencia
     def __init__(self) -> None:
 
-        self._pipelines: dict[tuple[str, str], object] = {}
+        self._pipelines: dict[tuple[str, str], Pipeline] = {}
 
     # Para devolver
 
-    def _get_pipeline(self, task: str, model: str) -> object:
+    def _get_pipeline(self, task: str, model: str) -> Pipeline:
         key = (task, model)
         if key not in self._pipelines:
             from transformers import pipeline
 
-            pipe = pipeline(task, model=model)
+            # `task` llega como `str` y los stubs de transformers declaran una
+            # sobrecarga por cada tarea concreta, así que ninguna casa. No es un
+            # fallo nuestro: el valor sale de las dos llamadas de abajo y las dos
+            # pasan una tarea válida.
+            pipe = pipeline(task, model=model)  # type: ignore[call-overload]
             self._pipelines[key] = pipe
 
         return self._pipelines[key]

--- a/backend/integrations/nlp/local.py
+++ b/backend/integrations/nlp/local.py
@@ -30,7 +30,7 @@ class LocalNLPClient(NLPBackend):
             # sobrecarga por cada tarea concreta, así que ninguna casa. No es un
             # fallo nuestro: el valor sale de las dos llamadas de abajo y las dos
             # pasan una tarea válida.
-            pipe = pipeline(task, model=model)  # type: ignore[call-overload]
+            pipe = pipeline(task, model=model)  # pyright: ignore[reportCallIssue, reportArgumentType]
             self._pipelines[key] = pipe
 
         return self._pipelines[key]

--- a/backend/integrations/nlp/model_cards.py
+++ b/backend/integrations/nlp/model_cards.py
@@ -52,8 +52,28 @@ no significan que el titular engañe. Sin este campo, el backend tendría que
 cablear qué señal es cuál — justo lo que se evita.
 """
 
+from backend.integrations.nlp.outputs import FichaModelo
 
-def cards_by_signal() -> dict[str, dict]:
+
+def model_id_de(signal: str) -> str:
+    """El id de HuggingFace de una señal, exigiendo que lo tenga.
+
+    ``model_id`` es ``None`` a propósito en el léxico y el lineal, que no son un
+    modelo descargable, y ese ``None`` es información. El precio lo pagaba quien
+    lo consume: las señales que sí necesitan un modelo lo leían de la ficha y se
+    lo pasaban al backend NLP sin comprobar nada.
+
+    Si una ficha perdiera su id, hoy el fallo saldría dentro de la llamada HTTP
+    —una URL con ``None`` dentro— y el mensaje no diría de qué señal viene. Aquí
+    dice cuál y por qué. Detectado por pyright en #139.
+    """
+    identificador = cards_by_signal()[signal]["model_id"]
+    if identificador is None:
+        raise ValueError(f"La señal «{signal}» no usa un modelo descargable.")
+    return identificador
+
+
+def cards_by_signal() -> dict[str, FichaModelo]:
     """Índice de fichas por nombre de tool.
 
     Vive aquí y no en quien lo usa porque lo necesitan DOS consumidores —la
@@ -64,7 +84,7 @@ def cards_by_signal() -> dict[str, dict]:
     return {card["signal"]: card for card in MODEL_CARDS}
 
 
-MODEL_CARDS = [
+MODEL_CARDS: list[FichaModelo] = [
     {
         "signal": "detect_clickbait",
         "model_id": "Stremie/roberta-base-clickbait",

--- a/backend/integrations/nlp/tool.py
+++ b/backend/integrations/nlp/tool.py
@@ -60,7 +60,7 @@ def register(mcp: FastMCP):
         response = await dedicated.detect(api, headline)
         if not response.has_content():
             raise ToolError(response.error or "Error al analizar el titular")
-        return response.data
+        return response.unwrap()
 
     @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
@@ -80,10 +80,12 @@ def register(mcp: FastMCP):
         Raises:
             Si la llamada al modelo falla (timeout o caída del proveedor).
         """
-        response = await api.classify(text, _ficha["analyze_sentiment"]["model_id"])
+        response = await api.classify(
+            text, model_cards.model_id_de("analyze_sentiment")
+        )
         if not response.has_content():
             raise ToolError(response.error or "Error al analizar el sentimiento")
-        return response.data
+        return response.unwrap()
 
     @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
@@ -117,7 +119,7 @@ def register(mcp: FastMCP):
             raise ToolError(
                 response.error or "Error al analizar incoherencia en el titular"
             )
-        return response.data
+        return response.unwrap()
 
     @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
@@ -144,7 +146,7 @@ def register(mcp: FastMCP):
         response = lexical.detect(headline)
         if not response.has_content():
             raise ToolError(response.error or "Error al analizar léxico en el titular")
-        return response.data
+        return response.unwrap()
 
     @mcp.tool(meta=tool_meta("Señales de análisis", __name__))
     @log_tool_invocation
@@ -167,7 +169,7 @@ def register(mcp: FastMCP):
         response = linear.predict(headline)
         if not response.has_content():
             raise ToolError(response.error or "Error al predecir clickbait")
-        return response.data
+        return response.unwrap()
 
     # Utilidad, no señal: describe los modelos, no analiza nada. Es el caso que
     # demuestra que la categoría no se puede derivar del paquete.

--- a/backend/integrations/nyt/client.py
+++ b/backend/integrations/nyt/client.py
@@ -63,7 +63,7 @@ class NYTAPI(BaseAPI):
         if not response.success or not response.has_content():
             return ToolResult.fail("No articles found")
 
-        results = response.data.get("response", {}).get("docs")
+        results = response.unwrap().get("response", {}).get("docs")
 
         if not results:
             return ToolResult.fail("No articles found")

--- a/backend/integrations/nyt/tool.py
+++ b/backend/integrations/nyt/tool.py
@@ -62,4 +62,4 @@ def register(mcp: FastMCP):
         response = await api.search_articles(topic, days)
         if not response.has_content():
             raise ToolError(response.error or "Error fetching news")
-        return response.data
+        return response.unwrap()

--- a/backend/integrations/weather/client.py
+++ b/backend/integrations/weather/client.py
@@ -39,7 +39,7 @@ class WeatherAPI(BaseAPI):
             return ToolResult.fail("Unable to find requested zone")
 
         # Eliminamos la URL Base ya que el json contiene la URL completa y no solo el endpoint
-        forecast = points_json.data.get("properties", {}).get("forecast")
+        forecast = points_json.unwrap().get("properties", {}).get("forecast")
         if not forecast:
             return ToolResult.fail("Forecast URL not found")
         points_url = forecast.replace(f"{self.BASE_URL}", "")

--- a/backend/integrations/weather/tool.py
+++ b/backend/integrations/weather/tool.py
@@ -32,7 +32,7 @@ def register(mcp: FastMCP):
         if not response.has_content():
             raise ToolError(response.error or "Error fetching alerts")
 
-        return response.data  # type: ignore
+        return response.unwrap()
 
     @mcp.tool(meta=tool_meta("Fuentes de contenido", __name__))
     @log_tool_invocation
@@ -56,11 +56,11 @@ def register(mcp: FastMCP):
             raise ToolError(zone_url.error or "Unknown error while fetching zone")
 
         # Get the forecast URL from the points response
-        response = await api.get_forecast_API(zone_url.data)  # type: ignore
+        response = await api.get_forecast_API(zone_url.unwrap())
         if not response.has_content():
             raise ToolError(response.error or "Unknown error while retrieving forecast")
 
-        periods = response.data.get("properties", {}).get("periods")  # type: ignore
+        periods = response.unwrap().get("properties", {}).get("periods")
         if not periods:
             raise ToolError("No forecast periods available")
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -350,9 +350,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Get Health Health Get"
+                  "$ref": "#/components/schemas/Salud"
                 }
               }
             }
@@ -782,6 +780,38 @@
         "title": "RetentionPolicy",
         "description": "Política de retención vigente, para que la interfaz no la cablee.\n\nVa en la respuesta porque la pantalla la necesita para dos cosas, y las dos\nson de usabilidad, no de adorno:\n\n1. **Explicar por qué faltan análisis viejos.** La poda es invisible, y eso\n   es justo el problema: quien analizó algo hace cuarenta días y no lo\n   encuentra no piensa «se habrá podado», piensa que la aplicación ha perdido\n   sus datos. Un borrado silencioso se lee como un fallo.\n2. **Acotar el selector de fechas.** Un calendario libre que permita pedir\n   «hace seis meses» y devuelva siempre vacío es una mala experiencia.\n\nY va aquí en vez de como constantes en Angular para que esos números salgan\nde la configuración REAL: cableados, se desincronizarían el día que cambie\nel `.env` y la pantalla seguiría prometiendo 30 días."
       },
+      "Salud": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "degraded",
+              "down"
+            ],
+            "title": "Status"
+          },
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
+          },
+          "integrations": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Sonda"
+            },
+            "type": "object",
+            "title": "Integrations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "timestamp",
+          "integrations"
+        ],
+        "title": "Salud",
+        "description": "Estado agregado del sistema y de cada integración por separado.\n\nSe devuelven las dos cosas a propósito: el agregado sirve para un semáforo,\npero sin el detalle por integración no se puede saber **cuál** falla."
+      },
       "ServerInfo": {
         "properties": {
           "url": {
@@ -928,6 +958,32 @@
         ],
         "title": "SignalType",
         "description": "Naturaleza del modelo. Se muestra como badge en la interfaz.\n\nNo mide cuán complejo es el modelo sino **dónde está la transparencia**:\n``hybrid`` es decisión transparente sobre un rasgo opaco — un umbral legible\naplicado a una similitud de embeddings, por ejemplo."
+      },
+      "Sonda": {
+        "properties": {
+          "reachable": {
+            "type": "boolean",
+            "title": "Reachable"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "reachable",
+          "error"
+        ],
+        "title": "Sonda",
+        "description": "Resultado de sondear una integración."
       },
       "ToolInfo": {
         "properties": {

--- a/frontend/src/app/api/schema.d.ts
+++ b/frontend/src/app/api/schema.d.ts
@@ -518,6 +518,26 @@ export interface components {
             max_days: number;
         };
         /**
+         * Salud
+         * @description Estado agregado del sistema y de cada integración por separado.
+         *
+         *     Se devuelven las dos cosas a propósito: el agregado sirve para un semáforo,
+         *     pero sin el detalle por integración no se puede saber **cuál** falla.
+         */
+        Salud: {
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "ok" | "degraded" | "down";
+            /** Timestamp */
+            timestamp: string;
+            /** Integrations */
+            integrations: {
+                [key: string]: components["schemas"]["Sonda"];
+            };
+        };
+        /**
          * ServerInfo
          * @description Un servidor MCP declarado en la configuración, respondiera o no.
          *
@@ -604,6 +624,16 @@ export interface components {
          * @enum {string}
          */
         SignalType: "interpretable" | "hybrid" | "opaque";
+        /**
+         * Sonda
+         * @description Resultado de sondear una integración.
+         */
+        Sonda: {
+            /** Reachable */
+            reachable: boolean;
+            /** Error */
+            error: string | null;
+        };
         /**
          * ToolInfo
          * @description Una herramienta del catálogo, con su procedencia y sus metadatos.
@@ -936,9 +966,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["Salud"];
                 };
             };
         };

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,33 @@
+{
+  // Configuración de pyright (#139). Se lee también desde el editor: Pylance ES
+  // pyright, así que lo que ve quien escribe es lo mismo que rompe el CI. Ésa
+  // es la razón de elegirlo frente a mypy — no hay dos listas que traducir.
+
+  "include": ["backend"],
+
+  "exclude": [
+    "**/__pycache__",
+
+    // Scripts de investigación de un solo uso. Acumulaban 41 de los 67 avisos
+    // iniciales y escondían los 26 del código servido, que son los que
+    // importan. Mismo criterio que en `.coveragerc`: lo que no se sirve, no
+    // distorsiona el número.
+    "backend/evaluation"
+  ],
+
+  // Sin esto pyright no encuentra las dependencias y produce 33 avisos de
+  // `reportMissingImports` que no son errores de tipos, sólo de configuración.
+  "venvPath": ".",
+  "venv": ".venv",
+
+  // `basic` y no `strict`. Con `strict` habría que anotar cada función y cada
+  // variable del proyecto entero antes de que el CI volviera a pasar, y lo que
+  // se enciende de golpe sobre código existente se acaba ignorando. `basic`
+  // encontró los 26 avisos reales, que ya era lo que se buscaba.
+  //
+  // Subir a `strict` es una decisión posterior y por módulos, con el mismo
+  // criterio que el umbral de cobertura: mirar primero, congelar después.
+  "typeCheckingMode": "basic",
+
+  "pythonVersion": "3.12"
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,3 +20,16 @@ sentence-transformers
 # el CI sin que cambiara una línea de código. El CI lo instala por separado
 # (`pip install ruff==...`) para no meter tooling en las deps de ejecución.
 ruff==0.16.1
+#
+# --- Tipos: comprobador estático (configuración en pyrightconfig.json) ---
+# Pineado por la misma razón que ruff: pyright afina reglas entre versiones, y
+# sin fijarla el CI fallaría sin que cambiara una línea de código. El CI también
+# lo instala por separado.
+#
+# Se eligió pyright y no mypy porque **Pylance ES pyright**: lo que ve quien
+# escribe en el editor es exactamente lo que rompe el CI, en vez de dos listas
+# parecidas que hay que traducir.
+#
+# Ojo al instalarlo: el paquete de pip descarga un runtime de Node la primera
+# vez (~50 MB) y lo cachea en `~/.cache/pyright-python`.
+pyright==1.1.411


### PR DESCRIPTION
## #139 · El comprobador de tipos ya corría, y el repositorio no se enteraba

Closes #139

`CLAUDE.md` daba esta issue por pendiente desde hacía semanas. Al ir a escribirla se vio que la herramienta **ya estaba funcionando**: es Pylance —o sea Pyright— dentro del editor. Lo que faltaba no era el comprobador, era que el repositorio lo ejecutara.

De ahí la decisión menos obvia: **Pyright y no mypy**. Adoptar en el CI lo mismo que ya corre en el editor significa que los avisos que aparecen al escribir son los que rompen la corrida, y no dos listas parecidas que hay que traducir.

Segunda de las tres issues que buscan fallos que hoy no se manifiestan, junto a #138 y #140.

### Qué incluye

- **`pyrightconfig.json`** *(nuevo)* — modo `basic`, `backend/evaluation` excluido, `venvPath` para el trabajo local y el editor.
- **`.github/workflows/ci.yml`** — paso propio, después del estilo. `--pythonpath $(which python)` porque en el runner no hay `.venv`.
- **`requirements-dev.txt`** — `pyright==1.1.411`, pineado por lo mismo que ruff.
- **26 correcciones** en código servido, y **0 avisos** al terminar.

### El número, otra vez distorsionado por `evaluation/`

67 avisos en total. **41 estaban en `backend/evaluation/`**, y escondían los 26 del código servido, que son los únicos accionables. Se excluye por el mismo criterio que en #138: lo que no se sirve, no distorsiona el número.

Y `basic`, no `strict`. Con `strict` habría que anotar el proyecto entero antes de que el CI volviera a pasar, y lo que se enciende de golpe sobre código existente se acaba ignorando.

### Los 26 no eran ruido

**Seis bugs latentes:**

| Dónde | Qué |
|---|---|
| `core/logging.py` | `if/elif` sin `else` sobre un `Literal`. Si se añade un tercer formato, `renderer` queda **sin asignar** y la línea siguiente revienta con un `UnboundLocalError` que no dice nada del problema |
| `core/base_api.py` | `make_request` declara `-> ToolResult` y tenía un camino que caía por el final devolviendo `None`. Quien llamara haría `.success` sobre él |
| `api/history.py` | `cursor.lastrowid` es `int \| None` y la firma prometía `int` |
| `integrations/metadata.py` | `analysis/tool.py` usa la categoría `"Análisis completo"`, que **no estaba en el `Literal` `Categoria`**. El comentario de esa tool explica por qué no es «Señales de análisis»; el vocabulario declarado nunca se actualizó |
| `model_cards.py` | `model_id` es `None` a propósito en el léxico y el lineal, y se pasaba a `classify(model: str)` sin comprobar. Una ficha sin id habría fallado dentro de una llamada HTTP, con una URL que lleva `None` dentro |
| `core/mcp/tools.py` | el contenido de una respuesta MCP es una **unión** —texto, imagen, audio, recurso— y se leía `.text` a ciegas. Un servidor ajeno que respondiera otra cosa habría reventado en vez de informar |

Ninguno se manifiesta hoy. Todos se manifestarían el día que cambiara algo, y ninguno con un mensaje que apuntara a su causa.

### Un solo patrón explicaba diez avisos

`ToolResult.data` es `Any | None`, porque un resultado fallido no trae ninguno. El precio lo pagaba quien lo consume: las tools hacían `return response.data` declarando devolver una forma concreta, y los clientes `response.data["clave"]`. Las dos cosas están bien **si el resultado fue bien**, y ninguna lo comprobaba en el mismo sitio donde leía.

```python
def unwrap(self) -> Any:
    if not self.success or self.data is None:
        raise ValueError(self.error or "El resultado no trae datos.")
    return self.data
```

Lo que cambia no es la seguridad de tipos —el dato sigue siendo `Any`— sino **dónde falla**. Antes un `None` inesperado daba un `TypeError` de subíndice tres marcos más abajo, o un modelo Pydantic quejándose de un campo que no existe.

Y en dos sitios había algo más que un tipo impreciso: `nlp/linear.py` leía `result.data["matches"]` **sin comprobar nada**, y `guardian/_find_tag` comprobaba `success` pero no el contenido, así que un éxito sin cuerpo llegaba al `.get` y reventaba sobre `None`.

### La invariante que vivía a noventa líneas de distancia

El aviso que destapó todo esto era el que aparecía en el editor:

> Argument of type `str | None` cannot be assigned to parameter `content` of type `str` in function `detect`

El código es correcto: el orquestador desvía la señal de incoherencia a `not_applicable` antes de llamarla, si no hay cuerpo. Pero **esa garantía vive en un `bool` de una tabla de constantes, comprobado noventa líneas por debajo del sitio que depende de él**. Ningún comprobador puede unir esos dos puntos, y ningún lector de un vistazo tampoco.

Y el modo de fallo, si alguien pusiera `needs_content=False` en esa entrada, era el peor posible: el guardia dejaría de correr, el detector reventaría al medir la longitud de `None`, y el aislamiento de fallos lo convertiría en una señal en estado `error`. Sin excepción que suba, sin test rojo.

Ahora la garantía se escribe donde se usa, con un `_con_cuerpo()` que falla diciendo qué pasó.

### Los cuatro `# type: ignore` eran reales

Había cuatro, puestos por alguien que veía los avisos en su editor. Sin comprobador instalado eran **comentarios inertes**, y nadie sabía si seguían haciendo falta.

Comprobado quitándolos: los cuatro suprimían errores de verdad. Tres eran el patrón de `.data` y desaparecieron al usar `unwrap()`. El cuarto —`Settings()` sin argumentos, que pydantic-settings rellena desde el entorno— se queda.

Y ahí apareció algo que merece constar, porque **la primera versión de esta PR lo decía mal**. Se dio por bueno que `# type: ignore[call-arg]` acotaba la supresión a esa regla. No lo hace: **pyright ignora el contenido del corchete** en esa forma. Medido poniendo una regla inventada —`# type: ignore[reglaInventada]`— y comprobando que suprime igual.

La forma que sí acota es la suya, `# pyright: ignore[reportCallIssue]`. Medido también al revés, que es la prueba que vale: con una regla **equivocada pero real**, el error vuelve a salir.

Importa porque un `ignore` sin regla efectiva silencia **cualquier error futuro de esa línea**, incluido uno que no tenga nada que ver con el que se quería tapar.

### Lo que se silencia, y por qué

Quedan dos más, y ninguno es un fallo nuestro. En `nlp/local.py`, los *stubs* de `transformers` declaran una sobrecarga de `pipeline` por cada tarea concreta y aquí la tarea llega como `str`.

En `nlp/incoherence.py`, el import de `sentence-transformers`. **Ése lo destapó el CI, no el trabajo local:** la dependencia vive en `requirements-dev.txt` porque arrastra torch y wheels de CUDA, y el CI instala sólo `requirements.txt`. En local resolvía; en el runner, no. Es la asimetría que hace que el import sea perezoso, y el `ignore` la declara en vez de esconderla.

De paso apareció uno que sí lo era: la caché de pipelines se declaraba `dict[..., object]`, y `object` no es invocable — así que `asyncio.to_thread(pipe, text)` era un error de tipos que nadie veía. Con `Callable[..., Any]` desaparecen cuatro avisos y el tipo dice la verdad.

### Un cambio de contrato, dicho en voz alta

`GET /health` declaraba devolver `dict` y devuelve un `Salud`. Corregirlo tiene una consecuencia buscada: **la forma pasa a publicarse en el contrato OpenAPI**, así que `openapi.json` gana `Salud` y `Sonda` —59 líneas— y el frontend recibirá el estado del sistema tipado en vez de como objeto libre cuando llegue #128.

Es un cambio de contrato dentro de una PR de análisis estático. Se deja aquí por decisión explícita, y queda anotado en vez de pasar desapercibido entre las correcciones de tipos.

### Verificación

**0 errores de pyright**, 215 tests y ruff limpio. El comando es el mismo en local y en el editor, porque la configuración vive en `pyrightconfig.json`:

```bash
pyright
```

### Notas

- **Un comprobador de tipos no encuentra errores de lógica.** No habría detectado que dos señales de forma eran la misma (#109), ni que un umbral estaba a ojo (#92), ni que un corpus era otro reempaquetado (#121). Encuentra desajustes entre lo que una función promete y lo que recibe — una franja estrecha, pero es justo la que los tests no cubren, porque un test sólo recorre el camino que alguien pensó en escribir.
- **Subir a `strict` es una decisión posterior y por módulos**, con el mismo criterio que el umbral de cobertura: mirar primero, congelar después.
- **El frontend queda fuera**: no tiene linter, y eso es #140.
- El paquete de pip de pyright descarga un runtime de Node la primera vez (~50 MB) y lo cachea en `~/.cache/pyright-python`. En el CI eso es una descarga por corrida.
- El log del CI lleva un `venv .venv subdirectory not found`: es **esperado**. Pyright valida el `venvPath` de la configuración aunque `--pythonpath` lo sustituya, y quitarlo del fichero costaría 43 avisos en local, que es donde ese `.venv` sí existe.
