### PR TITLE
docs: el plan de trabajo al día, y R13 pasa a ser H5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,51 @@ Version de Python: 3.12.3
 
 ## Plan de trabajo — hitos hasta la entrega
 
-**Estado actual (agosto 2026): `v0.2.0`.** El núcleo NLP está completo y validado: cuatro señales de clickbait contrastables, un modelo lineal interpretable propio, divulgación de modelos y una evaluación metodológicamente cerrada (split train/dev/test + validación externa). Lo que resta es la **capa web** (R4–R8) y la memoria. **Entrega: febrero 2027.**
+**Estado actual (septiembre 2026): `v0.4.0`.** El núcleo NLP está completo y
+validado —cuatro señales de clickbait contrastables, un modelo lineal
+interpretable propio, divulgación de modelos y una evaluación metodológicamente
+cerrada (split train/dev/test + validación externa)—, y la capa web ya sirve las
+tres pantallas del camino determinista sobre un contrato generado. Lo que resta
+es el **despliegue** (R7, R8), el **agente conversacional** (R13) y la memoria.
+**Entrega: febrero 2027.**
 
-| Hito | Fecha | Contenido | Requisitos |
-|---|---|---|---|
-| **H1 · Diseño de interfaz** | ago–sep 2026 | Wireframes de pantallas y navegación, definición de funcionalidades, diseño de los endpoints REST | — |
-| **H2 · `v0.3` API REST** | octubre | FastAPI: exposición de las tools, catálogo con metadatos, historial **persistente**, OpenAPI, CORS, tests | **R4, R5, R9** |
-| **H3 · `v0.4` SPA funcional** | noviembre | Angular: análisis de un titular → resultados con explicabilidad visual (cues resaltados, contraste de señales), catálogo de tools | **R6** |
-| **H4 · `v0.5` Docker** | diciembre | Docker Compose (MCP + API / web), **volumen** para el historial, despliegue continuo | **R7, R8** |
-| **H5 · `v1.0` Pulido y despliegue** | enero 2027 | Responsive, gestión de errores, pruebas E2E, despliegue | R6 |
-| **H6 · Memoria y defensa** | ene–feb 2027 | Redacción de la memoria y preparación de la defensa | — |
+**El agente conversacional (R13) es H5.** Hasta el 7 de septiembre no estaba en
+ninguna fila de esta tabla, que es un hueco grande: **el agente da nombre al
+TFG**. El spike #82 validó el *tool calling* y las decisiones de diseño están
+tomadas —`POST /chat` con sondeo, `backend/agent/`, `integrations/llm/`—, pero no
+tenía fecha ni versión.
+
+| Hito | Previsto (ago 2026) | Real | Contenido | Requisitos |
+|---|---|---|---|---|
+| **H1 · Diseño de interfaz** | ago–sep 2026 | **2 ago** | Wireframes de pantallas y navegación, definición de funcionalidades, diseño de los endpoints REST, R13 | — |
+| **H2 · `v0.3` API REST** | octubre | **15 ago** | FastAPI: exposición de las tools, catálogo con metadatos, historial **persistente**, OpenAPI, CORS, tests | **R4, R5, R9** |
+| **H3 · `v0.4` SPA funcional** | noviembre | **7 sep** | Angular: análisis con explicabilidad visual, catálogo de tools, historial, responsive y gestión de errores | **R6** |
+| **H4 · `v0.5` Docker y despliegue** | diciembre | *octubre* | Docker Compose (MCP + API / web), **volumen** para el historial, despliegue continuo y pruebas E2E | **R7, R8** |
+| **H5 · `v0.6` Agente conversacional** | — | *nov–dic* | Bucle del agente, `POST /chat` con sondeo, pantalla de chat y traza de herramientas | **R13**, R6.10/12/13 |
+| **H6 · `v1.0` Memoria y defensa** | ene–feb 2027 | *dic–feb* | Redacción de la memoria y preparación de la defensa | — |
+
+**El proyecto va unos dos meses por delante de esta previsión.** H2 se cerró en
+agosto donde se planificó octubre, y H3 en septiembre donde se planificó
+noviembre. La columna «previsto» se conserva a propósito: el desfase es un dato
+del proyecto —dice que la estimación de agosto era conservadora— y no un error
+que tapar. La columna «real» de H4 a H6 es la **re-previsión hecha con ese
+adelanto**: deja alrededor de un mes de colchón antes de febrero, que es lo que
+se come el agente si sale como en el spike.
+
+**Reparto de H4 a H6, decidido el 2026-09-07.** El H5 original era «responsive,
+gestión de errores, pruebas E2E y despliegue», y #130 se llevó las dos primeras
+a H3. De lo que quedaba, el despliegue ya era H4 y las pruebas E2E son *cómo se
+verifica un despliegue*, así que se funden ahí. **H5 pasa a ser el agente**, que
+no tenía hito, y con ello H6 recupera el `v1.0` — que el esquema reserva para la
+entrega final y antes se le daba a «pulido».
+
+**El orden Docker → agente no es arbitrario.** `CLAUDE.md` fija que el
+despliegue tiene que funcionar **sin el agente**, porque la máquina que corre el
+modelo se apaga cuando no se usa; esa propiedad se demuestra desplegando
+primero. Y el agente vive en la máquina 2 por SSH desde la 1, así que necesita
+que la 1 exista. El contraargumento —el agente es lo único de resultado
+incierto, y el riesgo se ataca antes— se acepta pero pesa menos: los dos meses
+de adelanto son el colchón que lo absorbe.
 
 _(Corrección de la tabla, 2026-08-11: **R9 —la persistencia— no figuraba en ninguna fila**. H2 pedía «historial de ejecución» y H4 «historial persistente», pero el requisito que los sostiene no estaba listado en ninguno de los dos. Se asigna a H2: hacer el historial en memoria ahora y persistirlo en diciembre sería construirlo dos veces y entregar una pantalla que pierde los datos al reiniciar. A H4 le queda lo que de verdad le corresponde — montar el volumen (R7.6) para que ese fichero sobreviva al contenedor.)_
 
@@ -97,7 +132,9 @@ Dos ramas permanentes con papeles distintos:
 3. **Verificación E2E** del servidor MCP pasada (tools respondiendo en vivo).
 4. **Documentación al día** (README y requisitos reflejan lo incluido).
 
-**Esquema de versiones** (semver adaptado al TFG): **minor** (`v0.X.0`) = bloque funcional — **un hito** en Fase B (`v0.3` = H2, `v0.4` = H3…), una épica en Fase A (`v0.1.0` = MVP, `v0.2.0` = Épica 5 NLP explicable); **patch** (`v0.X.Y`) = hotfix sobre lo shipeado; **major** (`v1.0.0`) = entrega final del TFG.
+**Esquema de versiones** (semver adaptado al TFG): **minor** (`v0.X.0`) = bloque funcional — **un hito** en Fase B (`v0.3` = H2, `v0.4` = H3…), una épica en Fase A (`v0.2.0` = Épica 5 NLP explicable); **patch** (`v0.X.Y`) = hotfix sobre lo shipeado; **major** (`v1.0.0`) = entrega final del TFG.
+
+_(El **MVP se entregó sin tag**: el versionado empieza de facto en `v0.2.0`, porque hasta entonces el flujo era `feature → PR → main` directo y no había promoción que tagear. Crear un `v0.1.0` ahora sería abrir un corte en el tiempo hacia atrás, que es justo lo que el principio de abajo prohíbe.)_
 
 > **Principio:** las versiones son **cortes en el tiempo**, no contenedores temáticos. Una mejora posterior va a la **siguiente** versión aunque pertenezca por dominio a una épica ya taggeada (la trazabilidad temática la dan los labels de épica en los issues, no los tags). Los tags son inmutables: nunca se "reabre" una versión.
 


### PR DESCRIPTION
## El plan de trabajo, al día

Sin issue: salió de revisar los criterios de tageo de `v0.4.0` y de que **la
organización por hitos había dejado de ser legible**. Es sólo README, más tres
milestones creados en el tablero.

### El problema

La tabla del plan era una previsión de agosto que la realidad adelantó y que
nadie reescribió:

| Hito | Previsto | Real |
|---|---|---|
| H2 · `v0.3` | octubre | **15 ago** |
| H3 · `v0.4` | noviembre | **7 sep** |

Unos **dos meses por delante**, con la consecuencia de que «H4 · diciembre» y
«H5 · enero» habían dejado de significar nada — y un hito es un punto de control
*con fecha*.

### Qué cambia

- **La tabla gana columna «real»**, y la de «previsto» se conserva: el desfase
  es un dato del proyecto —dice que la estimación de agosto era conservadora— y
  no un error que tapar.
- **R13 pasa a ser H5.** No estaba en ninguna fila, y **el agente da nombre al
  TFG**. El H5 original era «responsive, gestión de errores, E2E y despliegue»:
  #130 se llevó las dos primeras a H3, el despliegue ya era H4 y las E2E son
  *cómo se verifica un despliegue*, así que se funden ahí.
- **H6 recupera el `v1.0`**, que el esquema reserva para la entrega final y
  antes se le daba a «pulido».
- **Se anota por qué Docker va antes que el agente**: el despliegue tiene que
  demostrar que funciona **sin** el agente —la máquina que corre el modelo se
  apaga— y el agente vive en la máquina 2 por SSH desde la 1. El contraargumento
  —el agente es lo único de resultado incierto— queda escrito también.
- **`v0.1.0` deja de figurar en el esquema de versiones**: ese tag nunca se
  creó. El MVP se entregó sin tag, porque entonces el flujo era
  `feature → PR → main`. Crearlo ahora sería abrir un corte en el tiempo hacia
  atrás.

### En el tablero

Creados **H4 · v0.5**, **H5 · v0.6** y **H6 · v1.0** con sus fechas. Antes sólo
existían dos milestones de los seis hitos del plan, así que el tablero no podía
servir de índice.

No se crean labels `hito:*`: en Fase A hacían falta porque épica y fecha eran
ejes distintos, pero **en Fase B el hito ES el tema** —H3 frontend, H4
despliegue, H5 agente— y un label diría lo mismo que el milestone.

### Notas

- H1 y H2 no reciben milestone retroactivo: sus issues son anteriores a esta
  práctica y reasignarlas es trabajo sin lector.
- Queda pendiente cerrar los milestones `MVP` y `H3 · v0.4`, que tienen todo
  cerrado.
