### PR TITLE
fix(nlp): la señal dedicada declara que no se puede servir en remoto

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Dos ramas permanentes con papeles distintos:
 
 _(El **MVP se entregó sin tag**: el versionado empieza de facto en `v0.2.0`, porque hasta entonces el flujo era `feature → PR → main` directo y no había promoción que tagear. Crear un `v0.1.0` ahora sería abrir un corte en el tiempo hacia atrás, que es justo lo que el principio de abajo prohíbe.)_
 
+_(El primer patch fue **`v0.4.1`**, y fija el criterio: un patch cabe cuando **lo publicado induce a error a quien despliegue o lea**, no sólo cuando el código falla. Allí el tag, la release y el README llamaban «caída del proveedor» a una limitación permanente, y la ficha del modelo —que la API sirve— declaraba una vía remota inexistente. Esperar a la siguiente minor habría dejado meses de documentación llamando avería a un límite de diseño.)_
+
 > **Principio:** las versiones son **cortes en el tiempo**, no contenedores temáticos. Una mejora posterior va a la **siguiente** versión aunque pertenezca por dominio a una épica ya taggeada (la trazabilidad temática la dan los labels de épica en los issues, no los tags). Los tags son inmutables: nunca se "reabre" una versión.
 
 _(Histórico: hasta la v0.2.0 el flujo era feature → PR → `main` directo; el esquema dev→main se adoptó al cerrar la Épica 5.)_
@@ -1438,10 +1440,39 @@ que se vea coherente:
 - Los números de arriba salen de `getComputedStyle` y `getBoundingClientRect`
   sobre la aplicación corriendo con sus tres procesos —servidor MCP, API y
   `ng serve`—, no de mirar capturas.
-- El caso de prueba se creó a propósito: un análisis nuevo con el proveedor
-  `hf-inference` caído, que dejó una entrada con una señal en `error` y otra en
-  `not_applicable` — los dos casos que el issue pide comprobar, reales y no
+- El caso de prueba se creó a propósito: un análisis nuevo dejó una entrada con
+  una señal en `error` —la dedicada, por el límite de abajo— y otra en
+  `not_applicable`. Los dos casos que el issue pide comprobar, reales y no
   simulados.
+
+#### Corrección: la señal caída no era una caída del proveedor
+
+Durante esta issue se describió el fallo de `detect_clickbait` como una caída de
+`hf-inference` «igual que la de la Épica 4». **Es falso, y el propio repositorio
+ya decía lo contrario.** Se corrige aquí porque el error llegó a la PR #150, al
+mensaje del tag `v0.4.0` y a su release.
+
+Lo que hay, en tres momentos:
+
+- **Épica 3** ya lo dejó escrito: *«el serverless `hf-inference` no sirve ningún
+  modelo de clickbait específico»*, sondeados tres.
+- **#127**, el 3 de septiembre, lo confirmó para el modelo elegido: *«No es un
+  timeout ocasional como los medidos en la Épica 4: es permanente»*.
+- **El 7 de septiembre** se cerró contra el catálogo del proveedor: la ficha del
+  Hub no declara **ningún** proveedor para `Stremie/roberta-base-clickbait`, y de
+  los **40 modelos de clickbait** del Hub **ninguno** tiene proveedor. El de
+  sentimiento sí responde, por la misma vía y con el mismo token: 3.248.238
+  descargas/mes frente a 59. **HuggingFace sirve por demanda.** Doce reintentos
+  en dos minutos no lo reactivan.
+
+Un timeout se reintenta; esto no. La diferencia decide qué se hace en H4 —
+desplegar con `nlp_backend=local`, porque el modelo existe en el Hub aunque su
+servicio no— y por eso el límite pasa a estar declarado en la **ficha del
+modelo**, que es donde cada señal dice lo que puede y lo que no.
+
+Y el historial lo respalda: 8 análisis en `error` el 3 de septiembre a las 08:03,
+20 correctos entre las 08:08 y las 09:10 —con el backend en local—, y error otra
+vez el 6 y el 7 con el defecto `remote`.
 
 #### Límites
 

--- a/backend/integrations/nlp/model_cards.py
+++ b/backend/integrations/nlp/model_cards.py
@@ -101,9 +101,12 @@ MODEL_CARDS: list[FichaModelo] = [
             "A favor, y es lo que más pesa: entrenado con ETIQUETA HUMANA (`truthMean` de anotadores), no por fuente. Es la única señal del sistema con supervisión no sesgada por el medio que publicó el titular — el fallo que #76 destapó y #109 cuantificó.",
             "No memoriza, verificado: rinde MEJOR fuera de su dominio (F1 0.946 en Chakraborty) que dentro (0.631 y 0.758 en los dos splits de Webis), el patrón inverso al de `elozano/bert-base-cased-clickbait-news`, descartado por 99.7% dentro y F1 0.185 fuera.",
             "Ese 0.946 de Chakraborty NO significa que sea mejor ahí (#121): Chakraborty etiqueta por fuente y ese método no puede producir casos dudosos, así que mide sólo la mitad fácil del problema. Restringiendo Webis a los titulares donde los 5 anotadores coinciden — lo más parecido a Chakraborty que hay dentro de Webis — sube a F1 0.906, y el resto lo explica el balance de clases.",
+            "NO SE PUEDE SERVIR EN REMOTO, y es permanente: `hf-inference` responde `400 Model not supported by provider`. Detectado el 2026-09-03 al ejecutar la pantalla contra la API de verdad, y confirmado el 2026-09-07 contra el catálogo del proveedor: la ficha del Hub no declara ninguno (`inferenceProviderMapping` vacío) y NINGUNO de los 40 modelos de clickbait del Hub lo tiene. HuggingFace sirve por demanda, y éste tiene 59 descargas/mes frente a los 3.248.238 del de sentimiento, que sí responde por la misma vía y con el mismo token. Doce reintentos en dos minutos no lo reactivan. Con `nlp_backend=remote` esta señal sale SIEMPRE en `error` y el veredicto se emite con las otras cuatro.",
             "Contexto imprescindible para leer cualquiera de estos números: el techo humano de la tarea es F1 0.665, y sólo el 34.9% de los titulares tiene a los 5 anotadores de acuerdo (#121). Sus errores se concentran donde las personas discrepan (92.9% de los fallos en el 65.1% dudoso) y su confianza baja ahí (0.918 vs 0.834), sin haber visto nunca los juicios individuales.",
         ],
-        "backend": "remote | local",
+        # Era "remote | local" hasta el 2026-09-07. La vía remota no existe: ver
+        # el límite de arriba.
+        "backend": "local",
     },
     {
         "signal": "analyze_sentiment",


### PR DESCRIPTION
Sin issue. Sale de investigar por qué `detect_clickbait` seguía fallando después
de `v0.4.0`, y de encontrar que **lo publicado dice algo falso**.

### El error

El mensaje del tag `v0.4.0`, su release y la sección de #130 dicen que el
proveedor `hf-inference` **estaba caído**. No lo estaba. Medido el 7-09, con el
mismo token y en la misma tanda:

| | `Stremie/roberta-base-clickbait` | `cardiffnlp/…sentiment` |
|---|---|---|
| `inferenceProviderMapping` | `{}` — ninguno | `hf-inference: live` |
| Estado | `None` | `warm` |
| Descargas/mes | 59 | 3.248.238 |

Y no es un caso aislado: de los **40 modelos de clickbait del Hub, cero están
servidos**. HuggingFace sirve **por demanda**, así que un modelo con 59 descargas
al mes no tiene proveedor que lo levante. Doce reintentos en dos minutos
devolvieron los doce el mismo `400 Model not supported by provider`.

Lo peor es que el proyecto **ya lo sabía**: la Épica 3 escribió que
`hf-inference` no sirve ningún modelo de clickbait específico —por eso se usaba
zero-shot—, y #127 lo confirmó para éste el 3-09 con una frase que lleva en el
README desde entonces: *«No es un timeout ocasional como los medidos en la Épica
4: es permanente»*. La sección de #130 la contradecía.

### Qué cambia

- **`model_cards.py`** — la ficha de `detect_clickbait` gana el límite, con la
  evidencia y las tres fechas, y su campo `backend` pasa de `"remote | local"` a
  `"local"`. No es sólo documentación: es **lo que publica la API y lo que
  enseña la pantalla de Sistema**, así que el sistema pasa a declarar su propia
  limitación — que es el eje del TFG.
- **README** — #130 deja de decir «caída» y gana un bloque de corrección que
  encadena los tres momentos. El respaldo es el propio historial: 8 errores a
  las 08:03 del 3-09, 20 aciertos entre 08:08 y 09:10 con el backend en local, y
  error otra vez el 6 y el 7 con el defecto `remote`.
- **El esquema de versiones** gana la regla que justifica que exista un patch
  aquí: cabe cuando **lo publicado induce a error a quien despliegue o lea**, no
  sólo cuando el código falla.

### Qué NO cambia

- **El mensaje del tag `v0.4.0`.** Los tags son inmutables y una versión no se
  reabre. La release sí gana después una nota que apunta aquí.
- **El defecto de `nlp_backend`.** Pasarlo a `local` es la decisión correcta y
  **no se puede tomar todavía**: `requirements.txt` trae `transformers` pero
  **no `torch`**, así que hoy `local` no arrancaría en una instalación de
  producción. Meter torch (rueda CPU-only, 1,2 GB → ~300 MB) es parte de la
  decisión de la imagen de H4, y va con la issue que se abre para servir esta
  señal.

218 tests en verde, `ruff` limpio. Va a `v0.4.1`.
