### PR TITLE
docs: R6.14 en requisitos y dos diagramas del frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,79 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### R6.14 se escribe, y el frontend entra en los diagramas
+
+Sin issue, y conviene decir por qué: **salió de revisar los cuatro criterios de
+tageo** antes de la release `v0.4`, y son dos huecos de documentación que un
+issue propio sólo habría retrasado. El primero es además un fallo de coherencia
+que un tribunal ve antes que nadie.
+
+#### El README citaba un requisito que no existía
+
+`CLAUDE.md` recogía desde el 3 de septiembre una decisión: **R6.10 gana un matiz
+y aparece R6.14** —la interfaz no debe dejar controles que no funcionen—. Se
+aplicó en #128, donde el botón de ejecutar se bloquea si un parámetro
+obligatorio tiene un esquema que la pantalla no sabe representar, y se justificó
+**citando R6.14** en el README y en el cuerpo de la PR #148.
+
+Pero `docs/requisitos.md` tenía trece criterios en el Requisito 6. **R6.14 no
+existía.** La documentación afirmaba cumplir algo que el documento no contenía,
+y llevaba así desde el 6 de septiembre.
+
+Ahora está escrito:
+
+> **R6.14** · SI una capacidad no está disponible —el Agent_Orchestrator sin
+> configurar, o un parámetro de herramienta cuyo esquema LA Web_Interface no sabe
+> representar—, ENTONCES LA Web_Interface NO DEBERÁ ofrecer controles que no
+> puedan funcionar: DEBERÁ explicar por qué no está disponible en lugar de dejar
+> un botón cuyo único resultado posible es un error.
+
+Complementa a R6.7 y no lo repite: **aquel pide que el error se entienda; éste,
+no provocarlo.** Y R6.10 recibe su matiz —el formulario está siempre, el
+asistente cuando el orquestador esté configurado—, que no es una preferencia de
+diseño sino una consecuencia de la infraestructura: la máquina que corre el
+modelo se apaga cuando no se usa, así que el despliegue tiene que funcionar sin
+el agente.
+
+#### Los diagramas se paraban en el backend
+
+`docs/arquitectura.md` tenía siete secciones y las siete eran de servidor. De la
+SPA, nada — y H3 acababa de cerrarse. Se añaden dos.
+
+**La cadena del contrato** (sección 8) es la única del sistema que **cruza dos
+lenguajes y un paso de compilación**, así que no se ve entera en ningún fichero:
+`schemas.py` → `/openapi.json` → `openapi-typescript` → `schema.d.ts` →
+`models.ts` → servicios → pantallas → guardianes. Con ella se explican de un
+vistazo tres decisiones que hasta ahora sólo vivían en comentarios: por qué
+`schema.d.ts` se commitea aunque sea generado (para que un cambio de contrato
+aparezca en un diff), por qué el CI lo regenera y falla si difiere, y por qué
+`models.ts` se bifurca entre `paths` y `components`.
+
+**El camino de un análisis guardado** (sección 9) dibuja la decisión de #129:
+`/analizar` y `/analisis/:id` son la misma pantalla, y lo único distinto es de
+dónde sale el resultado. La secuencia enseña las dos salidas del guardián —encaja
+o no encaja— que en prosa se explican mal.
+
+Se escriben en **mermaid**, como los cuatro de #106: viven en el repositorio
+como texto, se difean y no exigen abrir una aplicación para corregir una flecha.
+Los dos SVG de draw.io son de Fase A y siguen congelados a propósito.
+
+#### Una etiqueta caducada, anotada y no corregida
+
+El diagrama de componentes de Fase A rotula **«MCP Server (STDIO)»**, y el
+transporte es configurable desde #90 — hoy se sirve por `streamable-http`. El
+dibujo se conserva porque todo lo demás sigue siendo cierto; lo que se añade es
+la nota que impide leerlo como vigente. Rehacer un diagrama congelado por una
+etiqueta costaría más de lo que aclara, y perderlo de vista costaría más aún.
+
+#### De paso, la tabla de estado de requisitos
+
+La fila de R6 decía «catálogo, historial y responsive pendientes (128, 129,
+130)». Las tres estaban cerradas. Ahora distingue lo que está hecho —las tres
+pantallas del camino determinista, con R6.7, R6.8 y R6.14— de lo que **no puede
+estarlo todavía**: R6.10, R6.12 y R6.13 dependen del asistente, y el asistente es
+R13.
+
 ### Lo que la interfaz no contaba de sí misma (#130)
 
 Último de H3, y transversal por naturaleza: sólo se puede hacer cuando las

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -311,6 +311,95 @@ La primera lleva además un `assert modulos` delante del recorrido: si la
 travesía del árbol se rompiera, la prueba se convertiría en un `assert not []`
 que pasa siempre.
 
+## 8 · El frontend: de dónde salen sus tipos
+
+Es la única cadena del sistema que **cruza dos lenguajes y un paso de
+compilación**, así que no se ve entera en ningún fichero.
+
+```mermaid
+flowchart LR
+    subgraph py["Backend · Python"]
+        SCH["schemas.py<br/>(Pydantic)"] --> OA["/openapi.json"]
+    end
+
+    OA -->|"npm run gen:api"| SD["schema.d.ts<br/>generado y COMMITEADO"]
+
+    subgraph ts["Frontend · TypeScript"]
+        SD --> MOD["models.ts"]
+        MOD -->|"de paths: lo que cruza la red"| SRV["servicios<br/>analyze · tools · history"]
+        MOD -->|"de components: las piezas"| PZ["piezas<br/>SignalResult · ToolInfo"]
+        SRV --> PAN["pantallas"]
+        PZ --> PAN
+        PAN --> GU["guardianes<br/>datos · formas · campos"]
+    end
+```
+
+Cuatro cosas que el dibujo hace visibles:
+
+- **`schema.d.ts` se genera y se commitea.** Podría regenerarse al construir,
+  pero entonces un cambio de contrato no aparecería en ningún diff. Commiteado,
+  la PR que cambia el backend enseña qué tipos cambian en el frontend.
+- **El CI lo regenera y falla si difiere.** Es lo único que impide que el
+  frontend compile contra un contrato viejo, y saltó de verdad al cambiar
+  `ToolModelCard` en #128.
+- **La bifurcación de `models.ts` no es de estilo.** Lo que cruza la red se toma
+  de `paths`, porque `http.post<T>()` no comprueba nada: es una afirmación, y
+  eligiendo `T` a mano de `components` la afirmación deja de estar atada a la
+  ruta. Pasó en #133 —el backend empezó a devolver un sobre y el frontend siguió
+  compilando— y por eso la regla es dura. Las piezas de dentro sí vienen de
+  `components`: son formas con nombre propio que se pasan a un componente.
+- **Los guardianes son la frontera de lo no tipado.** El `data` de una señal, el
+  `payload` del historial y el `input_schema` de una herramienta son
+  diccionarios libres en el contrato **a propósito**, para que quepa lo que aún
+  no existe. Cada uno pasa por una función que comprueba y devuelve `null` si no
+  encaja, y lo que no encaja **se enseña en crudo** en vez de desaparecer.
+
+## 9 · Volver a un análisis guardado
+
+`/analizar` y `/analisis/:id` son **la misma pantalla**. Lo único distinto es de
+dónde sale el resultado, y eso lo dejó preparado #127 al hacer que el bloque de
+resultados recibiera el análisis como estado en vez de calcularlo.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant HI as Historial
+    participant RO as Router
+    participant PA as AnalisisPage
+    participant API as Backend_API
+    participant GU as comoAnalisis
+
+    HI->>RO: /analisis/29
+    RO->>PA: id como input()
+    PA->>API: GET /history/29
+    API-->>PA: HistoryEntry con su payload
+    PA->>GU: comoAnalisis(payload)
+
+    alt tiene forma de analisis
+        GU-->>PA: AnalisisGuardado
+        PA->>PA: pinta la MISMA vista
+    else no la tiene
+        GU-->>PA: null
+        PA->>PA: lo dice, y el crudo queda en el historial
+    end
+```
+
+Tres decisiones que el diagrama no puede enseñar solo:
+
+- **El id llega como `input()`**, enlazado por `withComponentInputBinding()`. La
+  carga va en un `effect` y no en el constructor porque ir de `/analisis/28` a
+  `/analisis/29` **reutiliza el componente**: un `snapshot` leído al construir no
+  se enteraría del cambio.
+- **`comoAnalisis` devuelve tipos más anchos que el contrato**, y es deliberado.
+  `required` describe lo que el backend produce HOY; el historial guarda lo de
+  ayer. Hay filas sin `label` —anterior a #133— y con el veredicto en castellano
+  —anterior a #134—. `AnalyzeResponse` es asignable a `AnalisisGuardado` y al
+  revés no: esa asimetría es la que permite una sola vista para los dos orígenes.
+- **El 404 de `GET /history/{id}` es normal, no excepcional.** La retención poda
+  entradas, así que un enlace guardado deja de existir por funcionamiento
+  corriente; por eso el código está declarado en el contrato desde #129 y la
+  pantalla lo explica con esas palabras en vez de decir «no se pudo cargar».
+
 ## Los diagramas de la Fase A
 
 Se conservan como estaban. Describen **el servidor MCP**, que sigue siendo cierto
@@ -325,6 +414,7 @@ como componente aunque ya no sea el sistema entero.
   directos con su propio `httpx` y agrega `ok` / `degraded` / `down`.
 - El patrón **`tool.py` (registro) + `client.py` (lógica)** se repite idéntico en
   las integraciones, así que la estructura es predecible.
+- **El rótulo «MCP Server (STDIO)» ya no describe el despliegue**: el transporte es configurable desde #90 y hoy se sirve por `streamable-http`. El diagrama se conserva porque lo demás sigue siendo cierto, y mover un dibujo congelado por una etiqueta costaría más de lo que aclara — pero conviene leerlo con esta nota delante.
 
 ![Diagrama de secuencia del flujo get_nyt_news](img/secuencia.svg)
 
@@ -342,7 +432,7 @@ como componente aunque ya no sea el sistema entero.
 | **R3** NLP y explicabilidad | ◑ cinco señales contrastadas, incoherencia (R3.7) y fichas de modelo (R3.9) ✅; **sólo inglés**, y R3.9 a medias — los modelos no son intercambiables por configuración (issue 119) |
 | **R4** API REST | ✅ análisis, catálogo, ejecución, historial, CORS y OpenAPI |
 | **R5** Catálogo y transparencia | ✅ catálogo por handshake MCP, con procedencia y ficha de modelo |
-| **R6** Interfaz web | ◑ pantalla de análisis ✅ (issue 127); catálogo, historial y responsive pendientes (128, 129, 130); el asistente llega con R13 |
+| **R6** Interfaz web | ◑ las tres pantallas del camino determinista ✅ (127–130): análisis, catálogo e historial, con errores entendibles (R6.7), escritorio y tabletas (R6.8) y sin controles que no funcionen (R6.14). Pendiente lo que depende del asistente: R6.10, R6.12 y R6.13 llegan con R13 |
 | **R7** Docker | ⬜ H4 |
 | **R8** CI/CD | ◑ integración continua ✅ (Python y frontend); despliegue continuo ⬜ |
 | **R9** Persistencia e historial | ✅ SQLite con filtros y retención configurable |

--- a/docs/requisitos.md
+++ b/docs/requisitos.md
@@ -117,10 +117,11 @@ Este documento define los requisitos para un Trabajo de Fin de Grado (TFG) que i
 7. LA Web_Interface DEBERÁ mostrar mensajes de error en un formato entendible.
 8. LA Web_Interface DEBERÁ ser receptiva y funcionar en dispositivos de escritorio y tabletas.
 9. LA Web_Interface DEBERÁ incluir capacidades de filtrado y búsqueda para el catálogo de herramientas.
-10. LA Web_Interface DEBERÁ ofrecer **dos vías de entrada**: un formulario de análisis directo (determinista) y un **asistente conversacional** (ver Requisito 13).
+10. LA Web_Interface DEBERÁ ofrecer **dos vías de entrada**: un formulario de análisis directo (determinista) y un **asistente conversacional** (ver Requisito 13). _(Matizado: el formulario está SIEMPRE; el asistente, **cuando el Agent_Orchestrator esté configurado**. El despliegue tiene que funcionar sin él, porque la máquina que corre el modelo se apaga cuando no se usa. Ver memoria de cambios.)_
 11. LA Web_Interface DEBERÁ mostrar el estado de los **MCP_Server conectados** (nombre, transporte, estado y herramientas que aporta), generado dinámicamente a partir del descubrimiento; los filtros por servidor DEBERÁN derivarse de esa misma lista.
 12. CUANDO el Agent_Orchestrator invoque herramientas, LA Web_Interface DEBERÁ renderizar el **resultado estructurado de cada herramienta** —no solo la narración del modelo— junto a la **traza** de herramientas invocadas.
 13. SI la narración del modelo llega **vacía o ilegible**, ENTONCES LA Web_Interface DEBERÁ mostrar igualmente los **resultados estructurados** de las herramientas invocadas, indicando de forma discreta que el asistente no generó un resumen. LA Web_Interface NO DEBERÁ condicionar la visualización del análisis a la existencia de esa narración. _(Modo de fallo observado en el spike #82: el agente invoca correctamente las herramientas y devuelve una respuesta de cero caracteres; el análisis existe y no debe perderse.)_
+14. SI una capacidad no está disponible —el Agent_Orchestrator sin configurar, o un parámetro de herramienta cuyo esquema LA Web_Interface no sabe representar—, ENTONCES LA Web_Interface NO DEBERÁ ofrecer controles que no puedan funcionar: DEBERÁ explicar por qué no está disponible en lugar de dejar un botón cuyo único resultado posible es un error. _(Complementa a R6.7: aquel pide que el error se entienda; éste, no provocarlo. Ver memoria de cambios.)_
 
 ### Requisito 7: Entorno de implementación de Docker
 


### PR DESCRIPTION
## R6.14 en requisitos, y el frontend entra en los diagramas

Sin issue: salió de **revisar los cuatro criterios de tageo** antes de la release
`v0.4`, y son dos huecos de documentación que un issue propio sólo habría
retrasado.

### Qué incluye

- **`docs/requisitos.md`** — se escribe **R6.14** (no dejar controles que no
  puedan funcionar) y R6.10 recibe su matiz. El README y el cuerpo de la PR #148
  justificaban el botón bloqueado de #128 **citando R6.14**, y el Requisito 6
  tenía trece criterios: la documentación afirmaba cumplir algo que el documento
  no contenía. R6.14 complementa a R6.7 sin repetirlo — aquel pide que el error
  se entienda; éste, no provocarlo.
- **`docs/arquitectura.md`** — secciones **8** (la cadena del contrato, de
  Pydantic a los guardianes) y **9** (volver a un análisis guardado). Las siete
  que había eran todas de servidor, y H3 acaba de cerrarse. En mermaid, como los
  cuatro de #106. Se actualiza además la fila de R6 de la tabla de estado, que
  daba por pendientes #128, #129 y #130.
- **`README.md`** — la justificación del cambio de requisitos, como pide la
  convención.

### Notas

- Los dos SVG de draw.io de la Fase A siguen congelados. El de componentes
  rotula «MCP Server (STDIO)» y el transporte es configurable desde #90: se le
  añade la nota que impide leerlo como vigente, sin rehacer un dibujo congelado
  por una etiqueta.
- Los dos bloques de mermaid se comprobaron **renderizados** antes de subir: el
  de la secuencia es el primero del repositorio que usa `alt` / `else`.
- Con esto, el cuarto criterio de tageo —documentación al día— queda cumplido.
  El tercero sigue abierto: HuggingFace responde 400 y una de las doce
  herramientas no está viva.
