### PR TITLE
feat(web): responsive medido, la señal caída visible y los errores entendibles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,163 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### Lo que la interfaz no contaba de sí misma (#130)
+
+Último de H3, y transversal por naturaleza: sólo se puede hacer cuando las
+pantallas existen. Pide dos cosas —R6.8, que funcione en escritorio y tabletas;
+R6.7, que los errores lleguen entendibles— y las dos empezaron por medir, porque
+el plan escrito antes de mirar decía algo que resultó ser falso.
+
+#### La predicción era mala, y por eso se mide
+
+El plan afirmaba, dos veces, que **la tabla del historial era lo que peor se
+llevaba con el ancho**. Medido a 768 y 1024 en las cuatro rutas, comprobando qué
+elemento sobresale del viewport:
+
+| Ruta | 768 px | 1024 px |
+|---|---|---|
+| `/analizar` | no desborda | no desborda |
+| `/historial` | no desborda · tabla **1.662 px** de alto | tabla **1.099 px** |
+| `/sistema` | no desborda | no desborda |
+| `/analisis/:id` | no desborda | pastillas en 3 filas |
+
+**Cero elementos desbordan, con cero `@media` en el proyecto.** Lo sostienen
+`flex-wrap` y un `grid` con `auto-fill`. El coste de estrecharse no es
+horizontal sino vertical: la tabla crece un 51 % porque todo envuelve.
+
+De haber empezado por el CSS se habría añadido un `overflow-x` que nadie
+necesita, y R6.8 se habría dado por resuelto sin haberlo comprobado.
+
+#### La señal caída no se veía caída
+
+El borde de color de una tarjeta lleva el **tipo** de señal —dónde está la
+transparencia: interpretable, híbrida, opaca—, y eso significaba que una opaca
+que había fallado se pintaba exactamente igual que una opaca que había
+funcionado. Medido sobre un análisis con `detect_clickbait` en `error`:
+
+| Señal | Estado | Borde |
+|---|---|---|
+| RoBERTa dedicado | **error** | `rgb(184,84,80)` |
+| RoBERTa afinado en tuits | no vota | `rgb(184,84,80)` |
+
+Lo único que las distinguía era leer la palabra «error». Es justo lo que el
+issue señala: `_run_signals` aísla los fallos con `return_exceptions=True` para
+que una señal caída no se lleve el análisis por delante, y **si la interfaz no
+lo refleja, ese trabajo no se ve**.
+
+Ahora una señal que no produjo resultado se **apaga**: borde y fondo grises. Dos
+decisiones dentro:
+
+- **El tipo no se pierde.** La insignia sigue diciendo `opaque`. La información
+  sigue ahí; deja de competir por la atención.
+- **La comparación es contra `ok`, no contra la lista de fallos.**
+  `not_applicable` se llamaba `no_aplicable` antes de #134, así que enumerar los
+  estados malos habría dejado sin apagar justo las filas viejas del historial.
+  `ok` es el valor que no ha cambiado nunca. Hay un test con la clave antigua.
+
+Y una distinción que el diseño conserva: `analyze_sentiment` dice «no vota» y
+**no** se apaga, porque funcionó — mide tono, no clickbait. *No funcionó* y
+*funcionó y no opina* son cosas distintas, y antes se veían igual de bien.
+
+#### Las pastillas habían dejado de ser un índice
+
+La plantilla decía literalmente «*Índice compacto: todas las señales caben sobre
+la línea de flotación*», y desde #133 la pastilla muestra el `label` en vez del
+id de la herramienta: «Regresión logística sobre features léxicas (entrenada en
+Chakraborty)». Medido: **531 px una sola pastilla de 1024**, en tres filas.
+
+Se corta por el paréntesis, y eso es lo que lo hace mantenible: es una **regla,
+no un diccionario**. Una señal nueva no hay que añadirla a ninguna lista —la
+misma decisión que hace que las categorías del filtro de Sistema salgan de un
+`Set` sobre la respuesta y no de una constante—. La precisión entre paréntesis
+es de la ficha; el índice enseña el nombre.
+
+**531 px → 349 px, y de tres filas a dos.** El nombre completo sigue entero en
+la tarjeta, dos dedos más abajo.
+
+El comentario de la plantilla ahora dice por qué vuelve a ser cierto, con el
+número delante.
+
+#### R6.7: el inventario, y dónde estaba el hueco
+
+Un repaso por pantalla de qué códigos puede recibir y cuáles traduce:
+
+| Pantalla | Ruta | Declara el contrato | Traduce |
+|---|---|---|---|
+| Analizar | `POST /analyze` | 200 · 422 | 0 · 422 · ≥500 · resto |
+| Análisis guardado | `GET /history/{id}` | 200 · 404 · 422 | 404 propio + los de arriba |
+| Historial | `GET /history` | 200 · 422 | 0 · 422 · ≥500 · resto |
+| Sistema · catálogo | `GET /tools` | 200 | 0 · ≥500 · resto |
+| Sistema · ejecutar | `POST /tools/{name}/execute` | 200 · 404 · 422 · 504 | los cuatro + 0 · ≥500 · resto |
+
+Ningún código declarado llega sin mensaje, y los dos que el issue nombra —el 504
+de #113 y el 422 de validación— tienen frase propia desde #128. El `status: 0`
+está en las cuatro pantallas: no es un código HTTP, es que no contestó nadie, y
+el remedio que le das a quien mira es otro.
+
+**El hueco no estaba en el canal de errores, sino dentro de una respuesta 200**,
+y visto de cerca tiene sentido: `/analyze` responde 200 aunque una señal falle
+—decisión de #85—, así que el fallo más visible del sistema **nunca pasa por el
+traductor de errores de la pantalla**. El `detail` de la señal caída se volcaba
+tal cual como único mensaje:
+
+```
+HTTP error: 400 - {"error":"Model not supported by provider hf-inference"}
+```
+
+Ahora va la frase que se entiende primero, y el volcado debajo marcado como
+técnico. **No se esconde**: es lo único que permite diagnosticar, y esconderlo
+habría cambiado un problema por otro. En `not_applicable` no se antepone nada,
+porque su detalle ya es la frase que hay que leer —«Requiere el cuerpo o teaser
+de la noticia»— y precederla de «no llegó a ejecutarse» sería falso.
+
+Un caso revisado y **no** tocado: en Sistema, un servidor caído enseña
+`ConnectError: All connection attempts failed`. También es técnico, pero la
+frase que se entiende ya está en la fila —«no responde · 0 herramientas»— y el
+motivo va debajo como precisión. La estructura ya era la correcta, repartida en
+dos líneas.
+
+#### Dos incoherencias que aparecieron al mirar las capturas
+
+Ninguna la habrían encontrado los tests, que comprueban que el texto **está**, no
+que se vea coherente:
+
+- **En el historial convivían un enlace subrayado y un botón con caja** en la
+  misma columna, para dos acciones que hacen lo mismo: enseñar esa entrada. Se
+  igualó el aspecto **sin igualar el elemento**: la que navega sigue siendo un
+  `<a>` —se abre en otra pestaña, y el lector de pantalla la anuncia como
+  enlace— y la que despliega sigue siendo un `<button>`. Medido después: mismo
+  borde, mismo fondo, misma altura, distinta etiqueta. El `nowrap` que lleva ese
+  estilo quita además una línea por fila a 768 px.
+- **La insignia de tipo estaba tintada en la tarjeta de señal y gris en la ficha
+  de modelo.** Dos pantallas diciendo lo mismo de dos maneras. Ahora la ficha usa
+  los mismos tres colores que su borde.
+
+#### Medido
+
+- **101 tests de frontend** (12 nuevos), lint limpio con reglas de tipos y de
+  accesibilidad.
+- Los números de arriba salen de `getComputedStyle` y `getBoundingClientRect`
+  sobre la aplicación corriendo con sus tres procesos —servidor MCP, API y
+  `ng serve`—, no de mirar capturas.
+- El caso de prueba se creó a propósito: un análisis nuevo con el proveedor
+  `hf-inference` caído, que dejó una entrada con una señal en `error` y otra en
+  `not_applicable` — los dos casos que el issue pide comprobar, reales y no
+  simulados.
+
+#### Límites
+
+- **Por debajo de ~700 px la tabla del historial sí desborda**, con barra
+  horizontal. Queda fuera de R6.8, que pide escritorio y tabletas y no móvil;
+  se anota porque es dónde está el límite y dónde iría el contenedor con
+  `overflow-x` el día que se quiera bajar de ahí.
+- **Sigue sin haber ninguna `@media`.** No es un olvido: nada de lo medido a 768
+  la pedía, y añadir un punto de ruptura «por si acaso» habría sido escribir CSS
+  contra un problema que no existe.
+- Un análisis guardado antes de #134 se sigue viendo degradado —ids de máquina
+  por nombre, insignia `opaco` sin color—, que es la degradación diseñada en
+  #129 y no cambia aquí.
+
 ### El historial se puede leer, y un análisis guardado se vuelve a ver (#129)
 
 `GET /history` existía con paginación, filtros y retención desde #102 y #103, y

--- a/frontend/src/app/analisis/analisis-page.html
+++ b/frontend/src/app/analisis/analisis-page.html
@@ -104,11 +104,17 @@
 
   <h2 class="seccion">Señales contrastadas ({{ analisis.signals.length }})</h2>
 
-  <!-- Índice compacto: todas las señales caben sobre la línea de flotación. -->
+  <!-- Índice compacto, y lo es porque la pastilla usa el nombre CORTO: con el
+       `label` entero una sola ocupaba 531 px de 1024 (medido en #130). El
+       nombre completo está en la tarjeta, dos dedos más abajo. -->
   <ul class="pastillas">
     @for (senal of analisis.signals; track senal.name) {
-      <li class="pastilla" [attr.data-tipo]="senal.type">
-        <strong>{{ nombre(senal) }}</strong>
+      <li
+        class="pastilla"
+        [class.atenuada]="!funciono(senal)"
+        [attr.data-tipo]="senal.type"
+      >
+        <strong>{{ nombreCorto(senal) }}</strong>
         <span>{{ estado(senal) }}</span>
       </li>
     }

--- a/frontend/src/app/analisis/analisis-page.scss
+++ b/frontend/src/app/analisis/analisis-page.scss
@@ -221,6 +221,14 @@ button[disabled] {
   background: var(--opaque-fondo);
 }
 
+/* Y la pastilla se apaga con su tarjeta: el índice tiene que decir de un
+   vistazo cuáles votaron. Mismo truco de especificidad. */
+.pastilla.atenuada[data-tipo] {
+  border-color: var(--borde);
+  background: var(--fondo-suave);
+  color: var(--texto-suave);
+}
+
 .pastilla span {
   color: var(--texto-suave);
 }

--- a/frontend/src/app/analisis/analisis-page.spec.ts
+++ b/frontend/src/app/analisis/analisis-page.spec.ts
@@ -15,7 +15,7 @@ const RESPUESTA: AnalyzeResponse = {
   signals: [
     {
       name: 'detect_clickbait_lexical',
-      label: 'Léxico por reglas',
+      label: 'Léxico por reglas (listas de cues de Chakraborty et al. 2016)',
       status: 'ok',
       dimension: 'form',
       type: 'interpretable',
@@ -30,7 +30,7 @@ const RESPUESTA: AnalyzeResponse = {
     },
     {
       name: 'detect_clickbait_incoherence',
-      label: 'Incoherencia titular ↔ cuerpo',
+      label: 'MiniLM-L6-v2 (embeddings de frase)',
       status: 'not_applicable',
       dimension: 'deception',
       type: 'hybrid',
@@ -39,7 +39,7 @@ const RESPUESTA: AnalyzeResponse = {
     },
     {
       name: 'analyze_sentiment',
-      label: 'Tono',
+      label: 'RoBERTa afinado en tuits (3 clases)',
       status: 'ok',
       dimension: 'tone',
       type: 'opaque',
@@ -276,5 +276,39 @@ describe('AnalisisPage', () => {
       'no tiene forma de an',
     );
     expect(html().querySelector('.veredicto')).toBeNull();
+  });
+
+  // El índice compacto tiene que decir de un vistazo cuáles votaron. La segunda
+  // señal del fixture es `not_applicable` (la incoherencia sin cuerpo), que es
+  // el caso real de un análisis sin contenido.
+  it('las pastillas de las señales que no votaron se apagan', async () => {
+    pagina.formulario.controls.headline.setValue('Un titular');
+    await enviar();
+
+    http.expectOne('/api/analyze').flush(SOBRE);
+    await fixture.whenStable();
+
+    const apagadas = [...html().querySelectorAll('.pastilla')]
+      .filter((pastilla) => pastilla.classList.contains('atenuada'))
+      .map((pastilla) => pastilla.querySelector('strong')?.textContent);
+
+    expect(apagadas).toEqual(['MiniLM-L6-v2']);
+  });
+
+  // Medido en #130: con el `label` entero una sola pastilla ocupaba 531 px de
+  // 1024, y el comentario de la plantilla seguía prometiendo un índice compacto.
+  // La precisión entre paréntesis es de la ficha, no del indice.
+  it('el índice usa el nombre corto y la tarjeta el completo', async () => {
+    pagina.formulario.controls.headline.setValue('Un titular');
+    await enviar();
+
+    http.expectOne('/api/analyze').flush(SOBRE);
+    await fixture.whenStable();
+
+    const pastilla = html().querySelector('.pastilla strong')?.textContent;
+    expect(pastilla).toBe('Léxico por reglas');
+
+    const tarjeta = html().querySelector('app-senal-card strong')?.textContent;
+    expect(tarjeta).toContain('Chakraborty et al. 2016');
   });
 });

--- a/frontend/src/app/analisis/analisis-page.ts
+++ b/frontend/src/app/analisis/analisis-page.ts
@@ -19,6 +19,8 @@ import { TitularResaltado } from './titular-resaltado';
 import {
   estadoDeSenal,
   nombreDeDimension,
+  funciono,
+  nombreCortoDeSenal,
   nombreDeSenal,
   nombreDeVeredicto,
   resumenDimension,
@@ -92,7 +94,9 @@ export class AnalisisPage {
 
   // La plantilla sólo ve miembros de la clase, no imports del módulo.
   protected readonly nombre = nombreDeSenal;
+  protected readonly nombreCorto = nombreCortoDeSenal;
   protected readonly estado = estadoDeSenal;
+  protected readonly funciono = funciono;
   protected readonly dimension = nombreDeDimension;
   protected readonly resumen = resumenDimension;
 

--- a/frontend/src/app/analisis/senal-card.html
+++ b/frontend/src/app/analisis/senal-card.html
@@ -1,4 +1,8 @@
-<article class="tarjeta" [attr.data-tipo]="senal().type">
+<article
+  class="tarjeta"
+  [class.atenuada]="atenuada()"
+  [attr.data-tipo]="senal().type"
+>
   <button
     type="button"
     class="cabecera"

--- a/frontend/src/app/analisis/senal-card.html
+++ b/frontend/src/app/analisis/senal-card.html
@@ -15,8 +15,25 @@
     <span class="chevron" aria-hidden="true">{{ abierta() ? '▾' : '▸' }}</span>
   </button>
 
-  @if (senal().status !== 'ok') {
-    <p class="motivo">{{ senal().detail }}</p>
+  @if (atenuada()) {
+    <p class="motivo">
+      @if (senal().status === 'error') {
+        <!--
+          R6.7: el `detail` de una señal caída es texto técnico —«HTTP error:
+          400 - {"error":"Model not supported by provider hf-inference"}»— y
+          volcarlo como ÚNICO mensaje es lo que el requisito prohíbe. Se
+          antepone la frase que se entiende, y el volcado se queda marcado como
+          lo que es: no se esconde, porque es lo único que permite diagnosticar.
+        -->
+        <span class="motivo__resumen">Esta señal no llegó a ejecutarse.</span>
+        <span class="motivo__tecnico">{{ senal().detail }}</span>
+      } @else {
+        <!-- En `not_applicable` el detalle YA es la frase que se entiende
+             («Requiere el cuerpo o teaser de la noticia»): anteponerle nada
+             sería ruido. -->
+        {{ senal().detail }}
+      }
+    </p>
   } @else if (abierta()) {
     @switch (senal().name) {
       @case ('detect_clickbait_lexical') {

--- a/frontend/src/app/analisis/senal-card.scss
+++ b/frontend/src/app/analisis/senal-card.scss
@@ -96,6 +96,21 @@
   margin: 0 0.9rem 0.6rem;
 }
 
+.motivo__resumen {
+  display: block;
+}
+
+/* El volcado se ve como lo que es —texto de máquina—, para que nadie lo lea
+   esperando una explicación. */
+.motivo__tecnico {
+  display: block;
+  margin-top: 0.35rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75rem;
+  color: var(--texto-suave);
+  overflow-wrap: anywhere;
+}
+
 .motivo {
   padding: 0.5rem 0.7rem;
   border-radius: 6px;

--- a/frontend/src/app/analisis/senal-card.scss
+++ b/frontend/src/app/analisis/senal-card.scss
@@ -17,6 +17,26 @@
   border-left-color: var(--opaque);
 }
 
+/* Una señal que no llegó a producir resultado se APAGA.
+ *
+ * El selector lleva `[data-tipo]` para ganar a las tres reglas de arriba por
+ * ESPECIFICIDAD y no por orden: reordenar el fichero no puede romperlo. */
+.tarjeta.atenuada[data-tipo] {
+  border-left-color: var(--borde);
+  background: var(--fondo-suave);
+}
+
+.tarjeta.atenuada strong {
+  color: var(--texto-suave);
+}
+
+/* La insignia pierde el color del tipo, pero no la palabra: el tipo sigue
+   siendo cierto, sólo deja de competir por la atención. */
+.tarjeta.atenuada .badge {
+  background: var(--fondo);
+  color: var(--texto-suave);
+}
+
 .cabecera {
   display: flex;
   align-items: center;

--- a/frontend/src/app/analisis/senal-card.spec.ts
+++ b/frontend/src/app/analisis/senal-card.spec.ts
@@ -40,6 +40,20 @@ const CAIDA: SignalResult = {
   detail: 'HTTP error: 400 - Model not supported by provider hf-inference',
 };
 
+/**
+ * La incoherencia sin cuerpo de noticia. Su `detail` no es un volcado: ya es la
+ * frase que hay que leer, y por eso se trata distinto que un error.
+ */
+const NO_APLICABLE: SignalResult = {
+  name: 'detect_clickbait_incoherence',
+  label: 'MiniLM-L6-v2 (embeddings de frase)',
+  status: 'not_applicable',
+  dimension: 'deception',
+  type: 'hybrid',
+  is_clickbait: null,
+  detail: 'Requiere el cuerpo o teaser de la noticia.',
+};
+
 const DESCONOCIDA: SignalResult = {
   name: 'una_senal_futura',
   label: 'Una señal futura',
@@ -151,5 +165,32 @@ describe('SenalCard', () => {
     const raiz = await montar(vieja);
 
     expect(raiz.querySelector('.tarjeta')?.classList).toContain('atenuada');
+  });
+
+  // R6.7 pide que el error del backend llegue entendible y no como un volcado.
+  // El `detail` de esta señal es literalmente
+  // «HTTP error: 400 - {"error":"Model not supported by provider hf-inference"}»,
+  // así que se antepone la frase que se entiende y el volcado se queda marcado
+  // como técnico: esconderlo dejaría sin nada a quien tenga que diagnosticar.
+  it('una señal caída explica primero, y vuelca después', async () => {
+    const raiz = await montar(CAIDA);
+
+    expect(raiz.querySelector('.motivo__resumen')?.textContent).toContain(
+      'no llegó a ejecutarse',
+    );
+    expect(raiz.querySelector('.motivo__tecnico')?.textContent).toContain(
+      'hf-inference',
+    );
+  });
+
+  // En `not_applicable` el detalle YA es la frase que se entiende, así que no
+  // se le antepone nada: sería ruido sobre algo que no ha fallado.
+  it('una no aplicable usa su detalle tal cual', async () => {
+    const raiz = await montar(NO_APLICABLE);
+
+    expect(raiz.querySelector('.motivo__resumen')).toBeNull();
+    expect(raiz.querySelector('.motivo')?.textContent).toContain(
+      'Requiere el cuerpo',
+    );
   });
 });

--- a/frontend/src/app/analisis/senal-card.spec.ts
+++ b/frontend/src/app/analisis/senal-card.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed, type ComponentFixture } from '@angular/core/testing';
 
 import type { SignalResult } from '../api/models';
+import type { SenalGuardada } from './formas';
 import { SenalCard } from './senal-card';
 
 const LEXICA: SignalResult = {
@@ -52,7 +53,9 @@ const DESCONOCIDA: SignalResult = {
 describe('SenalCard', () => {
   let fixture: ComponentFixture<SenalCard>;
 
-  const montar = async (senal: SignalResult) => {
+  // La forma ANCHA, no el contrato: esta tarjeta pinta también lo guardado
+  // con versiones anteriores, y es lo que recibe de verdad desde #129.
+  const montar = async (senal: SenalGuardada) => {
     fixture = TestBed.createComponent(SenalCard);
     fixture.componentRef.setInput('senal', senal);
     await fixture.whenStable();
@@ -114,5 +117,39 @@ describe('SenalCard', () => {
     expect(html.querySelector('.crudo')?.textContent).toContain(
       'que nadie ha previsto',
     );
+  });
+
+  // Medido en #130 sobre el análisis 31: la tarjeta de una opaca CAÍDA tenía el
+  // mismo borde que la de una opaca sana, `rgb(184,84,80)`, porque el color
+  // lleva el TIPO. Lo único que las distinguía era leer la palabra «error».
+  it('una señal caída se apaga, y una sana no', async () => {
+    const caida = await montar(CAIDA);
+    expect(caida.querySelector('.tarjeta')?.classList).toContain('atenuada');
+
+    const sana = await montar(LEXICA);
+    expect(sana.querySelector('.tarjeta')?.classList).not.toContain('atenuada');
+  });
+
+  // Apagarla no puede borrar de que TIPO era: eso sigue siendo cierto, sólo
+  // deja de competir por la atención.
+  it('apagada, la tarjeta sigue diciendo su tipo', async () => {
+    const raiz = await montar(CAIDA);
+
+    expect(raiz.querySelector('.badge')?.textContent).toContain('opaque');
+    expect(raiz.querySelector('.tarjeta')?.getAttribute('data-tipo')).toBe('opaque');
+  });
+
+  // `not_applicable` tampoco votó, así que también se apaga. Y se comprueba con
+  // el valor ANTIGUO —`no_aplicable`, de antes de #134— porque el historial los
+  // guarda: `funciono` compara contra `ok`, no contra la lista de fallos.
+  it('una señal no aplicable se apaga, también con la clave vieja', async () => {
+    // Tipado con la forma ANCHA, no con el contrato: `no_aplicable` no es un
+    // `SignalStatus` válido hoy —lo dice el compilador— y ése es justo el
+    // caso, una fila guardada antes de #134.
+    const vieja: SenalGuardada = { ...CAIDA, status: 'no_aplicable' };
+
+    const raiz = await montar(vieja);
+
+    expect(raiz.querySelector('.tarjeta')?.classList).toContain('atenuada');
   });
 });

--- a/frontend/src/app/analisis/senal-card.ts
+++ b/frontend/src/app/analisis/senal-card.ts
@@ -4,6 +4,7 @@ import type { SenalGuardada } from './formas';
 import { comoEtiqueta, comoIncoherencia, comoLexico, comoLineal } from './datos';
 import {
   estadoDeSenal,
+  funciono,
   nombreDeCategoria,
   nombreDeSenal,
   numero,
@@ -32,6 +33,16 @@ export class SenalCard {
    * el análisis anterior.
    */
   readonly abierta = linkedSignal(() => this.senal().type !== 'opaque');
+
+  /**
+   * Una señal que no llegó a producir resultado se APAGA.
+   *
+   * El borde de color lleva el TIPO —dónde está la transparencia—, y eso
+   * hace que una opaca caída se vea igual que una opaca sana: medido en
+   * #130, las dos con `rgb(184,84,80)`. El tipo no se pierde al apagarla,
+   * sigue escrito en la insignia.
+   */
+  readonly atenuada = computed(() => !funciono(this.senal()));
 
   readonly lexico = computed(() => comoLexico(this.senal().data));
   readonly lineal = computed(() => comoLineal(this.senal().data));

--- a/frontend/src/app/analisis/vocabulario.ts
+++ b/frontend/src/app/analisis/vocabulario.ts
@@ -43,6 +43,23 @@ export function nombreDeSenal(senal: SenalGuardada): string {
   return senal.label ?? senal.name;
 }
 
+/**
+ * El nombre de una señal para el ÍNDICE, sin su precisión entre paréntesis.
+ *
+ * Los `label` que llegan desde #133 la traen incorporada —«RoBERTa dedicado
+ * (entrenado en Webis-17)»—, y eso es justo lo que hace falta en la ficha y
+ * estorba en un índice: medido en #130, una sola pastilla ocupaba 531 px de
+ * 1024, y la plantilla seguía prometiendo que cabían todas sobre la línea de
+ * flotación.
+ *
+ * Se corta por el paréntesis, que es una REGLA y no un diccionario: una señal
+ * nueva no hay que añadirla aquí. El nombre completo sigue entero en la
+ * tarjeta, que es donde se lee con calma.
+ */
+export function nombreCortoDeSenal(senal: SenalGuardada): string {
+  return nombreDeSenal(senal).split(' (')[0];
+}
+
 export function nombreDeVeredicto(verdict: string): string {
   return VEREDICTOS[verdict] ?? verdict;
 }
@@ -53,6 +70,18 @@ export function nombreDeDimension(dimension: string): string {
 
 export function nombreDeCategoria(categoria: string): string {
   return CATEGORIAS[categoria] ?? categoria;
+}
+
+/**
+ * ¿Llegó esta señal a producir un resultado?
+ *
+ * Se compara contra `ok` y no contra la lista de estados malos a propósito:
+ * `not_applicable` se llamaba `no_aplicable` antes de #134, así que enumerar
+ * los fallos dejaría sin apagar lo guardado entonces. `ok` es el valor que no
+ * ha cambiado nunca.
+ */
+export function funciono(senal: SenalGuardada): boolean {
+  return senal.status === 'ok';
 }
 
 /** Qué dijo la señal, o por qué no dijo nada. */

--- a/frontend/src/app/historial/historial-page.html
+++ b/frontend/src/app/historial/historial-page.html
@@ -108,11 +108,13 @@
             <td>{{ entrada.status }}</td>
             <td>
               @if (entrada.kind === 'analysis') {
-                <a [routerLink]="['/analisis', entrada.id]">Ver el análisis</a>
+                <a class="accion" [routerLink]="['/analisis', entrada.id]">
+                  Ver el análisis
+                </a>
               } @else {
                 <button
                   type="button"
-                  class="secundario"
+                  class="accion"
                   (click)="alternar(entrada.id)"
                   [attr.aria-expanded]="abierta() === entrada.id"
                 >

--- a/frontend/src/app/historial/historial-page.scss
+++ b/frontend/src/app/historial/historial-page.scss
@@ -130,6 +130,33 @@ code {
   white-space: nowrap;
 }
 
+/* Las dos acciones de una fila hacen lo mismo —enseñar esa entrada— y tienen
+   que verse igual. Lo que NO se iguala es el elemento: una navega y sigue
+   siendo un enlace —se abre en otra pestaña, y el lector de pantalla lo
+   anuncia como enlace—, y la otra despliega aquí y sigue siendo un botón.
+   Misma pinta, distinta naturaleza.
+
+   El `nowrap` además le quita una línea a cada fila a 768 px, donde «Ver el
+   análisis» partía en dos. */
+.accion {
+  display: inline-block;
+  padding: 0.35rem 0.8rem;
+  border: 1px solid var(--borde);
+  border-radius: 6px;
+  background: var(--fondo-suave);
+  color: inherit;
+  font: inherit;
+  font-size: 0.85rem;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.accion:hover {
+  border-color: var(--acento);
+  color: var(--acento);
+}
+
 /* --- Paginación y estados --- */
 
 .retencion {

--- a/frontend/src/app/historial/historial-page.spec.ts
+++ b/frontend/src/app/historial/historial-page.spec.ts
@@ -196,4 +196,20 @@ describe('HistorialPage', () => {
     const raiz = fixture.nativeElement as HTMLElement;
     expect(raiz.textContent).toContain('La API falló al leer el historial');
   });
+
+  // Las dos acciones de una fila hacen lo mismo —enseñar esa entrada— y se ven
+  // igual. Lo que no comparten es la naturaleza, y es deliberado: una navega y
+  // tiene que ser un enlace (otra pestaña, y el lector de pantalla lo anuncia
+  // como tal), la otra despliega aquí y tiene que ser un botón.
+  it('las dos acciones comparten estilo sin compartir naturaleza', async () => {
+    const raiz = await montar();
+
+    const enlace = raiz.querySelector('tbody a');
+    const boton = raiz.querySelector('tbody button');
+
+    expect(enlace?.classList).toContain('accion');
+    expect(boton?.classList).toContain('accion');
+    expect(enlace?.tagName).toBe('A');
+    expect(boton?.tagName).toBe('BUTTON');
+  });
 });

--- a/frontend/src/app/sistema/sistema-page.scss
+++ b/frontend/src/app/sistema/sistema-page.scss
@@ -220,6 +220,21 @@ button:focus-visible {
   border-left-color: var(--opaque);
 }
 
+/* La insignia dice el tipo y lo dice CON SU COLOR, igual que el borde. Es lo
+   que `senal-card` ya hacía; tenerlo de dos maneras según la pantalla era la
+   incoherencia. */
+.ficha[data-tipo='interpretable'] .badge {
+  background: var(--interpretable-fondo);
+}
+
+.ficha[data-tipo='hybrid'] .badge {
+  background: var(--hybrid-fondo);
+}
+
+.ficha[data-tipo='opaque'] .badge {
+  background: var(--opaque-fondo);
+}
+
 .ficha__tarea {
   margin: 0;
   color: var(--texto-suave);


### PR DESCRIPTION
## #130 · Lo que la interfaz no contaba de sí misma

Closes #130

Último de H3, y transversal por naturaleza: sólo se podía hacer con las
pantallas ya hechas. Pide dos cosas —R6.8 en escritorio y tabletas, R6.7 que los
errores lleguen entendibles— y las dos empezaron por medir, porque el plan
escrito antes de mirar decía algo que resultó falso.

### La predicción era mala, y por eso se mide

El plan afirmaba dos veces que **la tabla del historial era lo que peor se
llevaba con el ancho**. Medido a 768 y 1024 en las cuatro rutas, comprobando qué
elemento sobresale del viewport:

| Ruta | 768 px | 1024 px |
|---|---|---|
| `/analizar` | no desborda | no desborda |
| `/historial` | no desborda · tabla 1.662 px de alto | tabla 1.099 px |
| `/sistema` | no desborda | no desborda |
| `/analisis/:id` | no desborda | pastillas en 3 filas |

**Cero elementos desbordan, con cero `@media` en el proyecto.** Lo sostienen
`flex-wrap` y un `grid` con `auto-fill`. El coste de estrecharse es vertical, no
horizontal. De haber empezado por el CSS se habría añadido un `overflow-x` que
nadie necesita.

### La señal caída no se veía caída

El borde lleva el TIPO de señal, así que una opaca en `error` se pintaba igual
que una opaca sana — las dos con `rgb(184,84,80)`. Lo único que las distinguía
era leer la palabra «error». Es lo que el issue señala: `_run_signals` aísla los
fallos para que uno no se lleve el análisis por delante, y si la interfaz no lo
refleja, ese trabajo no se ve.

Ahora se apaga, con dos decisiones dentro:

- **El tipo no se pierde**: la insignia sigue diciendo `opaque`.
- **Se compara contra `ok`, no contra la lista de fallos.** `not_applicable` se
  llamaba `no_aplicable` antes de #134, así que enumerar los estados malos
  habría dejado sin apagar las filas viejas del historial. Con test.

Y `analyze_sentiment` dice «no vota» y **no** se apaga, porque funcionó: mide
tono. *No funcionó* y *funcionó y no opina* son cosas distintas.

### Las pastillas habían dejado de ser un índice

La plantilla prometía «todas las señales caben sobre la línea de flotación» y
desde #133 la pastilla muestra el `label`: **531 px una sola, de 1024**. Se corta
por el paréntesis —una regla, no un diccionario: una señal nueva no hay que
añadirla a ninguna lista—, y el nombre completo se queda en la tarjeta.

**531 px → 349 px, y de tres filas a dos.**

### R6.7: el inventario, y dónde estaba el hueco

| Pantalla | Ruta | Declara el contrato | Traduce |
|---|---|---|---|
| Analizar | `POST /analyze` | 200 · 422 | 0 · 422 · ≥500 · resto |
| Análisis guardado | `GET /history/{id}` | 200 · 404 · 422 | 404 propio + los de arriba |
| Historial | `GET /history` | 200 · 422 | 0 · 422 · ≥500 · resto |
| Sistema · catálogo | `GET /tools` | 200 | 0 · ≥500 · resto |
| Sistema · ejecutar | `POST /tools/{name}/execute` | 200 · 404 · 422 · 504 | los cuatro + 0 · ≥500 |

Ningún código declarado llega sin mensaje. **El hueco no estaba en el canal de
errores, sino dentro de una respuesta 200**: `/analyze` responde 200 aunque una
señal falle —decisión de #85—, así que el fallo más visible del sistema nunca
pasa por el traductor de la pantalla. Su `detail` se volcaba tal cual:

    HTTP error: 400 - {"error":"Model not supported by provider hf-inference"}

Ahora va la frase que se entiende primero y el volcado debajo, marcado como
técnico. No se esconde: es lo único que permite diagnosticar. En
`not_applicable` no se antepone nada, porque su detalle ya es la frase que hay
que leer.

### Dos incoherencias que aparecieron mirando las capturas

Ningún test podía cazarlas: comprueban que el texto está, no que se vea
coherente.

- En el historial convivían un enlace subrayado y un botón con caja para dos
  acciones que hacen lo mismo. Se igualó **el aspecto, no el elemento**: la que
  navega sigue siendo `<a>` y la que despliega sigue siendo `<button>`.
- La insignia de tipo estaba tintada en la tarjeta de señal y gris en la ficha
  de modelo. Ahora la ficha usa los mismos tres colores que su borde.

### Medido

- **101 tests de frontend** (12 nuevos) y 218 de backend, lint limpio.
- Los números salen de `getComputedStyle` y `getBoundingClientRect` sobre la
  aplicación corriendo con sus tres procesos, no de mirar capturas.
- El caso de prueba se creó a propósito: un análisis nuevo con `hf-inference`
  caído dejó una entrada con una señal en `error` y otra en `not_applicable`,
  que son los dos casos que el issue pide comprobar.

### Notas

- **Por debajo de ~700 px la tabla del historial sí desborda.** Queda fuera de
  R6.8, que pide escritorio y tabletas y no móvil; se anota porque es dónde está
  el límite y dónde iría el `overflow-x` si algún día se baja de ahí.
- **Sigue sin haber ninguna `@media`,** y es deliberado: nada de lo medido a 768
  la pedía.
- Un análisis anterior a #134 se sigue viendo degradado, que es la degradación
  diseñada en #129.
