### PR TITLE
feat(web): pantalla de Sistema con el formulario generado desde el esquema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,195 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### El catálogo se pinta solo: el formulario sale del esquema (#128)
+
+La pantalla de Sistema responde tres preguntas —qué servidores hay conectados
+(R6.11), qué herramientas ofrecen (R6.2, R6.9) y qué modelo hay detrás de cada
+señal (R3.8)— y el backend las servía enteras desde #97 y #137. Lo que faltaba
+era el consumidor.
+
+El riesgo de la issue nunca fue construir la pantalla. Era construirla
+**cableando las doce herramientas**: un formulario escrito a mano por tool, que
+funciona el primer día y convierte cada herramienta nueva en trabajo de
+frontend. Eso incumple R1.9, y de paso vacía de sentido que el catálogo se
+construya por *handshake* — daría igual descubrir lo que hay conectado si la
+interfaz sólo sabe pintar lo que alguien ya había previsto.
+
+#### `camposDe`: el fichero donde está la decisión
+
+`frontend/src/app/sistema/campos.ts` lee el `input_schema` que publica el
+catálogo y devuelve una lista de descriptores. No depende de Angular, así que se
+prueba con datos y sin montar nada; y no conoce ninguna herramienta, así que
+añadir una al backend no lo toca.
+
+Antes de escribir una línea se midieron los esquemas reales contra
+`mcp.list_tools()`: **ocho `string`, tres opcionales, dos `integer` con
+`minimum`/`maximum`/`default` y dos `number`**. Ni enums, ni arrays, ni objetos
+anidados. `describe_models` y `health_check` no tienen parámetros: son sólo un
+botón.
+
+La trampa estaba en esos tres opcionales. Un parámetro de Python como
+`topic: str | None = None` **no se publica como `{"type": "string"}`**, sino
+como `{"anyOf": [{"type": "string"}, {"type": "null"}], "default": null}`. Un
+lector que sólo mirara `type` los habría marcado como desconocidos y la pantalla
+los habría pintado en crudo sin ningún motivo. El `anyOf` se resuelve
+descartando el `null` y exigiendo que quede **exactamente un** tipo: una unión
+de verdad —`str | int`— no se sabe pintar con un solo control, y sigue siendo
+desconocida a propósito.
+
+El catálogo publica el esquema **crudo, sin aplanar**, y ésta es la razón: los
+topes y los valores por defecto son justo lo que la interfaz necesita para
+validar antes de enviar. `days` llega con su 1, su 30 y su 7, y los tres viajan
+al control y al validador.
+
+#### Lo que no se sabe pintar se enseña, no se omite
+
+Omitir un campo desconocido es lo cómodo y produce el peor fallo posible: el
+formulario mandaría un cuerpo incompleto, el backend respondería **422** —valida
+contra el `input_schema` desde #100— y quien mirara leería «la petición no es
+válida» sin ninguna forma de saber qué campo falta, porque ese campo nunca se
+dibujó. Se enseña con su esquema delante. Es la misma regla que el `@default` de
+`senal-card` con las señales que no conoce: feo, pero visible.
+
+Al implementarlo apareció un matiz que la planificación no tenía. Bloquear el
+botón cuando hay un campo desconocido es aplicar R6.14 —la interfaz no debe
+dejar controles que no funcionen—, pero **sólo vale si ese campo es
+obligatorio**. Uno opcional no impide una petición válida: la herramienta tira
+con sus valores por defecto y lo único que se pierde es poder tocar ese
+parámetro. Desactivar ahí sería quitar una función que sí sirve. Los dos casos
+tienen test.
+
+Y una distinción que ya costó una decisión en `/analyze`: **lo vacío se omite,
+no se manda como `""`**. Omitir es «usa tu valor por defecto»; la cadena vacía
+es una búsqueda de la cadena vacía. Un booleano nunca está vacío, así que
+siempre viaja.
+
+#### La ficha de modelo publicaba tres de sus siete campos
+
+`ToolModelCard` llevaba `type`, `dimension` y `limitations`. `name`, `task` y
+`model_id` se quedaban en el backend, en `model_cards.py`.
+
+O sea: el catálogo podía decir que `detect_clickbait_linear` es interpretable y
+mide forma, pero no **qué es** ni **qué hace**. La pantalla habría enseñado el
+identificador de máquina como si fuera el nombre — exactamente lo que #133 quitó
+de la pantalla de análisis al hacer viajar `label`. Se añaden los tres, y con
+ellos el `model_id: null` del léxico y el lineal, que **es información y no un
+hueco**: dice que esa señal es código propio y auditable, no un modelo
+descargable.
+
+Los tests nuevos de `test_catalog.py` comparan contra `cards_by_signal()` y no
+contra cadenas escritas a mano, más un `assert "detect_clickbait_lexical" not in
+ficha.name` que fija lo único que importaba: que el nombre de la ficha no es el
+de la tool.
+
+#### Tres canales, y fundirlos sería mentir
+
+| Qué ha pasado | Por dónde llega | Qué se enseña |
+|---|---|---|
+| Un servidor MCP no responde | 200, `status: unreachable` | Sale en la lista con su motivo |
+| La herramienta se ejecutó y falló | 200, `status: error` | Su `detail`, que es lo accionable |
+| 404 · 422 · 504 | canal de error | Mensaje propio por código |
+
+Los dos primeros son 200 porque **la petición era válida y el servidor la
+atendió**: lo que falló es otra cosa. Es la misma decisión que deja a `/analyze`
+responder 200 con una señal caída, y tiene una consecuencia para quien consume:
+dar por bueno todo lo que llega por `next` enseñaría un resultado vacío como si
+fuera correcto.
+
+Del tercer grupo, el **504** es el que más importa separar. No dice que la
+herramienta fallara: dice que se agotó la espera, y en #113 quedó medido que
+puede haber terminado bien —a los 151 s, con la API ya desistida—. El mensaje lo
+dice, y avisa de que repetir la llamada la ejecutaría otra vez.
+
+#### Las categorías del filtro salen del catálogo
+
+El desplegable se construye con un `Set` sobre lo que trae la respuesta, no con
+las cuatro categorías de `integrations/metadata.py` copiadas aquí. Es la misma
+razón que el formulario generado: si aparece una quinta, el filtro la ofrece sin
+tocar el frontend. El test lo comprueba comparando el desplegable contra el
+catálogo del fixture.
+
+El filtrado se resuelve en cliente porque son doce herramientas y ya están
+todas en memoria; volver a pedir sería una petición por tecla para reordenar una
+lista que cabe en la pantalla.
+
+#### Los tipos de las dos rutas nuevas, otra vez de `paths`
+
+`CatalogResult`, `ExecuteBody` y `ExecuteResult` se derivan de
+`paths['/tools']` y `paths['/tools/{name}/execute']`, no de `components`. Es la
+convención que salió de #133 aplicada al primer servicio escrito después de
+ella. La clave es la **plantilla literal** con `{name}` dentro: lo que está en
+el contrato es la ruta, no cada invocación.
+
+Las piezas de dentro —`ServerInfo`, `ToolInfo`, `ToolModelCard`— siguen viniendo
+de `components`, porque son formas con nombre propio que se pasan sueltas a los
+componentes que las pintan. La regla, dicha corta: **si el tipo cruza la red, lo
+elige la ruta; si el valor ya está dentro, lo elige el esquema**. De paso
+desaparecen tres alias que ya no usaba nadie (`CatalogResponse`,
+`ExecuteRequest`, `ExecuteResponse`): dos nombres para la misma forma son la
+condición que hace que alguien elija el que no ata.
+
+#### Dos cosas que ya no eran de ninguna pantalla
+
+`api/base.ts` guarda el prefijo `/api`. Estaba dentro de `analyze.service.ts`, y
+con dos servicios repetirlo significa que cambiar el prefijo tiene que acertar
+en los dos — y el que se olvidara seguiría compilando.
+
+`api/errores.ts` guarda la lectura del cuerpo de un 422 de FastAPI y el mensaje
+de «no contesta nadie». Los mensajes siguen siendo de cada pantalla, porque el
+análisis y el catálogo dicen cosas distintas del mismo código; lo que no es de
+ninguna es **leer el cuerpo**.
+
+#### El buscador, y qué significa «igual»
+
+La búsqueda normaliza los dos lados de la comparación, y por eso quitar
+diacríticos sólo puede **sumar** coincidencias: lo que encajaba antes sigue
+encajando. El riesgo no es dejar de encontrar algo, es que dos palabras
+distintas colapsen en la misma.
+
+Caen todos los diacríticos, **la ñ incluida**. No es un descuido: `ñ` se
+descompone en `n` + tilde combinante igual que `á` en `a` + acento, y
+conservarla exigiría protegerla aparte. Medido sobre las docstrings del catálogo
+—las únicas palabras con ñ son `señal`, `señales`, `engaño`, `añade`, `añadir` y
+`pestañas`— ninguna colisiona con otra al perder la tilde. La alternativa
+lingüísticamente correcta —la ñ es una letra, no una n con adorno— dejaría una
+asimetría difícil de explicar en pantalla: `analisis` encontraría `Análisis`,
+pero `senal` no encontraría `Señal`.
+
+#### `Validators.required` da por bueno un campo con espacios
+
+ESLint con información de tipos avisó de `unbound-method` al pasar
+`Validators.required` suelto a un array de validadores. Mirarlo en vez de
+silenciarlo dio dos razones para no usarlo, y la primera no tiene que ver con el
+aviso: **acepta un campo lleno de espacios**, cuando el proyecto ya decidió lo
+contrario para el titular de `/analyze`. El validador propio son cinco líneas y
+cubre `null`, `''` y sólo-espacios. Sin `ignore`.
+
+#### Lo que no está aquí
+
+- **La salud de las APIs externas.** `GET /health` sondea Weather, Guardian y
+  NYT, y no lo consume ninguna pantalla. Es otra pregunta que la de R6.11 —lo
+  que el sistema *es* frente a lo que ahora mismo *funciona*—, y mezclarlas en
+  esta pantalla habría sido cómodo y confuso. Queda como **#147**, con la
+  decisión de dónde vive sin tomar.
+- **El transporte de R6.11.** El contrato no publica un campo `transport`, y
+  añadirlo por una etiqueta no compensa: la URL lo dice, y hoy todos los
+  servidores son HTTP *streamable*. Se enseña la URL.
+- **El comportamiento en pantallas estrechas**, que es #130.
+
+#### Medido
+
+- **60 tests de frontend** (35 nuevos: 7 del lector de esquemas, 7 del servicio,
+  9 del formulario, 11 de la pantalla y 1 de la cáscara), lint limpio con reglas
+  de tipos y de accesibilidad.
+- La pantalla sale como **fragmento aparte de 21,69 kB** en el empaquetado, que
+  es la primera vez que la carga diferida preparada en #126 se nota en la salida
+  del *bundler* en vez de sólo en el código.
+- `tool_count` es **obligatorio incluso en un servidor `unreachable`**: tiene
+  `default: 0` en el backend y el contrato generado lo publica siempre presente.
+  Lo destapó un fixture que no compilaba, y dice lo correcto —cero herramientas,
+  no dato ausente—, pero no se habría escrito así a mano.
+
 ### El frontend crecía sin linter, y la accesibilidad dependía de la memoria (#140)
 
 `ng new` de Angular 22 no añade ESLint, y no se añadió después. Lo único que

--- a/backend/api/catalog.py
+++ b/backend/api/catalog.py
@@ -119,6 +119,9 @@ def _ficha_de(nombre: str) -> ToolModelCard | None:
         return None
 
     return ToolModelCard(
+        name=card["name"],
+        task=card["task"],
+        model_id=card["model_id"],
         type=SignalType(card["type"]),
         dimension=Dimension(card["dimension"]),
         limitations=card["limitations"],

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -124,7 +124,27 @@ class ToolModelCard(BaseModel):
     análisis» y esconda que es interpretable, que mide forma y que su F1 cae
     fuera de dominio. Reutiliza los enums de las señales en vez de duplicar
     cadenas sueltas.
+
+    Publicaba tres de los siete campos de la ficha hasta #128, y con eso la
+    pantalla no podía enseñar ni cómo se llama el modelo ni qué hace: seguía
+    diciendo «detect_clickbait_linear», que es justo lo que este tipo existe para
+    evitar. El dato estaba en ``MODEL_CARDS`` y no salía — la misma forma que los
+    cuatro huecos de #133.
     """
+
+    name: str = Field(
+        description="Etiqueta para personas: «Modelo lineal interpretable (…)»."
+    )
+    task: str = Field(description="Qué hace, en una frase.")
+    model_id: str | None = Field(
+        default=None,
+        description=(
+            "Identificador en HuggingFace del modelo que hay detrás. `null` en "
+            "el léxico y el lineal, que no son un modelo descargable — y ese "
+            "`null` es información, no un hueco: dice que la señal es código "
+            "propio y auditable."
+        ),
+    )
 
     type: SignalType
     dimension: Dimension

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1061,6 +1061,28 @@
       },
       "ToolModelCard": {
         "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Etiqueta para personas: «Modelo lineal interpretable (…)»."
+          },
+          "task": {
+            "type": "string",
+            "title": "Task",
+            "description": "Qué hace, en una frase."
+          },
+          "model_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Id",
+            "description": "Identificador en HuggingFace del modelo que hay detrás. `null` en el léxico y el lineal, que no son un modelo descargable — y ese `null` es información, no un hueco: dice que la señal es código propio y auditable."
+          },
           "type": {
             "$ref": "#/components/schemas/SignalType"
           },
@@ -1077,12 +1099,14 @@
         },
         "type": "object",
         "required": [
+          "name",
+          "task",
           "type",
           "dimension",
           "limitations"
         ],
         "title": "ToolModelCard",
-        "description": "Ficha del modelo que hay detrás de una señal de análisis.\n\nEs lo que evita que el catálogo enseñe «detect_clickbait_linear — Señales de\nanálisis» y esconda que es interpretable, que mide forma y que su F1 cae\nfuera de dominio. Reutiliza los enums de las señales en vez de duplicar\ncadenas sueltas."
+        "description": "Ficha del modelo que hay detrás de una señal de análisis.\n\nEs lo que evita que el catálogo enseñe «detect_clickbait_linear — Señales de\nanálisis» y esconda que es interpretable, que mide forma y que su F1 cae\nfuera de dominio. Reutiliza los enums de las señales en vez de duplicar\ncadenas sueltas.\n\nPublicaba tres de los siete campos de la ficha hasta #128, y con eso la\npantalla no podía enseñar ni cómo se llama el modelo ni qué hace: seguía\ndiciendo «detect_clickbait_linear», que es justo lo que este tipo existe para\nevitar. El dato estaba en ``MODEL_CARDS`` y no salía — la misma forma que los\ncuatro huecos de #133."
       },
       "ValidationError": {
         "properties": {

--- a/frontend/src/app/analisis/errores.ts
+++ b/frontend/src/app/analisis/errores.ts
@@ -1,37 +1,16 @@
 import { HttpErrorResponse } from '@angular/common/http';
 
-/**
- * El primer mensaje de un 422 de FastAPI, si el cuerpo tiene esa forma.
- *
- * FastAPI responde `{"detail": [{"loc", "msg", "type"}]}`, pero `fallo.error`
- * es `any` y **un proxy puede colar una página HTML por ahí**. Antes se
- * encadenaba con `?.` sobre ese `any`, que funciona pero apaga el tipado: el
- * resultado también era `any`, y a partir de ahí nada se comprobaba.
- *
- * Se comprueba en vez de castear, que es la regla de esta interfaz — la misma
- * que gobierna los guardianes del `data` en `datos.ts`. Lo destapó ESLint con
- * información de tipos (#140), como `no-unsafe-member-access`.
- */
-function detalleDeValidacion(cuerpo: unknown): string | null {
-  if (typeof cuerpo !== 'object' || cuerpo === null) return null;
-
-  const { detail } = cuerpo as { detail?: unknown };
-  if (!Array.isArray(detail) || detail.length === 0) return null;
-
-  const primero = detail[0] as { msg?: unknown };
-  return typeof primero?.msg === 'string' ? primero.msg : null;
-}
+import { detalleDeValidacion, SIN_RESPUESTA } from '../api/errores';
 
 /**
  * Traduce el fallo a algo que se pueda leer (R6.7).
  *
- * `status 0` no es un código HTTP: la petición no llegó a salir o no contestó
- * nadie. Separarlo importa porque el remedio que le das al usuario es otro.
+ * Los mensajes son de ESTA pantalla: hablan de analizar un titular. Lo que se
+ * lee del cuerpo, y el caso de que no conteste nadie, viven en `api/errores.ts`
+ * porque los comparte con el catálogo, que dice otras cosas de lo mismo.
  */
 export function mensajeDeError(fallo: HttpErrorResponse): string {
-  if (fallo.status === 0) {
-    return 'No se pudo contactar con la API. Comprueba que está arrancada en el puerto 8000.';
-  }
+  if (fallo.status === 0) return SIN_RESPUESTA;
   if (fallo.status === 422) {
     const detalle = detalleDeValidacion(fallo.error);
     return detalle

--- a/frontend/src/app/api/analyze.service.ts
+++ b/frontend/src/app/api/analyze.service.ts
@@ -11,17 +11,8 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
+import { API } from './base';
 import type { AnalyzeRequest, AnalyzeResult } from './models';
-
-/**
- * Prefijo de la API. NO es la dirección del backend, y esa es la gracia.
- *
- * En desarrollo `proxy.conf.json` reenvía `/api/*` a `http://127.0.0.1:8000`
- * quitando el prefijo; en despliegue lo hará nginx (decisión tomada para H4).
- * Para el navegador todo sale del MISMO origen, así que no hay CORS ni
- * preflight, y la SPA no tiene que saber dónde vive la API en cada entorno.
- */
-const API = '/api';
 
 @Injectable({ providedIn: 'root' })
 export class AnalyzeService {

--- a/frontend/src/app/api/base.ts
+++ b/frontend/src/app/api/base.ts
@@ -1,0 +1,13 @@
+/**
+ * Prefijo de la API. NO es la dirección del backend, y esa es la gracia.
+ *
+ * En desarrollo `proxy.conf.json` reenvía `/api/*` a `http://127.0.0.1:8000`
+ * quitando el prefijo; en despliegue lo hará nginx (decisión tomada para H4).
+ * Para el navegador todo sale del MISMO origen, así que no hay CORS ni
+ * preflight, y la SPA no tiene que saber dónde vive la API en cada entorno.
+ *
+ * Vive suelto desde que hay dos servicios (#128): repetido en cada uno, cambiar
+ * el prefijo obligaría a acertar en todos, y el que se olvidara seguiría
+ * compilando.
+ */
+export const API = '/api';

--- a/frontend/src/app/api/errores.ts
+++ b/frontend/src/app/api/errores.ts
@@ -1,0 +1,41 @@
+/**
+ * Lo que se puede leer del cuerpo de un error HTTP.
+ *
+ * Vive en `api/` y no en una pantalla porque no es de ninguna: es la forma en
+ * que FastAPI cuenta qué no le encaja, y la usan el análisis (titular en
+ * blanco) y el catálogo (argumentos que no cumplen el `input_schema`) para
+ * decir cosas distintas. El MENSAJE es de cada pantalla; leer el cuerpo, no.
+ */
+
+/**
+ * El primer mensaje de un 422 de FastAPI, si el cuerpo tiene esa forma.
+ *
+ * FastAPI responde `{"detail": [{"loc", "msg", "type"}]}`, pero `fallo.error`
+ * es `any` y **un proxy puede colar una página HTML por ahí**. Antes se
+ * encadenaba con `?.` sobre ese `any`, que funciona pero apaga el tipado: el
+ * resultado también era `any`, y a partir de ahí nada se comprobaba.
+ *
+ * Se comprueba en vez de castear, que es la regla de esta interfaz — la misma
+ * que gobierna los guardianes del `data` en `analisis/datos.ts`. Lo destapó
+ * ESLint con información de tipos (#140), como `no-unsafe-member-access`.
+ */
+export function detalleDeValidacion(cuerpo: unknown): string | null {
+  if (typeof cuerpo !== 'object' || cuerpo === null) return null;
+
+  const { detail } = cuerpo as { detail?: unknown };
+  if (!Array.isArray(detail) || detail.length === 0) return null;
+
+  const primero = detail[0] as { msg?: unknown };
+  return typeof primero?.msg === 'string' ? primero.msg : null;
+}
+
+/**
+ * Mensaje de lo que no depende de la pantalla: la petición no salió, o no
+ * contestó nadie.
+ *
+ * `status 0` no es un código HTTP. Separarlo importa porque el remedio que le
+ * das a quien mira es otro: no es un fallo del análisis ni del catálogo, es que
+ * no hay API al otro lado.
+ */
+export const SIN_RESPUESTA =
+  'No se pudo contactar con la API.';

--- a/frontend/src/app/api/models.ts
+++ b/frontend/src/app/api/models.ts
@@ -66,22 +66,42 @@ export type SignalStatus = Esquemas['SignalStatus'];
 export type SignalType = Esquemas['SignalType'];
 
 // --- Catálogo de herramientas (GET /tools) ---
-export type CatalogResponse = Esquemas['CatalogResponse'];
+//
+// Lo que devuelve la RUTA sale de `paths`, igual que en `/analyze`.
+// `CatalogResponse` existe como esquema y hoy coincide, pero nombrarlo a mano
+// volvería a dejar la respuesta sin atar a la ruta.
+type Tools = paths['/tools']['get'];
+export type CatalogResult = Tools['responses'][200]['content']['application/json'];
+
+// Las piezas de dentro sí vienen de `components`: son esquemas por derecho
+// propio, y llegan sueltas a los componentes que las pintan.
 export type ServerInfo = Esquemas['ServerInfo'];
 export type ServerStatus = Esquemas['ServerStatus'];
 export type ToolInfo = Esquemas['ToolInfo'];
 export type ToolModelCard = Esquemas['ToolModelCard'];
-export type Origin = Esquemas['Origin'];
 
-// --- Ejecución directa de una herramienta (POST /execute) ---
-export type ExecuteRequest = Esquemas['ExecuteRequest'];
-export type ExecuteResponse = Esquemas['ExecuteResponse'];
+// --- Ejecución de una herramienta (POST /tools/{name}/execute) ---
+//
+// La clave de `paths` es la PLANTILLA literal, con `{name}` dentro, y no la URL
+// ya sustituida: lo que está en el contrato es la ruta, no cada invocación.
+type Execute = paths['/tools/{name}/execute']['post'];
+export type ExecuteBody = Execute['requestBody']['content']['application/json'];
+export type ExecuteResult = Execute['responses'][200]['content']['application/json'];
+
+// Los argumentos son un diccionario libre —cada herramienta tiene los suyos, y
+// la forma buena la publica su `input_schema`—, así que se comprueban en
+// ejecución como el `data` de una señal. Se deriva en vez de escribirlo a mano
+// para que un cambio del contrato llegue hasta aquí, y `NonNullable` porque la
+// clave es opcional en el contrato pero el servicio siempre la manda.
+export type Argumentos = NonNullable<ExecuteBody['arguments']>;
+
 export type ExecuteStatus = Esquemas['ExecuteStatus'];
 
 // --- Historial (GET /history) ---
 export type HistoryPage = Esquemas['HistoryPage'];
 export type HistoryEntry = Esquemas['HistoryEntry'];
 export type HistoryKind = Esquemas['HistoryKind'];
+export type Origin = Esquemas['Origin'];
 export type RetentionPolicy = Esquemas['RetentionPolicy'];
 
 // --- Errores de validación de FastAPI (422) ---

--- a/frontend/src/app/api/schema.d.ts
+++ b/frontend/src/app/api/schema.d.ts
@@ -679,8 +679,29 @@ export interface components {
          *     análisis» y esconda que es interpretable, que mide forma y que su F1 cae
          *     fuera de dominio. Reutiliza los enums de las señales en vez de duplicar
          *     cadenas sueltas.
+         *
+         *     Publicaba tres de los siete campos de la ficha hasta #128, y con eso la
+         *     pantalla no podía enseñar ni cómo se llama el modelo ni qué hace: seguía
+         *     diciendo «detect_clickbait_linear», que es justo lo que este tipo existe para
+         *     evitar. El dato estaba en ``MODEL_CARDS`` y no salía — la misma forma que los
+         *     cuatro huecos de #133.
          */
         ToolModelCard: {
+            /**
+             * Name
+             * @description Etiqueta para personas: «Modelo lineal interpretable (…)».
+             */
+            name: string;
+            /**
+             * Task
+             * @description Qué hace, en una frase.
+             */
+            task: string;
+            /**
+             * Model Id
+             * @description Identificador en HuggingFace del modelo que hay detrás. `null` en el léxico y el lineal, que no son un modelo descargable — y ese `null` es información, no un hueco: dice que la señal es código propio y auditable.
+             */
+            model_id?: string | null;
             type: components["schemas"]["SignalType"];
             dimension: components["schemas"]["Dimension"];
             /** Limitations */

--- a/frontend/src/app/api/tools.service.spec.ts
+++ b/frontend/src/app/api/tools.service.spec.ts
@@ -1,0 +1,167 @@
+import { provideHttpClient, HttpErrorResponse } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import type { CatalogResult, ExecuteResult } from './models';
+import { ToolsService } from './tools.service';
+
+/**
+ * Catálogo con un servidor sano y otro caído, que es el caso que hay que tener
+ * delante: llega por el canal de éxito, con el motivo dentro, y las
+ * herramientas del que sí respondió se sirven igual.
+ */
+const CATALOGO: CatalogResult = {
+  servers: [
+    { url: 'http://127.0.0.1:8010/mcp', name: 'tfg', status: 'ok', tool_count: 1 },
+    {
+      url: 'http://127.0.0.1:8011/mcp',
+      status: 'unreachable',
+      // Lo publica el contrato aunque no responda: cero herramientas, no
+      // ausencia de dato.
+      tool_count: 0,
+      detail: 'ConnectError: All connection attempts failed',
+    },
+  ],
+  tools: [
+    {
+      name: 'detect_clickbait_lexical',
+      description: 'Detecta clickbait por vocabulario.',
+      input_schema: {
+        type: 'object',
+        properties: { headline: { type: 'string' } },
+        required: ['headline'],
+      },
+      server: 'tfg',
+    },
+  ],
+  degraded: true,
+};
+
+describe('ToolsService', () => {
+  let servicio: ToolsService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    servicio = TestBed.inject(ToolsService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('pide el catálogo a /api/tools por GET', () => {
+    servicio.catalogo().subscribe();
+
+    const peticion = http.expectOne('/api/tools');
+    expect(peticion.request.method).toBe('GET');
+
+    peticion.flush(CATALOGO);
+  });
+
+  // El servidor caído no es un fallo de la llamada: si algún día llegara por el
+  // canal de error, la pantalla dejaría de enseñar el catálogo entero por uno
+  // que no respondió.
+  it('entrega el catálogo aunque venga degradado', () => {
+    let recibido: CatalogResult | undefined;
+    servicio.catalogo().subscribe((catalogo) => {
+      recibido = catalogo;
+    });
+
+    http.expectOne('/api/tools').flush(CATALOGO);
+
+    expect(recibido?.degraded).toBe(true);
+    expect(recibido?.tools.length).toBe(1);
+    expect(recibido?.servers[1].detail).toContain('ConnectError');
+  });
+
+  it('ejecuta una herramienta con sus argumentos en el cuerpo', () => {
+    servicio
+      .ejecutar('detect_clickbait_lexical', { headline: 'Un titular' })
+      .subscribe();
+
+    const peticion = http.expectOne(
+      '/api/tools/detect_clickbait_lexical/execute',
+    );
+    expect(peticion.request.method).toBe('POST');
+    expect(peticion.request.body).toEqual({
+      arguments: { headline: 'Un titular' },
+    });
+
+    peticion.flush({ tool: 'detect_clickbait_lexical', server: 'tfg', status: 'ok' });
+  });
+
+  // El nombre lo declara el servidor MCP, no una lista de aquí. Sin escapar, un
+  // espacio partiría la URL y la petición iría a otra ruta.
+  it('escapa el nombre de la herramienta en la URL', () => {
+    servicio.ejecutar('nombre raro/con barra', {}).subscribe();
+
+    const peticion = http.expectOne(
+      '/api/tools/nombre%20raro%2Fcon%20barra/execute',
+    );
+
+    peticion.flush({ tool: 'nombre raro/con barra', server: 'tfg', status: 'ok' });
+  });
+
+  // Lo que sostiene el contrato: la herramienta falló, la petición no. Si esto
+  // llegara por `error`, quien se suscribe perdería el `detail` que explica qué
+  // pasó.
+  it('un fallo de la herramienta llega por next, no por error', () => {
+    const FALLO: ExecuteResult = {
+      tool: 'get_nyt_news',
+      server: 'tfg',
+      status: 'error',
+      detail: 'La API de NYT respondió 503.',
+    };
+
+    let recibido: ExecuteResult | undefined;
+    let error: unknown;
+    servicio.ejecutar('get_nyt_news', { topic: 'clima' }).subscribe({
+      next: (respuesta) => {
+        recibido = respuesta;
+      },
+      error: (fallo: unknown) => {
+        error = fallo;
+      },
+    });
+
+    http.expectOne('/api/tools/get_nyt_news/execute').flush(FALLO);
+
+    expect(error).toBeUndefined();
+    expect(recibido?.status).toBe('error');
+    expect(recibido?.detail).toContain('503');
+  });
+
+  // Y al revés: agotar la espera SÍ es un error de la llamada, y con un código
+  // propio. Fundirlo con el `status: error` diría que el análisis falló, que es
+  // justo lo que no se sabe (#113).
+  it('el 504 de espera agotada llega por el canal de error', () => {
+    let recibido: HttpErrorResponse | undefined;
+    servicio.ejecutar('detect_clickbait', { headline: 'Un titular' }).subscribe({
+      error: (fallo: HttpErrorResponse) => {
+        recibido = fallo;
+      },
+    });
+
+    http
+      .expectOne('/api/tools/detect_clickbait/execute')
+      .flush(
+        { detail: 'La herramienta tardó más de 60 s.' },
+        { status: 504, statusText: 'Gateway Timeout' },
+      );
+
+    expect(recibido?.status).toBe(504);
+  });
+
+  it('no llama a la API hasta que alguien se suscribe', () => {
+    servicio.catalogo();
+    servicio.ejecutar('detect_clickbait', { headline: 'Un titular' });
+
+    http.expectNone('/api/tools');
+    http.expectNone('/api/tools/detect_clickbait/execute');
+  });
+});

--- a/frontend/src/app/api/tools.service.ts
+++ b/frontend/src/app/api/tools.service.ts
@@ -1,0 +1,67 @@
+/**
+ * Cliente de `GET /tools` y `POST /tools/{name}/execute`.
+ *
+ * Un solo servicio para las dos rutas porque son la misma conversación: el
+ * catálogo dice qué herramientas hay y qué parámetros pide cada una, y ejecutar
+ * es usar justo eso. Partirlo en dos obligaría a la pantalla de Sistema a
+ * inyectar dos cosas para una sola pregunta.
+ *
+ * Como `analyze.service.ts`: los componentes inyectan esto y nunca `HttpClient`
+ * a pelo, así que las rutas viven en un único sitio.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { API } from './base';
+import type { Argumentos, CatalogResult, ExecuteBody, ExecuteResult } from './models';
+
+@Injectable({ providedIn: 'root' })
+export class ToolsService {
+  private readonly http = inject(HttpClient);
+
+  /**
+   * Pide el catálogo: qué servidores se consultaron y qué ofrecen.
+   *
+   * **Un servidor caído no llega por el canal de error.** El backend responde
+   * 200 con ese servidor en `unreachable` y su motivo, y sirve las herramientas
+   * de los demás — la misma degradación que las señales de `/analyze`. Quien se
+   * suscriba tiene que mirar `servers`, o enseñará un catálogo incompleto como
+   * si estuviera entero; `degraded` viene ya calculado para no tener que
+   * recorrer la lista.
+   *
+   * Cada suscripción es un handshake nuevo contra cada servidor (~0,2 s
+   * medidos, ver `api/catalog.py`). Es barato para abrir la pantalla y recargar
+   * a mano, y caro en bucle.
+   */
+  catalogo(): Observable<CatalogResult> {
+    return this.http.get<CatalogResult>(`${API}/tools`);
+  }
+
+  /**
+   * Ejecuta una herramienta suelta con los argumentos que pida su esquema.
+   *
+   * `encodeURIComponent` porque el nombre lo declara el servidor MCP y no una
+   * lista escrita aquí: hoy todos son identificadores de Python, pero el
+   * protocolo no lo garantiza y basta un espacio para partir la URL.
+   *
+   * **Que la herramienta falle llega por `next`, no por `error`**: 200 con
+   * `status` en `error` y su `detail`, porque la petición era válida y el
+   * servidor la atendió. Dar por bueno todo lo que llega por `next` enseñaría
+   * un resultado vacío como si fuera correcto.
+   *
+   * Por el canal de error quedan tres cosas distintas, y conviene no fundirlas
+   * al enseñarlas: **404** la herramienta no existe, **422** los argumentos no
+   * encajan en su esquema —el backend valida antes de invocar, así que dice
+   * cuál— y **504** se agotó la espera. El 504 no significa que fallara: en
+   * #113 la herramienta terminó bien a los 151 s con la API ya desistida. Lo
+   * que falló es la espera.
+   */
+  ejecutar(nombre: string, argumentos: Argumentos): Observable<ExecuteResult> {
+    const cuerpo: ExecuteBody = { arguments: argumentos };
+    return this.http.post<ExecuteResult>(
+      `${API}/tools/${encodeURIComponent(nombre)}/execute`,
+      cuerpo,
+    );
+  }
+}

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -3,6 +3,7 @@
 
   <nav class="nav">
     <a routerLink="/analizar" routerLinkActive="activo">Analizar</a>
+    <a routerLink="/sistema" routerLinkActive="activo">Sistema</a>
   </nav>
 </header>
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -25,6 +25,14 @@ export const routes: Routes = [
     loadComponent: () =>
       import('./analisis/analisis-page').then((m) => m.AnalisisPage),
   },
+  {
+    path: 'sistema',
+    title: 'Sistema · ClickBait Analysis',
+    // Aquí sí se nota la carga diferida que #126 dejó preparada: esta pantalla
+    // arrastra el formulario generado y no la necesita quien sólo analiza.
+    loadComponent: () =>
+      import('./sistema/sistema-page').then((modulo) => modulo.SistemaPage),
+  },
   // Cualquier otra cosa a la pantalla que existe. Cuando haya más rutas esto
   // debería ser un 404 de verdad, que es información; hoy sería una pantalla
   // vacía para decir lo mismo.

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -20,10 +20,10 @@ export const routes: Routes = [
     path: 'analizar',
     title: 'Analizar un titular · ClickBait Analysis',
     // `loadComponent` y no un import normal: la pantalla se descarga cuando se
-    // visita. Con una sola ruta da igual, pero el catálogo  y el
-    // historial entran detrás y ahí sí importa.
+    // visita. Con una sola ruta daba igual; con la de Sistema detrás ya no, y
+    // se ve en el empaquetado (21,69 kB en su propio fragmento).
     loadComponent: () =>
-      import('./analisis/analisis-page').then((m) => m.AnalisisPage),
+      import('./analisis/analisis-page').then((modulo) => modulo.AnalisisPage),
   },
   {
     path: 'sistema',

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -27,6 +27,25 @@ describe('App', () => {
     );
   });
 
+  // La regla de la cáscara es que una pestaña sólo existe si existe su
+  // pantalla. Este test la sostiene: al añadir la tercera (#129) hay que
+  // tocarlo, que es justo el momento de comprobar que la ruta ya está.
+  it('enseña una pestaña por cada pantalla que existe', async () => {
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    const html = fixture.nativeElement as HTMLElement;
+    const pestanas = [...html.querySelectorAll('.nav a')].map((enlace) => ({
+      texto: enlace.textContent?.trim(),
+      destino: enlace.getAttribute('href'),
+    }));
+
+    expect(pestanas).toEqual([
+      { texto: 'Analizar', destino: '/analizar' },
+      { texto: 'Sistema', destino: '/sistema' },
+    ]);
+  });
+
   it('deja un hueco donde el router pinta la pantalla', async () => {
     const fixture = TestBed.createComponent(App);
     await fixture.whenStable();

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -5,8 +5,8 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
  * Cáscara de la aplicación: cabecera y hueco donde el router pinta la pantalla.
  *
  * La navegación del prototipo tiene cuatro pestañas (Chat · Analizar ·
- * Historial · Sistema) y aquí sólo hay una: las otras tres son #128, #129 y el
- * agente de R13. Enlaces a rutas que no existen serían deuda visible, así que
+ * Historial · Sistema) y aquí hay dos: faltan Historial (#129) y el Chat del
+ * agente (R13). Enlaces a rutas que no existen serían deuda visible, así que
  * cada pestaña aparece cuando aparece su pantalla.
  */
 @Component({

--- a/frontend/src/app/sistema/campos.spec.ts
+++ b/frontend/src/app/sistema/campos.spec.ts
@@ -1,0 +1,93 @@
+import { camposDe } from './campos';
+
+/**
+ * Los esquemas de aquí son los REALES, copiados de lo que publican las tools
+ * (comprobado contra `mcp.list_tools()` al planificar #128). Inventarlos
+ * probaría que el lector funciona con lo que yo imagino, no con lo que llega.
+ */
+
+describe('camposDe', () => {
+  it('lee un campo de texto obligatorio', () => {
+    const [campo] = camposDe({
+      type: 'object',
+      properties: { headline: { type: 'string', title: 'Headline' } },
+      required: ['headline'],
+    });
+
+    expect(campo.nombre).toBe('headline');
+    expect(campo.tipo).toBe('texto');
+    expect(campo.requerido).toBe(true);
+  });
+
+  it('resuelve el opcional que FastAPI publica como anyOf con null', () => {
+    // `topic: str | None = None` en Python NO llega como `type: "string"`. Sin
+    // resolver este caso, los tres campos opcionales del catálogo saldrían como
+    // desconocidos y la pantalla los pintaría en crudo sin motivo.
+    const [campo] = camposDe({
+      type: 'object',
+      properties: {
+        topic: {
+          anyOf: [{ type: 'string' }, { type: 'null' }],
+          default: null,
+          description: 'Tema a buscar.',
+        },
+      },
+    });
+
+    expect(campo.tipo).toBe('texto');
+    expect(campo.requerido).toBe(false);
+    expect(campo.descripcion).toBe('Tema a buscar.');
+  });
+
+  it('conserva los topes y el valor por defecto de un entero', () => {
+    // Es la razón de que el catálogo publique el esquema CRUDO en vez de
+    // aplanarlo: sin esto la interfaz no puede validar antes de enviar.
+    const [campo] = camposDe({
+      type: 'object',
+      properties: {
+        days: { type: 'integer', minimum: 1, maximum: 30, default: 7 },
+      },
+    });
+
+    expect(campo.tipo).toBe('numero');
+    expect(campo.minimo).toBe(1);
+    expect(campo.maximo).toBe(30);
+    expect(campo.valorInicial).toBe(7);
+  });
+
+  it('una herramienta sin parámetros no tiene campos', () => {
+    // `describe_models` y `health_check` son así: sólo un botón.
+    expect(camposDe({ type: 'object', properties: {} })).toEqual([]);
+  });
+
+  it('marca como desconocido lo que no sabe pintar, y guarda el fragmento', () => {
+    // Omitirlo mandaría un cuerpo incompleto y el 422 llegaría sin explicación.
+    // Enseñarlo en crudo es feo y dice la verdad.
+    const [campo] = camposDe({
+      type: 'object',
+      properties: { etiquetas: { type: 'array', items: { type: 'string' } } },
+      required: ['etiquetas'],
+    });
+
+    expect(campo.tipo).toBe('desconocido');
+    expect(campo.requerido).toBe(true);
+    expect(campo.crudo).toEqual({ type: 'array', items: { type: 'string' } });
+  });
+
+  it('una unión de verdad tampoco se sabe pintar', () => {
+    // El `anyOf` sólo se resuelve cuando queda UN tipo al quitar el null.
+    const [campo] = camposDe({
+      type: 'object',
+      properties: { valor: { anyOf: [{ type: 'string' }, { type: 'integer' }] } },
+    });
+
+    expect(campo.tipo).toBe('desconocido');
+  });
+
+  it('no revienta con un esquema que no tiene la forma esperada', () => {
+    // Llega de un servidor MCP ajeno: puede ser cualquier cosa.
+    expect(camposDe(null)).toEqual([]);
+    expect(camposDe({ type: 'object' })).toEqual([]);
+    expect(camposDe('no soy un esquema')).toEqual([]);
+  });
+});

--- a/frontend/src/app/sistema/campos.ts
+++ b/frontend/src/app/sistema/campos.ts
@@ -1,0 +1,125 @@
+/**
+ * Lee el `input_schema` de una herramienta y dice qué campos pintar.
+ *
+ * **Es la pieza que hace que añadir una tool no toque el frontend** (R6.3, y por
+ * detrás R1.9). El catálogo publica el esquema JSON CRUDO —sin aplanar, para no
+ * perder mínimos, máximos ni valores por defecto— y esto lo traduce a una lista
+ * de descriptores que el formulario sabe pintar.
+ *
+ * Vive aparte del componente y sin depender de Angular a propósito: es la parte
+ * con decisiones, y así se prueba con datos y sin montar nada.
+ *
+ * **Lo que NO reconoce se marca `desconocido` y se enseña en crudo**, en vez de
+ * omitirlo. Omitir un campo mandaría un cuerpo incompleto y el 422 llegaría sin
+ * explicación posible; enseñarlo feo dice la verdad — la misma regla que el
+ * `@default` de `senal-card` con las señales que no conoce.
+ *
+ * El subconjunto cubre lo que publican las doce tools de hoy, comprobado contra
+ * los esquemas reales: ocho `string`, tres opcionales como
+ * `anyOf: [string, null]`, dos `integer` con `minimum`/`maximum`/`default` y dos
+ * `number`. Ni enums, ni arrays, ni objetos anidados.
+ */
+
+export type TipoDeCampo = 'texto' | 'numero' | 'booleano' | 'desconocido';
+
+export interface Campo {
+  nombre: string;
+  tipo: TipoDeCampo;
+  requerido: boolean;
+  /** La descripción del esquema, que es la ayuda que escribió quien hizo la tool. */
+  descripcion: string | null;
+  /** `default` del esquema. `null` significa «sin valor inicial», no «vacío». */
+  valorInicial: string | number | boolean | null;
+  minimo: number | null;
+  maximo: number | null;
+  /** El fragmento tal cual, para poder enseñarlo cuando el tipo es desconocido. */
+  crudo: unknown;
+}
+
+/** Un objeto cualquiera, para mirar dentro sin castear a una forma concreta. */
+type Diccionario = Record<string, unknown>;
+
+function esObjeto(valor: unknown): valor is Diccionario {
+  return typeof valor === 'object' && valor !== null && !Array.isArray(valor);
+}
+
+/**
+ * El tipo declarado, resolviendo el `anyOf` con `null` que produce FastAPI.
+ *
+ * Un parámetro opcional de Python (`topic: str | None = None`) no llega como
+ * `type: "string"` sino como `anyOf: [{type: "string"}, {type: "null"}]`. Sin
+ * resolverlo, los tres campos opcionales del catálogo saldrían como
+ * desconocidos.
+ */
+function tipoDeclarado(definicion: Diccionario): string | null {
+  if (typeof definicion['type'] === 'string') return definicion['type'];
+
+  const alternativas = definicion['anyOf'];
+  if (!Array.isArray(alternativas)) return null;
+
+  const tipos = alternativas
+    .filter(esObjeto)
+    .map((alternativa) => alternativa['type'])
+    .filter((tipo): tipo is string => typeof tipo === 'string' && tipo !== 'null');
+
+  // Sólo se resuelve si queda UN tipo tras descartar el null. Una unión de
+  // verdad —`str | int`— no se sabe pintar, y sale como desconocida.
+  return tipos.length === 1 ? tipos[0] : null;
+}
+
+function traducir(tipo: string | null): TipoDeCampo {
+  if (tipo === 'string') return 'texto';
+  if (tipo === 'integer' || tipo === 'number') return 'numero';
+  if (tipo === 'boolean') return 'booleano';
+  return 'desconocido';
+}
+
+function numeroONulo(valor: unknown): number | null {
+  return typeof valor === 'number' ? valor : null;
+}
+
+export function camposDe(esquema: unknown): Campo[] {
+  if (!esObjeto(esquema)) return [];
+
+  const propiedades = esquema['properties'];
+  if (!esObjeto(propiedades)) return [];
+
+  // `required` puede no venir: una tool sin parámetros obligatorios lo omite.
+  const requeridos = Array.isArray(esquema['required'])
+    ? esquema['required'].filter((nombre): nombre is string => typeof nombre === 'string')
+    : [];
+
+  return Object.entries(propiedades).map(([nombre, definicion]) => {
+    if (!esObjeto(definicion)) {
+      return {
+        nombre,
+        tipo: 'desconocido' as const,
+        requerido: requeridos.includes(nombre),
+        descripcion: null,
+        valorInicial: null,
+        minimo: null,
+        maximo: null,
+        crudo: definicion,
+      };
+    }
+
+    const inicial = definicion['default'];
+
+    return {
+      nombre,
+      tipo: traducir(tipoDeclarado(definicion)),
+      requerido: requeridos.includes(nombre),
+      descripcion:
+        typeof definicion['description'] === 'string' ? definicion['description'] : null,
+      valorInicial:
+        typeof inicial === 'string' ||
+        typeof inicial === 'number' ||
+        typeof inicial === 'boolean'
+          ? inicial
+          : null,
+      minimo: numeroONulo(definicion['minimum']),
+      maximo: numeroONulo(definicion['maximum']),
+      crudo: definicion,
+    };
+  });
+}

--- a/frontend/src/app/sistema/esquema-form.html
+++ b/frontend/src/app/sistema/esquema-form.html
@@ -1,0 +1,92 @@
+<form [formGroup]="formulario()" (ngSubmit)="enviar()">
+  @if (campos().length === 0) {
+    <p class="ayuda">Esta herramienta no necesita parámetros.</p>
+  }
+
+  @for (campo of campos(); track campo.nombre) {
+    @if (campo.tipo === 'desconocido') {
+      <!--
+        Se enseña el esquema tal cual en vez de omitir el campo: omitirlo
+        mandaría un cuerpo incompleto y el 422 hablaría de algo que nunca se
+        dibujó.
+      -->
+      <div class="campo campo--desconocido">
+        <p class="campo__nombre">{{ campo.nombre }}</p>
+        <p class="ayuda">
+          Este parámetro no se sabe pintar, así que se enseña su esquema.
+          @if (campo.requerido) {
+            Es obligatorio, y por eso la herramienta no se puede ejecutar desde
+            aquí.
+          } @else {
+            Es opcional: la herramienta usará su valor por defecto.
+          }
+        </p>
+        <pre class="crudo">{{ crudoDe(campo) }}</pre>
+      </div>
+    } @else {
+      <div class="campo">
+        <label [for]="'campo-' + idDe(campo)">
+          {{ campo.nombre }}
+          @if (campo.requerido) {
+            <span aria-hidden="true">*</span>
+          }
+        </label>
+
+        @if (campo.descripcion) {
+          <p class="ayuda" [id]="'ayuda-' + idDe(campo)">{{ campo.descripcion }}</p>
+        }
+
+        @switch (campo.tipo) {
+          @case ('numero') {
+            <input
+              type="number"
+              [id]="'campo-' + idDe(campo)"
+              [formControlName]="campo.nombre"
+              [required]="campo.requerido"
+              [attr.min]="campo.minimo"
+              [attr.max]="campo.maximo"
+              [attr.aria-invalid]="hayError(campo) ? 'true' : null"
+              [attr.aria-describedby]="descritoPor(campo)"
+            />
+          }
+          @case ('booleano') {
+            <input
+              type="checkbox"
+              [id]="'campo-' + idDe(campo)"
+              [formControlName]="campo.nombre"
+              [attr.aria-invalid]="hayError(campo) ? 'true' : null"
+              [attr.aria-describedby]="descritoPor(campo)"
+            />
+          }
+          @default {
+            <input
+              type="text"
+              [id]="'campo-' + idDe(campo)"
+              [formControlName]="campo.nombre"
+              [required]="campo.requerido"
+              [attr.aria-invalid]="hayError(campo) ? 'true' : null"
+              [attr.aria-describedby]="descritoPor(campo)"
+            />
+          }
+        }
+
+        @if (hayError(campo)) {
+          <p class="error-campo" [id]="'error-' + idDe(campo)">
+            {{ mensajeDeError(campo) }}
+          </p>
+        }
+      </div>
+    }
+  }
+
+  @if (bloqueado()) {
+    <p class="aviso" role="status">
+      No se puede ejecutar desde aquí: falta un parámetro obligatorio que esta
+      pantalla no sabe pintar.
+    </p>
+  }
+
+  <button type="submit" [disabled]="ejecutando() || bloqueado()">
+    {{ ejecutando() ? 'Ejecutando…' : 'Ejecutar' }}
+  </button>
+</form>

--- a/frontend/src/app/sistema/esquema-form.scss
+++ b/frontend/src/app/sistema/esquema-form.scss
@@ -1,0 +1,108 @@
+/* Estilos propios y no heredados de la pantalla: con encapsulación de vistas,
+   lo que se escribe en `sistema-page.scss` NO entra en la plantilla de este
+   componente. */
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+input[type='text'],
+input[type='number'] {
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--borde);
+  border-radius: 6px;
+  font: inherit;
+}
+
+input[type='checkbox'] {
+  align-self: flex-start;
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+input:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--acento);
+  outline-offset: 2px;
+}
+
+input[aria-invalid='true'] {
+  border-color: var(--error);
+}
+
+.ayuda {
+  margin: 0;
+  color: var(--texto-suave);
+  font-size: 0.85rem;
+}
+
+.error-campo {
+  margin: 0;
+  color: var(--error);
+  font-size: 0.85rem;
+}
+
+/* Lo que no se sabe pintar se marca, no se disimula. */
+.campo--desconocido {
+  padding: 0.6rem 0.75rem;
+  border: 1px dashed var(--aviso);
+  border-radius: 6px;
+  background: var(--aviso-fondo);
+}
+
+.campo__nombre {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-weight: 600;
+}
+
+.crudo {
+  margin: 0.5rem 0 0;
+  padding: 0.5rem;
+  overflow-x: auto;
+  border-radius: 6px;
+  background: var(--fondo-suave);
+  font-size: 0.8rem;
+}
+
+.aviso {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  background: var(--aviso-fondo);
+  color: var(--aviso);
+  font-size: 0.85rem;
+}
+
+button[type='submit'] {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+  padding: 0.5rem 1.1rem;
+  border: 1px solid var(--acento);
+  border-radius: 6px;
+  background: var(--acento);
+  color: #fff;
+  font: inherit;
+  cursor: pointer;
+}
+
+button[type='submit']:disabled {
+  border-color: var(--borde);
+  background: var(--borde);
+  color: var(--texto-suave);
+  cursor: not-allowed;
+}

--- a/frontend/src/app/sistema/esquema-form.spec.ts
+++ b/frontend/src/app/sistema/esquema-form.spec.ts
@@ -1,0 +1,153 @@
+import { TestBed, type ComponentFixture } from '@angular/core/testing';
+
+import type { Argumentos } from '../api/models';
+import { EsquemaForm } from './esquema-form';
+
+/**
+ * Los esquemas son los que publican las tools de verdad. Uno inventado probaría
+ * que el formulario funciona con lo que yo imagino.
+ */
+const CLICKBAIT = {
+  type: 'object',
+  properties: { headline: { type: 'string', title: 'Headline' } },
+  required: ['headline'],
+};
+
+const NOTICIAS = {
+  type: 'object',
+  properties: {
+    topic: {
+      anyOf: [{ type: 'string' }, { type: 'null' }],
+      default: null,
+      description: 'Tema a buscar.',
+    },
+    days: { type: 'integer', minimum: 1, maximum: 30, default: 7 },
+  },
+};
+
+const SIN_PARAMETROS = { type: 'object', properties: {} };
+
+const CON_ARRAY = {
+  type: 'object',
+  properties: { etiquetas: { type: 'array', items: { type: 'string' } } },
+  required: ['etiquetas'],
+};
+
+describe('EsquemaForm', () => {
+  let fixture: ComponentFixture<EsquemaForm>;
+  let enviados: Argumentos[];
+
+  const montar = async (herramienta: string, esquema: unknown) => {
+    fixture = TestBed.createComponent(EsquemaForm);
+    fixture.componentRef.setInput('herramienta', herramienta);
+    fixture.componentRef.setInput('esquema', esquema);
+
+    enviados = [];
+    fixture.componentInstance.ejecutar.subscribe((argumentos) => {
+      enviados.push(argumentos);
+    });
+
+    await fixture.whenStable();
+    return fixture.nativeElement as HTMLElement;
+  };
+
+  const ejecutar = async (raiz: HTMLElement) => {
+    raiz.querySelector<HTMLButtonElement>('button[type="submit"]')?.click();
+    await fixture.whenStable();
+  };
+
+  // Lo que hace que añadir una tool no toque esto: nadie escribió «headline».
+  it('pinta los campos que declara el esquema', async () => {
+    const raiz = await montar('detect_clickbait', CLICKBAIT);
+
+    const etiqueta = raiz.querySelector('label');
+    expect(etiqueta?.textContent).toContain('headline');
+    expect(etiqueta?.getAttribute('for')).toBe('campo-detect_clickbait-headline');
+  });
+
+  it('arranca con el valor por defecto del esquema', async () => {
+    const raiz = await montar('get_nyt_news', NOTICIAS);
+
+    const dias = raiz.querySelector<HTMLInputElement>('#campo-get_nyt_news-days');
+    expect(dias?.value).toBe('7');
+    // Los topes también viajan al control, no sólo al validador.
+    expect(dias?.getAttribute('min')).toBe('1');
+    expect(dias?.getAttribute('max')).toBe('30');
+  });
+
+  // Omitir y mandar vacío NO es lo mismo: omitir deja que la herramienta use su
+  // valor por defecto, y `""` es una búsqueda de la cadena vacía.
+  it('no manda los opcionales que quedan en blanco', async () => {
+    const raiz = await montar('get_nyt_news', NOTICIAS);
+
+    await ejecutar(raiz);
+
+    expect(enviados).toEqual([{ days: 7 }]);
+  });
+
+  it('manda el opcional cuando se rellena', async () => {
+    const raiz = await montar('get_nyt_news', NOTICIAS);
+
+    fixture.componentInstance.formulario().controls['topic'].setValue('clima');
+    await ejecutar(raiz);
+
+    expect(enviados).toEqual([{ topic: 'clima', days: 7 }]);
+  });
+
+  it('con el obligatorio en blanco no ejecuta, y lo dice', async () => {
+    const raiz = await montar('detect_clickbait', CLICKBAIT);
+
+    await ejecutar(raiz);
+
+    expect(enviados).toEqual([]);
+    expect(raiz.textContent).toContain('Este campo es obligatorio');
+    const control = raiz.querySelector('#campo-detect_clickbait-headline');
+    expect(control?.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  // El mensaje dice el número del esquema, no uno escrito en la plantilla que
+  // se quedaría viejo al cambiar la tool.
+  it('respeta el tope que declara el esquema', async () => {
+    const raiz = await montar('get_nyt_news', NOTICIAS);
+
+    fixture.componentInstance.formulario().controls['days'].setValue(99);
+    await ejecutar(raiz);
+
+    expect(enviados).toEqual([]);
+    expect(raiz.textContent).toContain('El valor máximo es 30.');
+  });
+
+  it('una herramienta sin parámetros ejecuta con el cuerpo vacío', async () => {
+    const raiz = await montar('describe_models', SIN_PARAMETROS);
+
+    expect(raiz.textContent).toContain('no necesita parámetros');
+    await ejecutar(raiz);
+
+    expect(enviados).toEqual([{}]);
+  });
+
+  // R6.14: nada de controles que sólo pueden producir un 422. Y el esquema a la
+  // vista, que es lo único que explica por qué no se puede.
+  it('un obligatorio que no se sabe pintar desactiva Ejecutar', async () => {
+    const raiz = await montar('tool_futura', CON_ARRAY);
+
+    const boton = raiz.querySelector<HTMLButtonElement>('button[type="submit"]');
+    expect(boton?.disabled).toBe(true);
+    expect(raiz.textContent).toContain('etiquetas');
+    expect(raiz.querySelector('pre')?.textContent).toContain('"type": "array"');
+  });
+
+  it('un opcional que no se sabe pintar se enseña, pero deja ejecutar', async () => {
+    const raiz = await montar('tool_futura', {
+      ...CON_ARRAY,
+      required: [],
+    });
+
+    const boton = raiz.querySelector<HTMLButtonElement>('button[type="submit"]');
+    expect(boton?.disabled).toBe(false);
+    expect(raiz.textContent).toContain('usará su valor por defecto');
+
+    await ejecutar(raiz);
+    expect(enviados).toEqual([{}]);
+  });
+});

--- a/frontend/src/app/sistema/esquema-form.ts
+++ b/frontend/src/app/sistema/esquema-form.ts
@@ -1,0 +1,203 @@
+/**
+ * Formulario de una herramienta, construido desde su esquema (R6.3).
+ *
+ * No conoce ninguna herramienta: recibe el `input_schema` que publica el
+ * catálogo, se lo da a `camposDe` y pinta lo que salga. **Ése es el punto de
+ * #128** — añadir una tool al backend no debe tocar el frontend (R1.9).
+ *
+ * Lo que no se sabe pintar se enseña en crudo en vez de omitirlo, y si además
+ * es obligatorio se desactiva el botón: R6.14 dice que la interfaz no debe
+ * dejar controles que no funcionen, y un «Ejecutar» que sólo puede producir un
+ * 422 es exactamente eso.
+ */
+import { Component, computed, input, output } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+  type AbstractControl,
+  type ValidationErrors,
+  type ValidatorFn,
+} from '@angular/forms';
+
+import type { Argumentos } from '../api/models';
+import { camposDe, type Campo } from './campos';
+
+/** Lo que puede valer un control de este formulario. */
+type Valor = string | number | boolean | null;
+
+/**
+ * Obligatorio, recortando antes de medir: un campo con espacios está vacío para
+ * quien lo lee. Es el mismo criterio que el titular de `/analyze`.
+ *
+ * Escrito aquí y no `Validators.required` por dos razones: aquel da por bueno
+ * un campo con espacios, y pasarlo suelto es un método estático sin ligar —lo
+ * canta ESLint con tipos (`unbound-method`), y tiene razón: nada garantiza que
+ * un día deje de ser independiente de su `this`.
+ */
+function obligatorio(control: AbstractControl<Valor>): ValidationErrors | null {
+  const valor = control.value;
+  if (valor === null || valor === '') return { obligatorio: true };
+  if (typeof valor === 'string' && !valor.trim()) return { obligatorio: true };
+  return null;
+}
+
+function validadoresDe(campo: Campo): ValidatorFn[] {
+  const validadores: ValidatorFn[] = [];
+
+  // En un booleano `required` significaría «tiene que estar marcado», que no es
+  // lo que dice el esquema: dice que la clave tiene que viajar, y un `false`
+  // viaja igual.
+  if (campo.requerido && campo.tipo !== 'booleano') {
+    validadores.push(obligatorio);
+  }
+  if (campo.minimo !== null) validadores.push(Validators.min(campo.minimo));
+  if (campo.maximo !== null) validadores.push(Validators.max(campo.maximo));
+
+  return validadores;
+}
+
+/**
+ * Valor de arranque: el `default` del esquema si lo hay.
+ *
+ * Cuando no lo hay, el vacío de cada tipo — y son distintos a propósito: un
+ * `null` en una caja de texto pinta la palabra «null».
+ */
+function inicialDe(campo: Campo): Valor {
+  if (campo.valorInicial !== null) return campo.valorInicial;
+  if (campo.tipo === 'booleano') return false;
+  if (campo.tipo === 'numero') return null;
+  return '';
+}
+
+@Component({
+  selector: 'app-esquema-form',
+  imports: [ReactiveFormsModule],
+  templateUrl: './esquema-form.html',
+})
+export class EsquemaForm {
+  /** Nombre de la herramienta. Sólo se usa para que los `id` sean únicos: la
+   * pantalla monta un formulario por herramienta y los `label` tienen que
+   * apuntar al control correcto. */
+  readonly herramienta = input.required<string>();
+
+  /**
+   * El `input_schema` del catálogo, CRUDO.
+   *
+   * Entra como `unknown` porque lo publica un servidor MCP que puede no ser el
+   * nuestro. Comprobarlo es trabajo de `camposDe`.
+   */
+  readonly esquema = input.required<unknown>();
+
+  /** Mientras la ejecución está en vuelo, para no lanzar dos. */
+  readonly ejecutando = input(false);
+
+  readonly ejecutar = output<Argumentos>();
+
+  readonly campos = computed(() => camposDe(this.esquema()));
+
+  /**
+   * El formulario se REHACE cuando cambia el esquema, que es lo que se quiere:
+   * son controles distintos, no los mismos con otro valor. Recargar el catálogo
+   * borra lo escrito, y es correcto — lo escrito era para otros campos.
+   */
+  readonly formulario = computed(() => {
+    const controles: Record<string, FormControl<Valor>> = {};
+    for (const campo of this.campos()) {
+      if (campo.tipo === 'desconocido') continue;
+      controles[campo.nombre] = new FormControl<Valor>(inicialDe(campo), {
+        nonNullable: false,
+        validators: validadoresDe(campo),
+      });
+    }
+    return new FormGroup(controles);
+  });
+
+  /**
+   * Un campo obligatorio que no se sabe pintar impide construir una petición
+   * válida: sin él el backend responde 422, y el mensaje hablaría de un campo
+   * que el formulario nunca dibujó.
+   *
+   * Uno OPCIONAL desconocido no bloquea: la herramienta funciona con sus
+   * valores por defecto y lo único que se pierde es poder tocar ese parámetro.
+   * Se dice en pantalla, que es distinto de esconderlo.
+   */
+  readonly bloqueado = computed(() =>
+    this.campos().some((campo) => campo.tipo === 'desconocido' && campo.requerido),
+  );
+
+  idDe(campo: Campo): string {
+    return `${this.herramienta()}-${campo.nombre}`;
+  }
+
+  /** Ayuda y error van los dos al `aria-describedby`, en ese orden. */
+  descritoPor(campo: Campo): string {
+    const identificador = this.idDe(campo);
+    return campo.descripcion
+      ? `ayuda-${identificador} error-${identificador}`
+      : `error-${identificador}`;
+  }
+
+  crudoDe(campo: Campo): string {
+    return JSON.stringify(campo.crudo, null, 2);
+  }
+
+  hayError(campo: Campo): boolean {
+    const control = this.control(campo);
+    return control.touched && control.invalid;
+  }
+
+  mensajeDeError(campo: Campo): string {
+    const control = this.control(campo);
+    if (control.hasError('obligatorio')) {
+      return 'Este campo es obligatorio.';
+    }
+    // Los topes salen del esquema, así que el mensaje dice el número de verdad
+    // en vez de uno escrito aquí que podría quedarse viejo.
+    if (control.hasError('min')) return `El valor mínimo es ${campo.minimo}.`;
+    if (control.hasError('max')) return `El valor máximo es ${campo.maximo}.`;
+    return 'El valor no es válido.';
+  }
+
+  enviar(): void {
+    if (this.ejecutando() || this.bloqueado()) return;
+
+    const formulario = this.formulario();
+    if (formulario.invalid) {
+      // Sin esto, pulsar Ejecutar con un obligatorio vacío no haría nada
+      // visible: los mensajes sólo salen cuando el control se ha tocado.
+      formulario.markAllAsTouched();
+      return;
+    }
+
+    this.ejecutar.emit(this.argumentos());
+  }
+
+  /**
+   * Los valores que van en la petición.
+   *
+   * **Lo vacío se OMITE, no se manda como cadena vacía.** No es lo mismo: en
+   * `/analyze` mandar `content: ""` es mandar un cuerpo vacío, y omitirlo es no
+   * tener cuerpo — con veredictos distintos. Aquí es igual: omitir deja que la
+   * herramienta use su valor por defecto.
+   *
+   * Un booleano nunca está vacío, así que siempre viaja.
+   */
+  private argumentos(): Argumentos {
+    const valores = this.formulario().getRawValue();
+    const argumentos: Argumentos = {};
+
+    for (const [nombre, valor] of Object.entries(valores)) {
+      if (valor === null || valor === '') continue;
+      argumentos[nombre] = valor;
+    }
+
+    return argumentos;
+  }
+
+  /** El control existe porque el grupo se construye de los mismos campos. */
+  private control(campo: Campo): FormControl<Valor> {
+    return this.formulario().controls[campo.nombre];
+  }
+}

--- a/frontend/src/app/sistema/esquema-form.ts
+++ b/frontend/src/app/sistema/esquema-form.ts
@@ -75,6 +75,7 @@ function inicialDe(campo: Campo): Valor {
   selector: 'app-esquema-form',
   imports: [ReactiveFormsModule],
   templateUrl: './esquema-form.html',
+  styleUrl: './esquema-form.scss',
 })
 export class EsquemaForm {
   /** Nombre de la herramienta. Sólo se usa para que los `id` sean únicos: la

--- a/frontend/src/app/sistema/sistema-page.html
+++ b/frontend/src/app/sistema/sistema-page.html
@@ -1,0 +1,170 @@
+<h1>Sistema</h1>
+<p class="subtitulo">
+  Qué servidores hay conectados, qué herramientas ofrecen y qué modelos hay
+  detrás de cada señal.
+</p>
+
+@if (cargando()) {
+  <p class="cargando" role="status">Consultando los servidores MCP…</p>
+}
+
+@if (error(); as fallo) {
+  <p class="error" role="alert">{{ fallo }}</p>
+  <button type="button" class="secundario" (click)="cargar()">Reintentar</button>
+}
+
+@if (catalogo(); as datos) {
+  <section aria-labelledby="titulo-servidores">
+    <h2 id="titulo-servidores">Servidores MCP</h2>
+
+    @if (datos.degraded) {
+      <!-- El catálogo se sirve igual: se dice que está incompleto en vez de
+           enseñar una lista más corta sin explicación. -->
+      <p class="aviso" role="status">
+        Algún servidor no respondió, así que el catálogo está incompleto.
+      </p>
+    }
+
+    <ul class="servidores">
+      @for (servidor of datos.servers; track servidor.url) {
+        <li class="servidor" [attr.data-estado]="servidor.status">
+          <p class="servidor__nombre">{{ servidor.name ?? 'sin nombre' }}</p>
+          <p class="servidor__estado">
+            {{ servidor.status === 'ok' ? 'conectado' : 'no responde' }} ·
+            {{ servidor.tool_count }} herramientas
+          </p>
+          <!-- El transporte se lee en la URL: hoy todos son HTTP streamable. -->
+          <p class="servidor__url"><code>{{ servidor.url }}</code></p>
+          @if (servidor.detail) {
+            <p class="motivo">{{ servidor.detail }}</p>
+          }
+        </li>
+      }
+    </ul>
+
+    <button type="button" class="secundario" [disabled]="cargando()" (click)="cargar()">
+      Recargar el catálogo
+    </button>
+  </section>
+
+  <section aria-labelledby="titulo-catalogo">
+    <h2 id="titulo-catalogo">Herramientas</h2>
+
+    <div class="filtros">
+      <p class="filtro">
+        <label for="busqueda">Buscar</label>
+        <input
+          id="busqueda"
+          type="search"
+          placeholder="nombre o descripción"
+          (input)="buscar($event)"
+        />
+      </p>
+
+      <p class="filtro">
+        <label for="categoria">Categoría</label>
+        <select id="categoria" (change)="filtrarPorCategoria($event)">
+          <option value="">Todas</option>
+          @for (nombre of categorias(); track nombre) {
+            <option [value]="nombre">{{ nombre }}</option>
+          }
+        </select>
+      </p>
+    </div>
+
+    <p class="cuenta" role="status">
+      {{ filtradas().length }} de {{ herramientas().length }} herramientas
+    </p>
+
+    @for (herramienta of filtradas(); track herramienta.name) {
+      <article class="tool">
+        <button
+          type="button"
+          class="tool__cabecera"
+          (click)="alternar(herramienta.name)"
+          [attr.aria-expanded]="abierta() === herramienta.name"
+        >
+          <code class="tool__nombre">{{ herramienta.name }}</code>
+          @if (herramienta.category) {
+            <span class="badge">{{ herramienta.category }}</span>
+          }
+          @if (herramienta.integration) {
+            <span class="origen">{{ herramienta.integration }}</span>
+          }
+          <span class="chevron" aria-hidden="true">
+            {{ abierta() === herramienta.name ? '▾' : '▸' }}
+          </span>
+        </button>
+
+        @if (herramienta.description) {
+          <p class="tool__descripcion">{{ herramienta.description }}</p>
+        }
+
+        @if (abierta() === herramienta.name) {
+          <app-esquema-form
+            [herramienta]="herramienta.name"
+            [esquema]="herramienta.input_schema"
+            [ejecutando]="ejecutando() === herramienta.name"
+            (ejecutar)="ejecutarHerramienta(herramienta.name, $event)"
+          />
+
+          @if (falloDe(herramienta.name); as fallo) {
+            <p class="error" role="alert">{{ fallo }}</p>
+          }
+
+          @if (resultadoDe(herramienta.name); as resultado) {
+            <!-- Un `status` en error NO es un fallo de la petición: la
+                 herramienta se ejecutó y falló, y su motivo es lo único que lo
+                 explica. -->
+            @if (resultado.status === 'error') {
+              <p class="motivo" role="status">
+                La herramienta falló: {{ resultado.detail }}
+              </p>
+            } @else {
+              <p class="resultado__meta" role="status">
+                Ejecutada en <code>{{ resultado.server }}</code>
+              </p>
+              <pre class="crudo">{{ crudoDe(resultado) }}</pre>
+            }
+          }
+        }
+      </article>
+    }
+  </section>
+
+  <section aria-labelledby="titulo-fichas">
+    <h2 id="titulo-fichas">Fichas de modelo</h2>
+    <p class="subtitulo">
+      Cada señal de análisis declara qué hay detrás y qué límites tiene medidos.
+      Es lo que evita leer un veredicto sin saber de dónde sale.
+    </p>
+
+    @for (herramienta of fichas(); track herramienta.name) {
+      @if (herramienta.model_card; as ficha) {
+        <article class="ficha" [attr.data-tipo]="ficha.type">
+          <h3>{{ ficha.name }}</h3>
+          <p class="ficha__tarea">{{ ficha.task }}</p>
+
+          <p class="ficha__meta">
+            <span class="badge">{{ ficha.type }}</span>
+            <span>Dimensión: {{ dimension(ficha.dimension) }}</span>
+            @if (ficha.model_id) {
+              <code>{{ ficha.model_id }}</code>
+            } @else {
+              <!-- El `null` ES información: la señal es código propio y
+                   auditable, no un modelo descargable. -->
+              <span>código propio, sin modelo descargable</span>
+            }
+          </p>
+
+          <h4>Límites</h4>
+          <ul class="ficha__limites">
+            @for (limite of ficha.limitations; track $index) {
+              <li>{{ limite }}</li>
+            }
+          </ul>
+        </article>
+      }
+    }
+  </section>
+}

--- a/frontend/src/app/sistema/sistema-page.scss
+++ b/frontend/src/app/sistema/sistema-page.scss
@@ -1,0 +1,260 @@
+h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.5rem;
+}
+
+h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.15rem;
+}
+
+h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+}
+
+h4 {
+  margin: 0.75rem 0 0.25rem;
+  font-size: 0.85rem;
+  color: var(--texto-suave);
+}
+
+.subtitulo {
+  margin: 0 0 1.5rem;
+  color: var(--texto-suave);
+}
+
+section {
+  margin-bottom: 2.5rem;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+}
+
+/* --- Servidores --- */
+
+.servidores {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+  margin: 0 0 1rem;
+  padding: 0;
+  list-style: none;
+}
+
+.servidor {
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--borde);
+  border-left: 4px solid var(--interpretable);
+  border-radius: 8px;
+}
+
+/* Un servidor caído sigue en la lista: por eso hace falta distinguirlo. */
+.servidor[data-estado='unreachable'] {
+  border-left-color: var(--error);
+  background: var(--error-fondo);
+}
+
+.servidor__nombre {
+  margin: 0;
+  font-weight: 600;
+}
+
+.servidor__estado,
+.servidor__url {
+  margin: 0.15rem 0 0;
+  color: var(--texto-suave);
+  font-size: 0.85rem;
+}
+
+.motivo {
+  margin: 0.4rem 0 0;
+  color: var(--error);
+  font-size: 0.85rem;
+}
+
+/* --- Filtros --- */
+
+.filtros {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.filtro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0;
+}
+
+.filtro label {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.filtro input,
+.filtro select {
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--borde);
+  border-radius: 6px;
+  font: inherit;
+}
+
+.filtro input:focus-visible,
+.filtro select:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--acento);
+  outline-offset: 2px;
+}
+
+.cuenta {
+  margin: 0 0 0.75rem;
+  color: var(--texto-suave);
+  font-size: 0.85rem;
+}
+
+/* --- Herramientas --- */
+
+.tool {
+  margin-bottom: 0.6rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--borde);
+  border-radius: 8px;
+}
+
+.tool__cabecera {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tool__nombre {
+  font-weight: 600;
+}
+
+.badge,
+.origen {
+  padding: 0.1rem 0.6rem;
+  border-radius: 999px;
+  background: var(--fondo-suave);
+  color: var(--texto-suave);
+  font-size: 0.75rem;
+  /* El texto va en caja normal y las mayúsculas las pone el CSS: muchos
+     lectores de pantalla deletrean lo que está escrito en caja alta. */
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.chevron {
+  margin-left: auto;
+  color: var(--texto-suave);
+}
+
+.tool__descripcion {
+  margin: 0.5rem 0 0;
+  color: var(--texto-suave);
+  font-size: 0.9rem;
+  white-space: pre-line;
+}
+
+.resultado__meta {
+  margin: 0.75rem 0 0.25rem;
+  color: var(--texto-suave);
+  font-size: 0.85rem;
+}
+
+.crudo {
+  margin: 0;
+  padding: 0.6rem 0.75rem;
+  max-height: 22rem;
+  overflow: auto;
+  border-radius: 6px;
+  background: var(--fondo-suave);
+  font-size: 0.8rem;
+}
+
+/* --- Fichas de modelo --- */
+
+.ficha {
+  margin-bottom: 0.75rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--borde);
+  border-left: 4px solid var(--borde);
+  border-radius: 8px;
+}
+
+/* El color dice dónde está la transparencia, no cuán bueno es el modelo. */
+.ficha[data-tipo='interpretable'] {
+  border-left-color: var(--interpretable);
+}
+
+.ficha[data-tipo='hybrid'] {
+  border-left-color: var(--hybrid);
+}
+
+.ficha[data-tipo='opaque'] {
+  border-left-color: var(--opaque);
+}
+
+.ficha__tarea {
+  margin: 0;
+  color: var(--texto-suave);
+}
+
+.ficha__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0.5rem 0 0;
+  color: var(--texto-suave);
+  font-size: 0.85rem;
+}
+
+.ficha__limites {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: 0.9rem;
+}
+
+/* --- Estados de la pantalla --- */
+
+.cargando {
+  color: var(--texto-suave);
+}
+
+.aviso {
+  padding: 0.6rem 0.85rem;
+  border-radius: 6px;
+  background: var(--aviso-fondo);
+  color: var(--aviso);
+}
+
+.error {
+  padding: 0.6rem 0.85rem;
+  border-radius: 6px;
+  background: var(--error-fondo);
+  color: var(--error);
+}
+
+.secundario {
+  padding: 0.45rem 1rem;
+  border: 1px solid var(--borde);
+  border-radius: 6px;
+  background: var(--fondo-suave);
+  font: inherit;
+  cursor: pointer;
+}

--- a/frontend/src/app/sistema/sistema-page.spec.ts
+++ b/frontend/src/app/sistema/sistema-page.spec.ts
@@ -1,0 +1,255 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed, type ComponentFixture } from '@angular/core/testing';
+
+import type { CatalogResult } from '../api/models';
+import { SistemaPage } from './sistema-page';
+
+/**
+ * Un catálogo con las tres cosas que la pantalla tiene que saber contar: un
+ * servidor caído, herramientas de categorías distintas y una señal con ficha.
+ */
+const CATALOGO: CatalogResult = {
+  servers: [
+    { url: 'http://127.0.0.1:8010/mcp', name: 'tfg', status: 'ok', tool_count: 3 },
+    {
+      url: 'http://127.0.0.1:8011/mcp',
+      status: 'unreachable',
+      tool_count: 0,
+      detail: 'ConnectError: All connection attempts failed',
+    },
+  ],
+  tools: [
+    {
+      name: 'detect_clickbait_lexical',
+      description: 'Detecta clickbait por vocabulario, con reglas visibles.',
+      input_schema: {
+        type: 'object',
+        properties: { headline: { type: 'string' } },
+        required: ['headline'],
+      },
+      category: 'Señales de análisis',
+      integration: 'nlp',
+      server: 'tfg',
+      model_card: {
+        name: 'Léxico por reglas',
+        task: 'Marca los cues de clickbait que aparecen en el titular.',
+        model_id: null,
+        type: 'interpretable',
+        dimension: 'form',
+        limitations: ['Sólo inglés.', 'No entiende el contexto.'],
+      },
+    },
+    {
+      name: 'get_nyt_news',
+      description: 'Trae titulares del New York Times.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          days: { type: 'integer', minimum: 1, maximum: 30, default: 7 },
+        },
+      },
+      category: 'Fuentes de contenido',
+      integration: 'nyt',
+      server: 'tfg',
+    },
+    {
+      name: 'describe_models',
+      description: 'Devuelve las fichas de los modelos.',
+      input_schema: { type: 'object', properties: {} },
+      category: 'Utilidades',
+      integration: 'nlp',
+      server: 'tfg',
+    },
+  ],
+  degraded: true,
+};
+
+describe('SistemaPage', () => {
+  let fixture: ComponentFixture<SistemaPage>;
+  let http: HttpTestingController;
+
+  const montar = async (catalogo: CatalogResult = CATALOGO) => {
+    fixture = TestBed.createComponent(SistemaPage);
+    // La petición sale en el constructor: la pantalla no sirve de nada vacía.
+    http.expectOne('/api/tools').flush(catalogo);
+    await fixture.whenStable();
+    return fixture.nativeElement as HTMLElement;
+  };
+
+  const escribir = async (raiz: HTMLElement, selector: string, valor: string) => {
+    const control = raiz.querySelector<HTMLInputElement | HTMLSelectElement>(selector);
+    if (control) {
+      control.value = valor;
+      const evento = control instanceof HTMLSelectElement ? 'change' : 'input';
+      control.dispatchEvent(new Event(evento));
+    }
+    await fixture.whenStable();
+  };
+
+  const desplegar = async (raiz: HTMLElement, indice: number) => {
+    raiz.querySelectorAll<HTMLButtonElement>('.tool__cabecera')[indice]?.click();
+    await fixture.whenStable();
+  };
+
+  const ejecutar = async (raiz: HTMLElement) => {
+    const boton = raiz.querySelector<HTMLButtonElement>(
+      'app-esquema-form button[type="submit"]',
+    );
+    boton?.click();
+    await fixture.whenStable();
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  // Un servidor caído sale en la lista con su motivo: la alternativa —una lista
+  // más corta— no distingue «no hay» de «no contestó».
+  it('enseña los servidores, incluido el que no respondió', async () => {
+    const raiz = await montar();
+
+    expect(raiz.textContent).toContain('tfg');
+    expect(raiz.textContent).toContain('no responde');
+    expect(raiz.textContent).toContain('ConnectError');
+    expect(raiz.querySelector('[data-estado="unreachable"]')).not.toBeNull();
+  });
+
+  it('avisa de que el catálogo está incompleto', async () => {
+    const raiz = await montar();
+
+    expect(raiz.textContent).toContain('el catálogo está incompleto');
+  });
+
+  // Las categorías del desplegable salen del catálogo. Una tool con una
+  // categoría nueva la ofrecería sin tocar esta pantalla (R1.9).
+  it('ofrece como filtro las categorías que trae el catálogo', async () => {
+    const raiz = await montar();
+
+    const opciones = [...raiz.querySelectorAll('#categoria option')].map((opcion) =>
+      opcion.textContent?.trim(),
+    );
+    expect(opciones).toEqual([
+      'Todas',
+      'Fuentes de contenido',
+      'Señales de análisis',
+      'Utilidades',
+    ]);
+  });
+
+  it('filtra por categoría', async () => {
+    const raiz = await montar();
+
+    await escribir(raiz, '#categoria', 'Utilidades');
+
+    expect(raiz.querySelectorAll('.tool').length).toBe(1);
+    expect(raiz.textContent).toContain('describe_models');
+  });
+
+  it('busca por nombre de herramienta', async () => {
+    const raiz = await montar();
+
+    await escribir(raiz, '#busqueda', 'nyt');
+
+    expect(raiz.querySelectorAll('.tool').length).toBe(1);
+    expect(raiz.textContent).toContain('get_nyt_news');
+  });
+
+  // La descripción es la docstring que lee el LLM, y ahí está lo que la
+  // herramienta hace de verdad: buscar sólo por nombre dejaría fuera lo útil.
+  it('busca también en la descripción, sin distinguir mayúsculas', async () => {
+    const raiz = await montar();
+
+    await escribir(raiz, '#busqueda', 'VOCABULARIO');
+
+    expect(raiz.querySelectorAll('.tool').length).toBe(1);
+    expect(raiz.textContent).toContain('detect_clickbait_lexical');
+  });
+
+  it('ejecuta la herramienta desplegada y enseña su salida', async () => {
+    const raiz = await montar();
+
+    await desplegar(raiz, 1);
+    await ejecutar(raiz);
+
+    const peticion = http.expectOne('/api/tools/get_nyt_news/execute');
+    // El `days: 7` no lo escribió nadie: sale del `default` del esquema.
+    expect(peticion.request.body).toEqual({ arguments: { days: 7 } });
+
+    peticion.flush({
+      tool: 'get_nyt_news',
+      server: 'tfg',
+      status: 'ok',
+      data: { articles: [] },
+    });
+    await fixture.whenStable();
+
+    expect(raiz.querySelector('.crudo')?.textContent).toContain('articles');
+  });
+
+  // 200 con `status: error`: la herramienta falló, la petición no. Se enseña su
+  // motivo, que es lo único accionable.
+  it('enseña el motivo cuando la herramienta falla', async () => {
+    const raiz = await montar();
+
+    await desplegar(raiz, 1);
+    await ejecutar(raiz);
+
+    http.expectOne('/api/tools/get_nyt_news/execute').flush({
+      tool: 'get_nyt_news',
+      server: 'tfg',
+      status: 'error',
+      detail: 'La API de NYT respondió 503.',
+    });
+    await fixture.whenStable();
+
+    expect(raiz.textContent).toContain('La herramienta falló');
+    expect(raiz.textContent).toContain('503');
+  });
+
+  // El 504 NO dice que la herramienta fallara: dice que se agotó la espera, y
+  // puede haber terminado bien (#113). El mensaje tiene que distinguirlo.
+  it('explica el 504 como espera agotada, no como fallo', async () => {
+    const raiz = await montar();
+
+    await desplegar(raiz, 1);
+    await ejecutar(raiz);
+
+    http
+      .expectOne('/api/tools/get_nyt_news/execute')
+      .flush({ detail: 'timeout' }, { status: 504, statusText: 'Gateway Timeout' });
+    await fixture.whenStable();
+
+    expect(raiz.textContent).toContain('Se agotó la espera');
+  });
+
+  it('enseña la ficha de modelo de las señales, con sus límites', async () => {
+    const raiz = await montar();
+
+    const ficha = raiz.querySelector('.ficha');
+    expect(ficha?.textContent).toContain('Léxico por reglas');
+    expect(ficha?.textContent).toContain('Forma');
+    // El `null` del `model_id` es información, no un hueco.
+    expect(ficha?.textContent).toContain('código propio');
+    expect(ficha?.querySelectorAll('li').length).toBe(2);
+  });
+
+  it('explica el fallo cuando el catálogo no se puede cargar', async () => {
+    fixture = TestBed.createComponent(SistemaPage);
+    http
+      .expectOne('/api/tools')
+      .flush({ detail: 'boom' }, { status: 500, statusText: 'Server Error' });
+    await fixture.whenStable();
+
+    const raiz = fixture.nativeElement as HTMLElement;
+    expect(raiz.textContent).toContain('La API falló al construir el catálogo');
+  });
+});

--- a/frontend/src/app/sistema/sistema-page.ts
+++ b/frontend/src/app/sistema/sistema-page.ts
@@ -46,11 +46,19 @@ function mensajeDeEjecucion(fallo: HttpErrorResponse): string {
  * Deja un texto listo para comparar en el buscador.
  *
  * Se aplica igual a lo escrito y a lo buscado, así que lo que decida esta
- * función ES lo que la búsqueda considera «igual».
- *
+ * función ES lo que la búsqueda considera «igual». Por eso quitar diacríticos
+ * sólo puede SUMAR coincidencias: lo que encajaba antes sigue encajando.
  */
 function normalizar(texto: string): string {
-  return texto.normalize('NFD').toLowerCase().replace(/\p{Diacritic}/gu, ''); // quita acentos y diéresis, y pasa a minúsculas
+  // Caen todos los diacríticos, la ñ INCLUIDA, y es a propósito: medido sobre
+  // las docstrings del catálogo, ninguna palabra colisiona con otra al
+  // perderlos (`señal`, `engaño`, `añadir`, `pestañas`). No es un descuido que
+  // haya que arreglar.
+  return texto
+    .trim()
+    .normalize('NFD')
+    .toLowerCase()
+    .replace(/\p{Diacritic}/gu, '');
 }
 
 /**

--- a/frontend/src/app/sistema/sistema-page.ts
+++ b/frontend/src/app/sistema/sistema-page.ts
@@ -1,0 +1,221 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, computed, inject, signal } from '@angular/core';
+
+import { detalleDeValidacion, SIN_RESPUESTA } from '../api/errores';
+import type { Argumentos, CatalogResult, ExecuteResult } from '../api/models';
+import { ToolsService } from '../api/tools.service';
+import { nombreDeDimension } from '../analisis/vocabulario';
+import { EsquemaForm } from './esquema-form';
+
+/** El catálogo no se pudo construir. */
+function mensajeDeCatalogo(fallo: HttpErrorResponse): string {
+  if (fallo.status === 0) return SIN_RESPUESTA;
+  if (fallo.status >= 500) {
+    return `La API falló al construir el catálogo (${fallo.status}).`;
+  }
+  return `No se pudo cargar el catálogo (${fallo.status}).`;
+}
+
+/**
+ * La ejecución no llegó a producir un resultado.
+ *
+ * Los tres casos se separan porque el remedio es distinto en cada uno, y
+ * fundirlos en «no se pudo ejecutar» los volvería inaccionables. El 504 es el
+ * que más importa: **no dice que la herramienta fallara**, dice que se agotó la
+ * espera — en #113 terminó bien a los 151 s con la API ya desistida.
+ */
+function mensajeDeEjecucion(fallo: HttpErrorResponse): string {
+  if (fallo.status === 0) return SIN_RESPUESTA;
+  if (fallo.status === 404) {
+    return 'Esa herramienta ya no está en el catálogo. Recarga la lista.';
+  }
+  if (fallo.status === 422) {
+    const detalle = detalleDeValidacion(fallo.error);
+    return detalle
+      ? `Los argumentos no encajan en el esquema: ${detalle}`
+      : 'Los argumentos no encajan en el esquema de la herramienta.';
+  }
+  if (fallo.status === 504) {
+    return 'Se agotó la espera. La herramienta puede haber terminado igualmente, así que repetir la llamada la ejecutaría otra vez.';
+  }
+  if (fallo.status >= 500) return `La API falló al ejecutar (${fallo.status}).`;
+  return `No se pudo ejecutar la herramienta (${fallo.status}).`;
+}
+
+/**
+ * Deja un texto listo para comparar en el buscador.
+ *
+ * Se aplica igual a lo escrito y a lo buscado, así que lo que decida esta
+ * función ES lo que la búsqueda considera «igual».
+ *
+ */
+function normalizar(texto: string): string {
+  return texto.normalize('NFD').toLowerCase().replace(/\p{Diacritic}/gu, ''); // quita acentos y diéresis, y pasa a minúsculas
+}
+
+/**
+ * Pantalla de Sistema: qué hay conectado, qué ofrece y con qué modelos.
+ *
+ * Tres secciones que responden tres preguntas distintas — servidores (R6.11),
+ * catálogo con búsqueda y filtro (R6.2, R6.9) y fichas de modelo (R3.8)— y una
+ * cuarta cosa que NO está aquí: la salud de las APIs externas, que sale de
+ * `/health` y es otra pregunta (issue #147).
+ *
+ * **No es un lanzador.** Se puede ejecutar una herramienta suelta porque hace
+ * falta para probar una señal sin pasar por el análisis completo, pero el
+ * camino normal del producto es `/analizar`.
+ */
+@Component({
+  selector: 'app-sistema-page',
+  imports: [EsquemaForm],
+  templateUrl: './sistema-page.html',
+  styleUrl: './sistema-page.scss',
+})
+export class SistemaPage {
+  private readonly tools = inject(ToolsService);
+
+  readonly catalogo = signal<CatalogResult | null>(null);
+  readonly cargando = signal(false);
+  readonly error = signal<string | null>(null);
+
+  readonly busqueda = signal('');
+  readonly categoria = signal('');
+
+  /**
+   * Qué herramienta tiene el formulario desplegado. Una sola: con doce tools,
+   * todas abiertas serían doce formularios y ninguna vista de conjunto.
+   */
+  readonly abierta = signal<string | null>(null);
+
+  /**
+   * Qué herramienta se está ejecutando, o `null`. Una a la vez a propósito: en
+   * la máquina de despliegue no hay GPU, y dos señales pesadas en paralelo se
+   * estorban.
+   */
+  readonly ejecutando = signal<string | null>(null);
+
+  // Por nombre de herramienta, para que el resultado se quede donde se pidió al
+  // desplegar otra.
+  readonly resultados = signal<Record<string, ExecuteResult>>({});
+  readonly fallos = signal<Record<string, string>>({});
+
+  readonly servidores = computed(() => this.catalogo()?.servers ?? []);
+  readonly herramientas = computed(() => this.catalogo()?.tools ?? []);
+
+  /**
+   * Las categorías salen del catálogo, no de una lista escrita aquí.
+   *
+   * Es la misma razón que el formulario generado: el backend las declara en
+   * `integrations/metadata.py`, y si aparece una quinta el filtro la ofrece sin
+   * tocar el frontend (R1.9).
+   */
+  readonly categorias = computed(() => {
+    const vistas = new Set<string>();
+    for (const herramienta of this.herramientas()) {
+      if (herramienta.category) vistas.add(herramienta.category);
+    }
+    return [...vistas].sort((primera, segunda) => primera.localeCompare(segunda, 'es'));
+  });
+
+  /** Filtrado en cliente: son doce herramientas, no hace falta volver a pedir. */
+  readonly filtradas = computed(() => {
+    const texto = normalizar(this.busqueda());
+    const categoria = this.categoria();
+
+    return this.herramientas().filter((herramienta) => {
+      if (categoria && herramienta.category !== categoria) return false;
+      if (!texto) return true;
+      return (
+        normalizar(herramienta.name).includes(texto) ||
+        normalizar(herramienta.description ?? '').includes(texto)
+      );
+    });
+  });
+
+  /** Las que llevan ficha son exactamente las señales de análisis. */
+  readonly fichas = computed(() =>
+    this.herramientas().filter((herramienta) => herramienta.model_card),
+  );
+
+  protected readonly dimension = nombreDeDimension;
+
+  constructor() {
+    this.cargar();
+  }
+
+  /**
+   * Pide el catálogo. Se llama al montar y desde el botón de recargar, nunca en
+   * bucle: cada llamada es un handshake contra cada servidor MCP.
+   */
+  cargar(): void {
+    if (this.cargando()) return;
+
+    this.cargando.set(true);
+    this.error.set(null);
+
+    this.tools.catalogo().subscribe({
+      next: (catalogo) => {
+        this.catalogo.set(catalogo);
+        this.cargando.set(false);
+      },
+      error: (fallo: HttpErrorResponse) => {
+        this.error.set(mensajeDeCatalogo(fallo));
+        this.cargando.set(false);
+      },
+    });
+  }
+
+  alternar(nombre: string): void {
+    this.abierta.update((actual) => (actual === nombre ? null : nombre));
+  }
+
+  buscar(evento: Event): void {
+    this.busqueda.set((evento.target as HTMLInputElement).value);
+  }
+
+  filtrarPorCategoria(evento: Event): void {
+    this.categoria.set((evento.target as HTMLSelectElement).value);
+  }
+
+  /**
+   * Ejecuta la herramienta y guarda lo que conteste.
+   *
+   * **Un `status: 'error'` llega por `next`**, no por el canal de error: la
+   * petición era válida y el servidor la atendió, lo que falló es la
+   * herramienta. Se guarda igual que un resultado bueno, porque su `detail` es
+   * lo único que explica qué pasó.
+   */
+  ejecutarHerramienta(nombre: string, argumentos: Argumentos): void {
+    if (this.ejecutando()) return;
+
+    this.ejecutando.set(nombre);
+    this.fallos.update((previos) => ({ ...previos, [nombre]: '' }));
+
+    this.tools.ejecutar(nombre, argumentos).subscribe({
+      next: (resultado) => {
+        this.resultados.update((previos) => ({ ...previos, [nombre]: resultado }));
+        this.ejecutando.set(null);
+      },
+      error: (fallo: HttpErrorResponse) => {
+        this.fallos.update((previos) => ({
+          ...previos,
+          [nombre]: mensajeDeEjecucion(fallo),
+        }));
+        this.ejecutando.set(null);
+      },
+    });
+  }
+
+  resultadoDe(nombre: string): ExecuteResult | null {
+    return this.resultados()[nombre] ?? null;
+  }
+
+  falloDe(nombre: string): string {
+    return this.fallos()[nombre] ?? '';
+  }
+
+  /** La salida en crudo: no se sabe qué forma tiene cada herramienta. */
+  crudoDe(resultado: ExecuteResult): string {
+    return JSON.stringify(resultado.data, null, 2);
+  }
+}

--- a/tests/api/test_catalog.py
+++ b/tests/api/test_catalog.py
@@ -22,6 +22,7 @@ from backend.api import catalog
 from backend.api.schemas import ServerStatus
 from backend.config.settings import settings
 from backend.core.mcp import session as mcp_session
+from backend.integrations.nlp.model_cards import cards_by_signal
 
 # El Host debe llevar puerto: la protección anti DNS-rebinding de FastMCP acepta
 # `127.0.0.1:*` y rechazaría con 421 un Host sin él.
@@ -124,12 +125,41 @@ async def test_una_tool_del_nucleo_no_tiene_integracion(monkeypatch, servidor_mc
 async def test_las_senales_traen_su_ficha_de_modelo(monkeypatch, servidor_mcp):
     tools = await _tools(monkeypatch, servidor_mcp)
 
+    fichas = cards_by_signal()
+
     ficha = tools["detect_clickbait_lexical"].model_card
     assert ficha is not None
     assert ficha.type.value == "interpretable"
     assert ficha.dimension.value == "form"
     # Los límites medidos son lo que evita que el catálogo prometa de más.
     assert any("0.498" in limite for limite in ficha.limitations)
+
+    # El nombre y la tarea viajan desde #128, y se comparan contra la ficha en
+    # vez de contra una cadena escrita aquí: así renombrar una señal en
+    # `model_cards.py` no puede desalinear el test de lo que se publica.
+    assert ficha.name == fichas["detect_clickbait_lexical"]["name"]
+    assert ficha.task == fichas["detect_clickbait_lexical"]["task"]
+    # Sin ellos la pantalla sólo podía titular «detect_clickbait_lexical», que es
+    # justo lo que `ToolModelCard` dice en su docstring que quiere evitar.
+    assert "detect_clickbait_lexical" not in ficha.name
+
+
+@pytest.mark.asyncio
+async def test_un_model_id_nulo_es_informacion_y_viaja(monkeypatch, servidor_mcp):
+    """`model_id` es `None` en el léxico y el lineal, y ese None se publica.
+
+    Dice que la señal NO es un modelo descargable sino código propio y
+    auditable, que bajo R3.9 es más divulgador que esconderlo. El dedicado sí
+    trae su identificador de HuggingFace.
+    """
+    tools = await _tools(monkeypatch, servidor_mcp)
+
+    lexico = tools["detect_clickbait_lexical"].model_card
+    dedicado = tools["detect_clickbait"].model_card
+    assert lexico is not None and dedicado is not None
+
+    assert lexico.model_id is None
+    assert dedicado.model_id == cards_by_signal()["detect_clickbait"]["model_id"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## #128 · El catálogo se pinta solo: el formulario sale del esquema

Closes #128

El backend servía la pantalla entera desde #97 y #137. Lo que faltaba era el
consumidor — y el riesgo no era construirla, era construirla **cableando las
doce herramientas**: un formulario por tool, que funciona el primer día y
convierte cada herramienta nueva en trabajo de frontend. Eso incumple R1.9 y
vacía de sentido que el catálogo se construya por handshake.

### Qué incluye

- **`sistema/campos.ts`** *(nuevo)* — lee el `input_schema` crudo y dice qué
  campos pintar. Sin Angular, para probarlo con datos.
- **`sistema/esquema-form.{ts,html,scss}`** *(nuevo)* — el formulario, que no
  conoce ninguna herramienta.
- **`sistema/sistema-page.{ts,html,scss}`** *(nuevo)* — servidores (R6.11),
  catálogo con búsqueda y filtro (R6.2, R6.9) y fichas de modelo (R3.8).
- **`api/tools.service.ts`** *(nuevo)* — `GET /tools` y
  `POST /tools/{name}/execute`, con los tipos derivados de `paths`.
- **`api/base.ts` y `api/errores.ts`** *(nuevos)* — lo que dejó de ser de una
  sola pantalla al haber dos.
- **`api/schemas.py`** — `ToolModelCard` gana `name`, `task` y `model_id`.
- **`app.routes.ts` / `app.html`** — ruta `/sistema` y segunda pestaña.

### El esquema se midió antes de escribir el lector

Contra `mcp.list_tools()`: ocho `string`, tres opcionales, dos `integer` con
`minimum`/`maximum`/`default` y dos `number`. Ni enums, ni arrays, ni objetos
anidados.

La trampa estaba en los opcionales. `topic: str | None = None` **no se publica
como `{"type": "string"}`** sino como `anyOf: [{string}, {null}]`; sin
resolverlo, los tres campos opcionales del catálogo habrían salido como
desconocidos. El `anyOf` se resuelve sólo si queda **un** tipo tras descartar el
`null`: una unión de verdad —`str | int`— no se sabe pintar con un control, y
sigue siendo desconocida a propósito.

### Lo desconocido se enseña, no se omite

Omitirlo mandaría un cuerpo incompleto, y el 422 hablaría de un campo que la
pantalla nunca dibujó. Se enseña con su esquema delante — la misma regla que el
`@default` de `senal-card`.

Con un matiz que apareció al implementarlo: el botón se bloquea **sólo si el
campo desconocido es obligatorio**. Uno opcional no impide una petición válida,
y desactivar ahí sería quitar una función que sí sirve. Un test para cada caso.

### La ficha publicaba tres de sus siete campos

`ToolModelCard` llevaba `type`, `dimension` y `limitations`. Sin `name`, `task`
ni `model_id`, el catálogo podía decir que `detect_clickbait_linear` es
interpretable y mide forma, pero no qué es ni qué hace — y la pantalla habría
enseñado el id de máquina como nombre, que es justo lo que #133 quitó de la
pantalla de análisis.

Los tests comparan contra `cards_by_signal()`, no contra cadenas escritas.

### Tres canales que no se pueden fundir

| Qué ha pasado | Por dónde llega |
|---|---|
| Un servidor MCP no responde | 200, `status: unreachable`, con su motivo |
| La herramienta se ejecutó y falló | 200, `status: error`, con su `detail` |
| 404 · 422 · 504 | canal de error, mensaje propio por código |

El **504** es el que más importa separar: no dice que la herramienta fallara,
dice que se agotó la espera — en #113 terminó bien a los 151 s con la API ya
desistida.

### Nada de esto nombra una herramienta

Las categorías del filtro salen de un `Set` sobre la respuesta, no de las cuatro
de `metadata.py` copiadas. Los campos salen del esquema. Las fichas salen de
`model_card`. El test del filtro compara el desplegable contra el catálogo del
fixture, no contra una lista escrita en el frontend.

### Medido

- **60 tests de frontend** (35 nuevos), lint limpio con reglas de tipos y de
  accesibilidad.
- La pantalla sale como **fragmento aparte de 21,69 kB**: la carga diferida que
  #126 preparó se nota por primera vez en la salida del empaquetador.
- `tool_count` es **obligatorio incluso en un servidor `unreachable`** (tiene
  `default: 0`). Lo destapó un fixture que no compilaba.
- ESLint avisó de `unbound-method` con `Validators.required`, y mirarlo dio una
  razón mejor para no usarlo: **acepta un campo lleno de espacios**, cuando el
  proyecto ya decidió lo contrario para el titular de `/analyze`.

### Fuera de alcance, a propósito

- **`GET /health`** no lo consume nadie todavía. Es otra pregunta que R6.11 —lo
  que el sistema *es* frente a lo que ahora *funciona*—, y va en **#147**.
- **El transporte de R6.11**: el contrato no publica un campo `transport` y no
  se inventa uno; la URL lo dice.
- **Pantallas estrechas**, que son #130.
