### PR TITLE
feat(web): la salud de las APIs externas, visible desde cualquier pantalla

### DIFF
--- a/README.md
+++ b/README.md
@@ -1228,6 +1228,122 @@ Añadir el registro a `/analyze` convirtió, sin avisar, todos los tests de esa 
 
 `tests/api/test_history.py` cubre los dos lados por separado —el almacén llamando a sus funciones, el endpoint por HTTP— porque responden preguntas distintas: si los datos sobreviven y salen en orden, y si la decisión de «una entrada por análisis» se sostiene de verdad.
 
+### El semáforo que faltaba: qué APIs responden, desde cualquier pantalla (#147)
+
+`GET /health` existía desde #86: sondea Weather, Guardian y NYT, agrega en
+`ok`/`degraded`/`down` y devuelve además el detalle por integración. Estaba
+probado, y desde #139 publicaba su forma en el contrato. **No lo consumía
+nadie** — un endpoint sin destino, y R6.6 sin cumplir. La issue nació dentro de
+#128, al separar qué estado enseña cada pantalla: R6.11 pide el de los
+servidores MCP y eso sale del catálogo; la salud de las APIs de terceros es otra
+pregunta, y no la respondía ninguna vista.
+
+#### Dónde va, y por qué no en la pantalla de Sistema
+
+Las dos opciones eran defendibles y el trabajo cambiaba con la elección. Sistema
+responde **qué está conectado**, que es lo que el sistema *es*; esto responde
+**qué funciona ahora mismo**, que cambia solo y sin avisar. Mezclarlas en una
+pantalla junta dos ejes distintos.
+
+Pesó más el momento en que surge la pregunta: quien ve fallar `get_nyt_news` la
+formula **mientras mira el fallo**, en `/analizar` o en el historial. Una
+respuesta a dos clics y en otra pantalla llega tarde. Va en la cabecera, visible
+desde cualquier ruta, desplegable al pulsarla.
+
+El precio está pagado a conciencia y conviene dejarlo escrito: **la cáscara gana
+estado y una dependencia que antes no tenía**. `app.spec.ts` ya necesita
+proveedores de HTTP para montar la cabecera, así que probar la navegación arrastra
+algo que no es de la navegación. Es el coste de que el indicador sea global; a
+cambio, el componente tiene su propio spec y la cáscara sigue sin lógica propia.
+
+Vive en `salud/`, carpeta nueva, y **no es una pantalla**: no tiene ruta. Ponerlo
+dentro de `analisis/` o de `sistema/` habría obligado a las otras dos a importar
+de una pantalla ajena, que es la dependencia que #129 prohibió.
+
+#### Lo que el indicador NO cubre, y por qué se dice en voz alta
+
+`PROBES` tiene tres entradas: `weather`, `guardian` y `nyt`. **Ninguna señal
+NLP.** Así que un verde aquí no dice absolutamente nada sobre si
+`detect_clickbait` responde: el 3 de septiembre habría estado en verde toda la
+mañana mientras esa señal devolvía `400` en cada análisis.
+
+Y la trampa se repite un nivel más abajo, que es lo que la hace interesante:
+**añadir `huggingface` a la lista tampoco lo arreglaría**. El proveedor responde
+`live` —medido el 7-09, ver `v0.4.1`— y aun así ese modelo no se sirve. La sonda
+que haría falta es **por modelo**, no por proveedor, y es trabajo de backend:
+queda en #156.
+
+De ahí dos decisiones de redacción, que no son cosmética:
+
+- La pastilla dice **«APIs externas ok»**, no «sistema ok». Un semáforo que
+  promete más de lo que mira es peor que no tener semáforo, porque quien lo cree
+  deja de buscar donde está el fallo.
+- El panel lo dice con todas las letras: *«Sólo las APIs de noticias. Las
+  señales de análisis no se sondean aquí»*. Está en un test, no sólo en la
+  plantilla.
+
+Esto corrigió, de paso, una afirmación escrita el día anterior en las notas del
+proyecto, que daba por hecho que esta pantalla habría hecho visible la caída de
+HuggingFace. No la habría hecho visible. Lo mismo que pasó con `v0.4.1`: el
+error estaba en la explicación, no en el sistema.
+
+#### El hallazgo medido: con la API apagada no llega `status 0`, llega 502
+
+Al probar el estado de fallo —parando uvicorn con la interfaz delante— apareció
+lo que ningún test unitario podía enseñar: **el error no llega como `status 0`,
+llega como 502**.
+
+La causa es la topología, y **es la misma en desarrollo y en despliegue**: entre
+el navegador y la API hay siempre un proxy —`proxy.conf.json` hoy, nginx en H4—
+y quien contesta cuando el destino no está es el proxy. El `status 0` que
+`api/errores.ts` traduce como «no hay API al otro lado» sólo aparecería si no
+contestara ni él.
+
+Con el mapeo original, apagar la API pintaba *«La API no pudo informar de su
+estado (502)»*, que sugiere que la API contestó algo estando muerta — y manda a
+mirar donde no es. Ahora 502, 503 y 504 se leen como **no hay API al otro lado**,
+con la medición escrita en el código y un test que fija el caso.
+
+**Por qué los tests no lo cazaron:** `HttpTestingController` sustituye el
+transporte, así que en las pruebas no hay proxy y el escenario no existe. Habrían
+pasado igual con el mapeo malo. Es la misma lección que dejó #86 al exigir un
+primer análisis real por HTTP: hay fallos que sólo aparecen ejecutando.
+
+#### Sondear no es gratis, así que no se sondea en bucle
+
+Cada consulta son **tres peticiones HTTP reales**, con corte de 5 s por sonda,
+contra APIs de terceros que además tienen cuota. Y es información que cambia
+despacio. Así que: **al cargar y a petición**, nunca periódico. Hay un test que
+lo sostiene —comprueba que no queda ninguna petición pendiente tras montar—, de
+modo que añadir un refresco automático rompe la suite en vez de pasar
+inadvertido.
+
+Al fallar, el estado anterior **se descarta** en vez de conservarse: dejar la
+hora de un sondeo antiguo junto a un mensaje de error es peor que no saber,
+porque parece información fresca.
+
+#### El detalle, no sólo el agregado
+
+Un ámbar dice que algo falla y no dice cuál, así que no es accionable. El panel
+lista cada integración con su estado, **las caídas primero** —lo accionable no
+puede quedar el último de una lista ordenada por nombre— y con el texto de la
+excepción marcado como técnico: no se esconde, porque es lo único que permite
+diagnosticar, pero no se confunde con la frase que se entiende. Es el mismo
+criterio que #130 aplicó al `detail` de una señal caída.
+
+Una integración que el frontend no sepa nombrar **se enseña con su clave en
+crudo**: `integrations` es un diccionario abierto en el contrato, así que el
+backend puede sondear una más sin que esta interfaz se entere. Enumerar aquí las
+tres de hoy la habría escondido sin que nada fallara al compilar.
+
+#### Medido
+
+- **117 tests** en el frontend, desde los 101 con los que empezó la issue.
+- **A 768 px no desborda nada**, con cero `@media`: el panel ocupa de 360 a 744
+  en un viewport de 768. Sale flotando por encima del contenido en vez de
+  empujarlo, porque mover la pantalla que estás mirando es justo lo que no
+  quieres al abrir algo para entender un fallo que tienes delante.
+
 ### R6.14 se escribe, y el frontend entra en los diagramas
 
 Sin issue, y conviene decir por qué: **salió de revisar los cuatro criterios de

--- a/docs/estructura.md
+++ b/docs/estructura.md
@@ -217,6 +217,7 @@ lógica: si algo se le añadiera, pertenece a otro sitio.
 | `analisis/` | Analizar un titular y ver el resultado —también uno guardado—, con lo que sólo esa vista usa: los guardianes del `data`, el resaltado del titular, la tarjeta de señal y el vocabulario |
 | `historial/` | La lista de lo anterior: filtros, paginación y el aviso de retención |
 | `sistema/` | Servidores, catálogo y fichas de modelo, más el lector de esquemas que genera el formulario de cada herramienta |
+| `salud/` | El indicador de salud de la cabecera (#147). **No es una pantalla**: no tiene ruta y se monta en la cáscara, porque la pregunta que responde —«¿esto falla por mí o por un tercero?»— surge desde cualquiera de las tres. Meterlo en la carpeta de una de ellas obligaría a las otras dos a importar de esa pantalla, que es justo la dependencia que la regla de abajo prohíbe |
 
 **Tres reglas que no se ven mirando el árbol:**
 

--- a/frontend/src/app/api/health.service.spec.ts
+++ b/frontend/src/app/api/health.service.spec.ts
@@ -1,0 +1,100 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { HealthService } from './health.service';
+import type { HealthResult } from './models';
+
+/** Las tres integraciones que sondea el backend hoy, todas respondiendo. */
+const TODO_BIEN: HealthResult = {
+  status: 'ok',
+  timestamp: '2026-09-07T13:00:00+00:00',
+  integrations: {
+    weather: { reachable: true, error: null },
+    guardian: { reachable: true, error: null },
+    nyt: { reachable: true, error: null },
+  },
+};
+
+describe('HealthService', () => {
+  let servicio: HealthService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    servicio = TestBed.inject(HealthService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('sondea la salud contra el prefijo de la API', () => {
+    servicio.estado().subscribe();
+
+    const peticion = http.expectOne('/api/health');
+    expect(peticion.request.method).toBe('GET');
+
+    peticion.flush(TODO_BIEN);
+  });
+
+  // La razón de que el servicio exista: nadie más consulta esta ruta, así que
+  // el prefijo tiene un único sitio donde equivocarse.
+  it('no manda parámetros: el sondeo no se configura desde el cliente', () => {
+    servicio.estado().subscribe();
+
+    const peticion = http.expectOne('/api/health');
+    expect(peticion.request.urlWithParams).toBe('/api/health');
+
+    peticion.flush(TODO_BIEN);
+  });
+
+  // Una integración caída viaja en una respuesta CORRECTA, no por `error`. Es
+  // el mismo patrón que `/tools` con un servidor inalcanzable y que `/analyze`
+  // con una señal que falla: dar por bueno todo lo que llega por `next` dejaría
+  // el semáforo en verde con dos APIs muertas.
+  it('un degradado llega por next, con el motivo de cada sonda', () => {
+    let recibida: HealthResult | undefined;
+    servicio.estado().subscribe((salud) => (recibida = salud));
+
+    http.expectOne('/api/health').flush({
+      status: 'degraded',
+      timestamp: '2026-09-07T13:00:00+00:00',
+      integrations: {
+        weather: { reachable: true, error: null },
+        guardian: { reachable: true, error: null },
+        nyt: { reachable: false, error: 'ReadTimeout: timed out' },
+      },
+    } satisfies HealthResult);
+
+    expect(recibida?.status).toBe('degraded');
+    expect(recibida?.integrations['nyt'].reachable).toBe(false);
+    expect(recibida?.integrations['nyt'].error).toContain('timed out');
+    expect(recibida?.integrations['guardian'].reachable).toBe(true);
+  });
+
+  // `integrations` es un diccionario abierto en el contrato: el backend puede
+  // sondear una integración más sin que el frontend se entere. El tipo tiene
+  // que dejarla pasar, porque enumerarlas aquí la escondería en silencio.
+  it('acepta una integración que hoy no existe', () => {
+    let recibida: HealthResult | undefined;
+    servicio.estado().subscribe((salud) => (recibida = salud));
+
+    http.expectOne('/api/health').flush({
+      status: 'ok',
+      timestamp: '2026-09-07T13:00:00+00:00',
+      integrations: {
+        weather: { reachable: true, error: null },
+        guardian: { reachable: true, error: null },
+        nyt: { reachable: true, error: null },
+        inventada: { reachable: true, error: null },
+      },
+    } satisfies HealthResult);
+
+    expect(Object.keys(recibida?.integrations ?? {})).toContain('inventada');
+  });
+});

--- a/frontend/src/app/api/health.service.ts
+++ b/frontend/src/app/api/health.service.ts
@@ -1,0 +1,46 @@
+/**
+ * Cliente de `GET /health`.
+ *
+ * Servicio propio y no un método más de `ToolsService` porque responden
+ * preguntas distintas: el catálogo dice **qué servidores MCP hay y qué
+ * ofrecen**, y esto dice **si las APIs de terceros contestan ahora mismo**. Uno
+ * describe lo que el sistema es; el otro, lo que en este momento funciona.
+ *
+ * **Qué NO cubre, y conviene tenerlo delante:** el backend sondea `weather`,
+ * `guardian` y `nyt`. Las señales NLP no están en la lista, así que un `ok` de
+ * aquí no dice nada sobre si `detect_clickbait` responde — el 3 de septiembre
+ * habría dicho `ok` con esa señal devolviendo 400 durante toda la mañana. Y
+ * añadir el proveedor de HuggingFace tampoco lo arreglaría: `hf-inference`
+ * responde, y aun así ese modelo no se sirve. La sonda que haría falta es **por
+ * modelo**, y es trabajo de backend (#156).
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { API } from './base';
+import type { HealthResult } from './models';
+
+@Injectable({ providedIn: 'root' })
+export class HealthService {
+  private readonly http = inject(HttpClient);
+
+  /**
+   * Sondea las integraciones externas y devuelve el agregado más el detalle.
+   *
+   * **Cada suscripción son tres peticiones HTTP de verdad**, con un corte de
+   * 5 s por sonda en el backend (`PROBE_TIMEOUT`). Es barato al abrir la
+   * aplicación y a petición del usuario, y caro en un bucle de refresco: es
+   * información que cambia despacio, y sondear en bucle multiplica el tráfico
+   * contra APIs de terceros que además tienen cuota.
+   *
+   * **Que una integración esté caída NO llega por el canal de error**, igual
+   * que en `/tools` y en `/analyze`: el backend responde 200 con `status` en
+   * `degraded` o `down` y el motivo dentro de cada sonda. Por `error` sólo
+   * llega que no se pueda hablar con la propia API, que significa otra cosa —
+   * el backend no contesta— y hay que enseñarlo distinto.
+   */
+  estado(): Observable<HealthResult> {
+    return this.http.get<HealthResult>(`${API}/health`);
+  }
+}

--- a/frontend/src/app/api/models.ts
+++ b/frontend/src/app/api/models.ts
@@ -122,6 +122,31 @@ export type HistoryKind = Esquemas['HistoryKind'];
 export type Origin = Esquemas['Origin'];
 export type RetentionPolicy = Esquemas['RetentionPolicy'];
 
+// --- Salud de las integraciones externas (GET /health) ---
+//
+// De `paths`, como todo lo que cruza la red. Aquí el contrato aporta algo que
+// no aporta en las otras rutas: `integrations` es un diccionario ABIERTO
+// —`Record<string, Sonda>`—, no una lista de las tres de hoy. Así una
+// integración nueva en el backend aparece sola en la interfaz; enumerarlas aquí
+// a mano la dejaría fuera sin que nada fallara al compilar.
+//
+// Ojo con lo que este endpoint NO cubre: sondea las APIs de noticias
+// (`weather`, `guardian`, `nyt`) y **ninguna señal NLP**. Un `ok` aquí no dice
+// nada sobre si `detect_clickbait` funciona — el 3-09 habría dicho `ok` con esa
+// señal devolviendo 400 toda la mañana. Ver #156.
+type Health = paths['/health']['get'];
+export type HealthResult = Health['responses'][200]['content']['application/json'];
+
+// El estado agregado sale de la respuesta y no de `components` porque en el
+// contrato es un enum EN LÍNEA, sin esquema propio con nombre.
+export type EstadoSalud = HealthResult['status'];
+
+// La sonda de una integración: si respondió y, si no, por qué. El `error` es el
+// texto de la excepción de httpx, así que es técnico a propósito — quien lo
+// pinte tiene que marcarlo como tal, igual que hizo #130 con el `detail` de una
+// señal caída.
+export type Sonda = Esquemas['Sonda'];
+
 // --- Errores de validación de FastAPI (422) ---
 export type HTTPValidationError = Esquemas['HTTPValidationError'];
 export type ValidationError = Esquemas['ValidationError'];

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -6,6 +6,10 @@
     <a routerLink="/historial" routerLinkActive="activo">Historial</a>
     <a routerLink="/sistema" routerLinkActive="activo">Sistema</a>
   </nav>
+
+  <!-- Fuera del `nav`: no es un destino, es el estado de algo. Meterlo dentro
+       lo anunciaría como una pestaña más a quien navegue por landmarks. -->
+  <app-indicador-salud />
 </header>
 
 <main class="contenido">

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -1,3 +1,5 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 
@@ -7,9 +9,17 @@ describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
-      // La plantilla usa `routerLink`, que no funciona sin un Router. Con la
-      // tabla vacía basta: aquí no se navega, sólo se pinta la cáscara.
-      providers: [provideRouter([])],
+      providers: [
+        // La plantilla usa `routerLink`, que no funciona sin un Router. Con la
+        // tabla vacía basta: aquí no se navega, sólo se pinta la cáscara.
+        provideRouter([]),
+        // Desde #147 la cáscara monta el indicador de salud, que consulta al
+        // construirse. Sin esto los tests de la cabecera fallarían por una
+        // dependencia que no es suya — el precio de meter algo con estado en la
+        // cáscara, y la razón de que el indicador tenga su propio spec.
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     }).compileComponents();
   });
 
@@ -45,6 +55,17 @@ describe('App', () => {
       { texto: 'Historial', destino: '/historial' },
       { texto: 'Sistema', destino: '/sistema' },
     ]);
+  });
+
+  // El indicador va en la cabecera pero FUERA del `nav`: no es un destino, y
+  // dentro se anunciaría como una pestaña más a quien navegue por landmarks.
+  it('lleva el indicador de salud en la cabecera, fuera de la navegación', async () => {
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+
+    const html = fixture.nativeElement as HTMLElement;
+    expect(html.querySelector('.cabecera app-indicador-salud')).not.toBeNull();
+    expect(html.querySelector('.nav app-indicador-salud')).toBeNull();
   });
 
   it('deja un hueco donde el router pinta la pantalla', async () => {

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,15 +1,21 @@
 import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
+import { IndicadorSalud } from './salud/indicador-salud';
+
 /**
  * Cáscara de la aplicación: cabecera y hueco donde el router pinta la pantalla.
  *
  * La navegación del prototipo tiene cuatro pestañas (Chat · Analizar ·
  * Historial · Sistema) y aquí hay tres: falta el Chat del agente (R13). Enlaces a rutas que no existen serían deuda visible, así que
  * cada pestaña aparece cuando aparece su pantalla.
+ *
+ * Desde #147 la cabecera lleva además el indicador de salud de las APIs
+ * externas. Está aquí y no en una pantalla porque la pregunta —«¿esto falla por
+ * mí o por un tercero?»— surge al ver fallar algo en cualquiera de las tres.
  */
 @Component({
-  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, IndicadorSalud],
   selector: 'app-root',
   styleUrl: './app.scss',
   templateUrl: './app.html',

--- a/frontend/src/app/salud/indicador-salud.html
+++ b/frontend/src/app/salud/indicador-salud.html
@@ -1,0 +1,60 @@
+<div class="salud" [attr.data-estado]="estado()">
+  <button
+    type="button"
+    class="pastilla"
+    (click)="alternar()"
+    [attr.aria-expanded]="abierto()"
+    aria-controls="detalle-salud"
+  >
+    <!-- El punto es decoración: el estado va en el texto de al lado, porque el
+         color no puede ser el único canal. -->
+    <span class="punto" aria-hidden="true"></span>
+    <span class="etiqueta" role="status">{{ etiqueta() }}</span>
+    <span class="chevron" aria-hidden="true">{{ abierto() ? '▾' : '▸' }}</span>
+  </button>
+
+  @if (abierto()) {
+    <div class="detalle" id="detalle-salud">
+      <p class="explicacion">{{ explicacion() }}</p>
+
+      @if (error(); as motivo) {
+        <p class="fallo" role="alert">{{ motivo }}</p>
+      }
+
+      @if (sondas().length > 0) {
+        <ul class="sondas">
+          @for (integracion of sondas(); track integracion.clave) {
+            <li class="sonda" [class.caida]="!integracion.sonda.reachable">
+              <span class="sonda__nombre">{{ integracion.nombre }}</span>
+              <span class="sonda__estado">
+                {{ integracion.sonda.reachable ? 'responde' : 'no responde' }}
+              </span>
+
+              <!-- El `error` de la sonda es el texto de la excepción de httpx,
+                   así que es técnico. Se enseña igual —es lo único que permite
+                   diagnosticar— pero marcado como lo que es, igual que hizo
+                   #130 con el `detail` de una señal caída. -->
+              @if (integracion.sonda.error; as tecnico) {
+                <span class="sonda__tecnico">{{ tecnico }}</span>
+              }
+            </li>
+          }
+        </ul>
+      }
+
+      <p class="alcance">
+        Sólo las APIs de noticias. Las señales de análisis no se sondean aquí:
+        que esto esté en verde no significa que respondan.
+      </p>
+
+      <div class="acciones">
+        @if (comprobadoA(); as hora) {
+          <span class="momento">Comprobado a las {{ hora }}</span>
+        }
+        <button type="button" class="recargar" (click)="consultar()" [disabled]="cargando()">
+          {{ cargando() ? 'Comprobando…' : 'Volver a comprobar' }}
+        </button>
+      </div>
+    </div>
+  }
+</div>

--- a/frontend/src/app/salud/indicador-salud.scss
+++ b/frontend/src/app/salud/indicador-salud.scss
@@ -1,0 +1,171 @@
+/*
+ * El indicador vive en la cabecera, así que se ancla con `position: relative` y
+ * el panel sale flotando por encima del contenido. Empujar la página hacia
+ * abajo al desplegarlo movería la pantalla que se está mirando, que es justo lo
+ * que no quieres cuando lo abres para entender un fallo que tienes delante.
+ */
+.salud {
+  position: relative;
+}
+
+/*
+ * El color del estado se resuelve una vez y lo heredan el punto y el borde. Los
+ * tres colores son los mismos que usan los tipos de señal, para no introducir
+ * un vocabulario cromático nuevo: verde responde, ámbar avisa, rojo falla.
+ */
+.salud[data-estado='ok'] {
+  --color-estado: var(--interpretable);
+}
+
+.salud[data-estado='degraded'] {
+  --color-estado: var(--aviso);
+}
+
+.salud[data-estado='down'],
+.salud[data-estado='incomunicado'] {
+  --color-estado: var(--error);
+}
+
+.salud[data-estado='cargando'] {
+  --color-estado: var(--texto-suave);
+}
+
+.pastilla {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--borde);
+  border-radius: 999px;
+  background: var(--fondo);
+  color: var(--texto-suave);
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.pastilla:hover {
+  border-color: var(--color-estado);
+}
+
+.punto {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--color-estado);
+}
+
+/* Mayúsculas por CSS: en el DOM el texto va en caja normal, porque muchos
+   lectores de pantalla deletrean las palabras escritas en caja alta. */
+.etiqueta {
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.chevron {
+  color: var(--texto-suave);
+}
+
+.detalle {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  z-index: 10;
+  width: min(24rem, calc(100vw - 2rem));
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--borde);
+  border-top: 3px solid var(--color-estado);
+  border-radius: 0.5rem;
+  background: var(--fondo);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 12%);
+  font-size: 0.85rem;
+}
+
+.explicacion {
+  margin: 0 0 0.75rem;
+}
+
+.fallo {
+  margin: 0 0 0.75rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 0.35rem;
+  background: var(--error-fondo);
+  color: var(--error);
+}
+
+.sondas {
+  margin: 0 0 0.75rem;
+  padding: 0;
+  list-style: none;
+}
+
+.sonda {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.15rem 0.5rem;
+  padding: 0.4rem 0;
+  border-top: 1px solid var(--borde);
+}
+
+.sonda__nombre {
+  font-weight: 600;
+}
+
+.sonda__estado {
+  color: var(--texto-suave);
+  text-align: right;
+}
+
+.sonda.caida .sonda__estado {
+  color: var(--error);
+  font-weight: 600;
+}
+
+/* El volcado técnico ocupa la fila entera y se distingue del resto: no se
+   esconde, pero tampoco se confunde con la frase que sí se entiende. */
+.sonda__tecnico {
+  grid-column: 1 / -1;
+  font-family: ui-monospace, monospace;
+  font-size: 0.75rem;
+  color: var(--texto-suave);
+  overflow-wrap: anywhere;
+}
+
+.alcance {
+  margin: 0 0 0.75rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--borde);
+  color: var(--texto-suave);
+  font-size: 0.78rem;
+}
+
+.acciones {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.momento {
+  color: var(--texto-suave);
+  font-size: 0.78rem;
+}
+
+.recargar {
+  margin-left: auto;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--borde);
+  border-radius: 0.35rem;
+  background: var(--fondo-suave);
+  color: inherit;
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.recargar:disabled {
+  color: var(--texto-suave);
+  cursor: default;
+}

--- a/frontend/src/app/salud/indicador-salud.spec.ts
+++ b/frontend/src/app/salud/indicador-salud.spec.ts
@@ -1,0 +1,205 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IndicadorSalud } from './indicador-salud';
+import type { HealthResult } from '../api/models';
+
+const TODO_BIEN: HealthResult = {
+  status: 'ok',
+  timestamp: '2026-09-07T13:00:00+00:00',
+  integrations: {
+    weather: { reachable: true, error: null },
+    guardian: { reachable: true, error: null },
+    nyt: { reachable: true, error: null },
+  },
+};
+
+const UNA_CAIDA: HealthResult = {
+  status: 'degraded',
+  timestamp: '2026-09-07T13:00:00+00:00',
+  integrations: {
+    weather: { reachable: true, error: null },
+    guardian: { reachable: true, error: null },
+    nyt: { reachable: false, error: 'ReadTimeout: timed out' },
+  },
+};
+
+describe('IndicadorSalud', () => {
+  let fixture: ComponentFixture<IndicadorSalud>;
+  let http: HttpTestingController;
+
+  /** Monta el indicador y responde al sondeo que lanza al construirse. */
+  async function montar(respuesta: HealthResult): Promise<HTMLElement> {
+    fixture = TestBed.createComponent(IndicadorSalud);
+    http.expectOne('/api/health').flush(respuesta);
+    await fixture.whenStable();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  /** Despliega el panel pulsando la pastilla. */
+  async function desplegar(html: HTMLElement): Promise<void> {
+    html.querySelector<HTMLButtonElement>('.pastilla')?.click();
+    await fixture.whenStable();
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [IndicadorSalud],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  // Cada sondeo son tres peticiones HTTP reales contra APIs de terceros con
+  // cuota, así que un refresco periódico sería caro y no aportaría: es
+  // información que cambia despacio.
+  it('consulta una sola vez al montar, no en bucle', async () => {
+    await montar(TODO_BIEN);
+
+    expect(http.match('/api/health').length).toBe(0);
+  });
+
+  it('dice el estado con palabras, no sólo con el color', async () => {
+    const html = await montar(TODO_BIEN);
+
+    expect(html.querySelector('.etiqueta')?.textContent).toContain('ok');
+    expect(html.querySelector('.salud')?.getAttribute('data-estado')).toBe('ok');
+  });
+
+  // El texto va en caja normal en el DOM y las mayúsculas las pone el CSS:
+  // muchos lectores de pantalla deletrean las palabras escritas en caja alta.
+  it('no escribe la etiqueta en mayúsculas en el DOM', async () => {
+    const html = await montar(TODO_BIEN);
+
+    const etiqueta = html.querySelector('.etiqueta')?.textContent?.trim() ?? '';
+    expect(etiqueta).not.toBe(etiqueta.toUpperCase());
+  });
+
+  it('el panel está plegado hasta que se pide', async () => {
+    const html = await montar(TODO_BIEN);
+
+    expect(html.querySelector('.detalle')).toBeNull();
+    expect(html.querySelector('.pastilla')?.getAttribute('aria-expanded')).toBe(
+      'false',
+    );
+
+    await desplegar(html);
+
+    expect(html.querySelector('.detalle')).not.toBeNull();
+    expect(html.querySelector('.pastilla')?.getAttribute('aria-expanded')).toBe(
+      'true',
+    );
+  });
+
+  // Sin el detalle por integración, el ámbar no es accionable: dice que algo
+  // falla y no cuál. Es el requisito explícito de #147.
+  it('al desplegarse enseña qué integración falla y por qué', async () => {
+    const html = await montar(UNA_CAIDA);
+    await desplegar(html);
+
+    const caidas = [...html.querySelectorAll('.sonda.caida')];
+    expect(caidas.length).toBe(1);
+    expect(caidas[0].textContent).toContain('New York Times');
+    expect(caidas[0].querySelector('.sonda__tecnico')?.textContent).toContain(
+      'timed out',
+    );
+  });
+
+  // Lo accionable es lo que está roto, y con una lista ordenada por nombre
+  // podría quedar la última.
+  it('pone las caídas delante', async () => {
+    const html = await montar(UNA_CAIDA);
+    await desplegar(html);
+
+    const nombres = [...html.querySelectorAll('.sonda__nombre')].map(
+      (elemento) => elemento.textContent?.trim(),
+    );
+    expect(nombres[0]).toBe('New York Times');
+  });
+
+  // `integrations` es un diccionario abierto: una integración que el frontend
+  // no conoce se enseña con su clave en crudo en vez de desaparecer. Mismo
+  // criterio que el `@default` de `senal-card`.
+  it('enseña en crudo una integración que no sabe nombrar', async () => {
+    const html = await montar({
+      status: 'ok',
+      timestamp: '2026-09-07T13:00:00+00:00',
+      integrations: { inventada: { reachable: true, error: null } },
+    });
+    await desplegar(html);
+
+    expect(html.querySelector('.sonda__nombre')?.textContent).toContain(
+      'inventada',
+    );
+  });
+
+  // Que no conteste la API es distinto de que contesten «todo caído»: en el
+  // primer caso no se sabe nada de las APIs externas, y el remedio es otro.
+  it('distingue no poder preguntar de que nadie responda', async () => {
+    fixture = TestBed.createComponent(IndicadorSalud);
+    http.expectOne('/api/health').error(new ProgressEvent('error'), {
+      status: 0,
+      statusText: 'Unknown Error',
+    });
+    await fixture.whenStable();
+
+    const html = fixture.nativeElement as HTMLElement;
+    expect(html.querySelector('.salud')?.getAttribute('data-estado')).toBe(
+      'incomunicado',
+    );
+
+    await desplegar(html);
+    expect(html.querySelector('.fallo')?.textContent).toContain(
+      'No se pudo contactar con la API',
+    );
+    expect(html.querySelector('.sondas')).toBeNull();
+  });
+
+  // Medido el 7-09 parando uvicorn con la interfaz delante: con la API apagada
+  // NO llega `status 0`, llega **502**, porque entre el navegador y la API hay
+  // siempre un proxy —`proxy.conf.json` hoy, nginx en H4— y quien contesta
+  // cuando el destino no está es él. Sin este caso, el mensaje diría que la API
+  // no pudo informar de su estado, de un proceso que está apagado.
+  it('un 502 del proxy se lee como que no hay API, no como que la API falló', async () => {
+    fixture = TestBed.createComponent(IndicadorSalud);
+    http.expectOne('/api/health').flush('Bad Gateway', {
+      status: 502,
+      statusText: 'Bad Gateway',
+    });
+    await fixture.whenStable();
+
+    const html = fixture.nativeElement as HTMLElement;
+    await desplegar(html);
+
+    expect(html.querySelector('.fallo')?.textContent).toContain(
+      'No se pudo contactar con la API',
+    );
+    expect(html.querySelector('.fallo')?.textContent).not.toContain('502');
+  });
+
+  it('avisa de que no cubre las señales de análisis', async () => {
+    const html = await montar(TODO_BIEN);
+    await desplegar(html);
+
+    expect(html.querySelector('.alcance')?.textContent).toContain(
+      'Las señales de análisis no se sondean aquí',
+    );
+  });
+
+  it('vuelve a comprobar a petición', async () => {
+    const html = await montar(UNA_CAIDA);
+    await desplegar(html);
+
+    html.querySelector<HTMLButtonElement>('.recargar')?.click();
+    http.expectOne('/api/health').flush(TODO_BIEN);
+    await fixture.whenStable();
+
+    expect(html.querySelector('.salud')?.getAttribute('data-estado')).toBe('ok');
+  });
+});

--- a/frontend/src/app/salud/indicador-salud.ts
+++ b/frontend/src/app/salud/indicador-salud.ts
@@ -1,0 +1,181 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, computed, inject, signal } from '@angular/core';
+
+import { SIN_RESPUESTA } from '../api/errores';
+import { HealthService } from '../api/health.service';
+import type { HealthResult, Sonda } from '../api/models';
+
+/**
+ * Los cinco estados que puede enseñar el indicador.
+ *
+ * Son los tres del backend más dos que el backend no puede contar: que la
+ * consulta está en marcha, y que **no contestó nadie**. El último es el que
+ * obliga a tener un tipo propio: `down` significa «pregunté y ninguna API
+ * responde», e `incomunicado` significa «no pude preguntar». Fundirlos pintaría
+ * de rojo un backend apagado y mandaría a mirar unas APIs de terceros que
+ * probablemente estén perfectamente.
+ */
+type EstadoIndicador = 'cargando' | 'ok' | 'degraded' | 'down' | 'incomunicado';
+
+/**
+ * Lo que se lee en la pastilla. Es la única señal para quien no distingue los
+ * colores, así que dice el estado con palabras y no sólo con el punto.
+ */
+const ETIQUETAS: Record<EstadoIndicador, string> = {
+  cargando: 'Comprobando…',
+  ok: 'APIs externas ok',
+  degraded: 'Alguna API falla',
+  down: 'APIs externas caídas',
+  incomunicado: 'Sin respuesta',
+};
+
+/** La frase que explica el estado al desplegar, ya sin abreviar. */
+const EXPLICACIONES: Record<EstadoIndicador, string> = {
+  cargando: 'Sondeando las APIs externas…',
+  ok: 'Todas las APIs externas respondieron al último sondeo.',
+  degraded: 'Alguna API externa no respondió. Las herramientas que dependen de ella fallarán.',
+  down: 'Ninguna API externa respondió.',
+  incomunicado: 'No se pudo consultar el estado, así que no se sabe cómo están las APIs externas.',
+};
+
+/**
+ * Nombres presentables de las integraciones que sondea el backend hoy.
+ *
+ * Con recurso al original: `integrations` es un diccionario ABIERTO, así que
+ * una integración nueva llega sin pasar por aquí y se enseña con su clave en
+ * crudo. Es el mismo criterio que el `@default` de `senal-card` — lo
+ * desconocido **se ve**, aunque se vea feo; omitirlo sería mentir sobre lo que
+ * se sondeó.
+ */
+const NOMBRES: Record<string, string> = {
+  weather: 'Weather.gov',
+  guardian: 'The Guardian',
+  nyt: 'New York Times',
+};
+
+/** Una integración lista para pintar, con su clave por si hace falta. */
+interface SondaDeIntegracion {
+  clave: string;
+  nombre: string;
+  sonda: Sonda;
+}
+
+/**
+ * Indicador de salud de las APIs externas, en la cabecera (#147).
+ *
+ * **Por qué en la cabecera y no en la pantalla de Sistema.** Sistema responde
+ * «qué está conectado», que es lo que el sistema *es*; esto responde «qué
+ * funciona ahora mismo», que cambia solo. Y sobre todo: la pregunta surge al
+ * ver fallar algo en `/analizar` o en el historial, así que la respuesta tiene
+ * que estar a la vista desde cualquier pantalla, no a dos clics.
+ *
+ * **Lo que NO cubre, y está escrito en la propia pastilla al desplegarla:** el
+ * backend sondea las APIs de noticias, no las señales NLP. Un verde aquí no
+ * dice nada sobre si `detect_clickbait` responde — el 3 de septiembre lo habría
+ * dicho toda la mañana con esa señal devolviendo 400. Prometer «estado del
+ * sistema» sería peor que no tener indicador. Ver #156.
+ */
+@Component({
+  selector: 'app-indicador-salud',
+  templateUrl: './indicador-salud.html',
+  styleUrl: './indicador-salud.scss',
+})
+export class IndicadorSalud {
+  private readonly salud = inject(HealthService);
+
+  readonly estadoRecibido = signal<HealthResult | null>(null);
+  readonly cargando = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly abierto = signal(false);
+
+  readonly estado = computed<EstadoIndicador>(() => {
+    if (this.cargando()) return 'cargando';
+    if (this.error()) return 'incomunicado';
+    return this.estadoRecibido()?.status ?? 'incomunicado';
+  });
+
+  readonly etiqueta = computed(() => ETIQUETAS[this.estado()]);
+  readonly explicacion = computed(() => EXPLICACIONES[this.estado()]);
+
+  /**
+   * Las integraciones sondeadas, las que fallan primero.
+   *
+   * Ordenar por estado y no por nombre es la diferencia entre un panel que se
+   * lee y uno que hay que recorrer: lo accionable es lo que está roto, y con
+   * una lista corta ordenada alfabéticamente puede quedar la última.
+   */
+  readonly sondas = computed<SondaDeIntegracion[]>(() => {
+    const integraciones = this.estadoRecibido()?.integrations ?? {};
+
+    return Object.entries(integraciones)
+      .map(([clave, sonda]) => ({ clave, nombre: NOMBRES[clave] ?? clave, sonda }))
+      .sort((primera, segunda) => Number(primera.sonda.reachable) - Number(segunda.sonda.reachable));
+  });
+
+  /** La hora del último sondeo, o `null` si todavía no hay ninguno. */
+  readonly comprobadoA = computed(() => {
+    const marca = this.estadoRecibido()?.timestamp;
+    if (!marca) return null;
+
+    const momento = new Date(marca);
+    return Number.isNaN(momento.getTime())
+      ? null
+      : momento.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' });
+  });
+
+  constructor() {
+    this.consultar();
+  }
+
+  /**
+   * Pide el estado. Se llama al montar y desde el botón de volver a comprobar,
+   * **nunca en bucle**: cada llamada son tres peticiones HTTP reales contra
+   * APIs de terceros con cuota, y es información que cambia despacio.
+   */
+  consultar(): void {
+    if (this.cargando()) return;
+
+    this.cargando.set(true);
+    this.error.set(null);
+
+    this.salud.estado().subscribe({
+      next: (recibido) => {
+        this.estadoRecibido.set(recibido);
+        this.cargando.set(false);
+      },
+      error: (fallo: HttpErrorResponse) => {
+        // El estado anterior se descarta: mantenerlo dejaría una hora de
+        // sondeo antigua junto a un mensaje de fallo, que es peor que no saber.
+        this.estadoRecibido.set(null);
+        this.error.set(this.mensajeDeFallo(fallo));
+        this.cargando.set(false);
+      },
+    });
+  }
+
+  alternar(): void {
+    this.abierto.update((estaAbierto) => !estaAbierto);
+  }
+
+  /**
+   * **Con la API apagada NO llega `status 0`, llega 502.** Medido el 7-09
+   * parando uvicorn con la interfaz delante.
+   *
+   * La razón es la topología, que es la misma en desarrollo y en despliegue:
+   * entre el navegador y la API hay siempre un proxy —`proxy.conf.json` ahora,
+   * nginx en H4— y quien contesta cuando el destino no está es el proxy. El
+   * `status 0` de `SIN_RESPUESTA` sólo aparecería si no contestara ni él.
+   *
+   * Por eso los códigos de pasarela se tratan como «no hay API al otro lado» y
+   * no como «la API falló»: son cosas distintas para quien mira, y decir «la
+   * API no pudo informar de su estado» de un proceso que está apagado es
+   * mentir sobre dónde está el problema.
+   */
+  private mensajeDeFallo(fallo: HttpErrorResponse): string {
+    const DE_PASARELA = [502, 503, 504];
+    if (fallo.status === 0 || DE_PASARELA.includes(fallo.status)) {
+      return SIN_RESPUESTA;
+    }
+    return `La API no pudo informar de su estado (${fallo.status}).`;
+  }
+}


### PR DESCRIPTION
## #147 · El semáforo que faltaba: qué APIs responden, desde cualquier pantalla

Closes #147

`GET /health` existía desde #86 —sondea Weather, Guardian y NYT, agrega en
`ok`/`degraded`/`down` y devuelve además el detalle por integración—, estaba
probado, y desde #139 publicaba su forma en el contrato. **No lo consumía
nadie.** Un endpoint sin destino, y con él **R6.6 incumplido** teniendo el
trabajo hecho al otro lado.

Lo que resuelve: hoy, quien ve fallar `get_nyt_news` no puede distinguir «la API
de terceros está caída» de «esta herramienta está rota». Son dos problemas con
remedios distintos y se veían igual.

### Qué incluye

- **`api/models.ts`** — `HealthResult` derivado de `paths['/health']['get']`,
  más `Sonda` y el estado agregado. `integrations` se deja como el diccionario
  **abierto** que declara el contrato: una integración nueva en el backend
  aparece sola en la interfaz.
- **`api/health.service.ts`** (+ spec, 4 tests) — servicio propio, no un método
  de `ToolsService`: el catálogo dice qué servidores hay, esto dice si los
  terceros contestan ahora. En su docstring va lo que no se ve en la firma: cada
  suscripción son **tres peticiones HTTP reales** con corte de 5 s.
- **`salud/indicador-salud.*`** (+ spec, 11 tests) — el indicador. Carpeta
  nueva, y **no es una pantalla**: no tiene ruta.
- **`app.html` · `app.ts` · `app.spec.ts`** — montado en la cabecera, fuera del
  `nav`.
- **`docs/estructura.md`** — la fila de `salud/` con su criterio.
- **`README.md`** — la sección de la issue, con las decisiones y las medidas.

### Dónde va, y qué cuesta

Las dos opciones eran defendibles. Sistema responde **qué está conectado** —lo
que el sistema *es*—; esto responde **qué funciona ahora mismo**, que cambia
solo. Decidió el momento en que surge la pregunta: se formula **mientras miras
el fallo**, en `/analizar` o en el historial, así que la respuesta tiene que
estar a la vista desde cualquier ruta.

El precio, dicho explícitamente: **la cáscara gana estado y una dependencia que
antes no tenía**. `app.spec.ts` ya necesita proveedores de HTTP para probar la
navegación. A cambio, la lógica vive en el componente con su propio spec.

Va en `salud/` y no dentro de `analisis/` o `sistema/` porque eso habría
obligado a las otras dos pantallas a importar de una pantalla ajena — la
dependencia que #129 prohibió.

### El hallazgo: con la API apagada no llega `status 0`, llega 502

Medido parando uvicorn con la interfaz delante. La causa es la topología, y **es
la misma en despliegue**: entre el navegador y la API hay siempre un proxy
—`proxy.conf.json` hoy, nginx en H4— y quien contesta cuando el destino no está
es el proxy. El `status 0` que `api/errores.ts` traduce como «no hay API al otro
lado» sólo aparecería si no contestara ni él.

Con el mapeo original, apagar la API pintaba *«La API no pudo informar de su
estado (502)»*: sugiere que la API contestó algo estando muerta, y manda a mirar
donde no es. Ahora 502, 503 y 504 se leen como **no hay API al otro lado**.

**Por qué los tests no lo cazaron:** `HttpTestingController` sustituye el
transporte, así que en las pruebas no hay proxy y el escenario no existe —
habrían pasado igual con el mapeo malo. Misma lección que dejó #86 al exigir un
primer análisis real por HTTP.

### Lo que NO cubre, y por qué se dice en voz alta

`PROBES` tiene tres entradas: `weather`, `guardian` y `nyt`. **Ninguna señal
NLP.** Un verde aquí no dice nada sobre si `detect_clickbait` responde: el 3 de
septiembre habría estado en verde toda la mañana con esa señal devolviendo 400.

Y añadir `huggingface` a la lista **tampoco lo arreglaría**: el proveedor
responde `live` —medido el 7-09, ver `v0.4.1`— y aun así ese modelo no se sirve.
La sonda que haría falta es **por modelo**, y es trabajo de backend: queda en
**#156**.

De ahí que la pastilla diga «APIs externas ok» y no «sistema ok», y que el panel
lo escriba con todas las letras. Un semáforo que promete más de lo que mira es
peor que no tenerlo, porque quien lo cree deja de buscar donde está el fallo.

### Sondear no es gratis

Tres peticiones reales por consulta, contra APIs con cuota, sobre información
que cambia despacio. Así que **al cargar y a petición, nunca periódico**, con un
test que comprueba que no queda ninguna petición pendiente tras montar: añadir
un refresco automático rompe la suite en vez de pasar inadvertido.

Al fallar, el estado anterior **se descarta**: dejar la hora de un sondeo
antiguo junto a un mensaje de error parece información fresca y no lo es.

### El detalle, no sólo el agregado

Un ámbar dice que algo falla y no dice cuál, así que no es accionable. El panel
lista cada integración, **las caídas primero**, con el texto de la excepción
marcado como técnico: no se esconde —es lo único que permite diagnosticar— pero
no se confunde con la frase que se entiende. Mismo criterio que #130 con el
`detail` de una señal caída. Una integración que la interfaz no sepa nombrar se
enseña **con su clave en crudo**.

### Medido

- **117 tests** en el frontend, desde los 101 con los que empezó la issue.
  Backend intacto: 218.
- **A 768 px no desborda nada**, con cero `@media`: el panel ocupa de 360 a 744
  en un viewport de 768. Sale flotando sobre el contenido en vez de empujarlo,
  porque mover la pantalla que estás mirando es lo último que quieres al abrir
  algo para entender un fallo que tienes delante.
- Verificado en vivo contra el backend real, incluidos el estado degradado y el
  de API apagada.

### Notas

- **La sonda por proveedor no habría servido**, y eso corrige lo que se había
  anotado antes de medir: se creía que esta pantalla haría visible el fallo de
  HuggingFace. No lo haría. Queda escrito para que #156 no repita el diseño.
- **Deuda menor de nombres**: dos tarjetas de señal empiezan por «RoBERTa» —la
  dedicada y la de sentimiento— y no se distinguen de un vistazo. Sale del campo
  `name` de `model_cards.py`, así que cambiarlo es una línea por señal; se deja
  para cuando se decida el vocabulario, no aquí.
- No se toca el backend: `PROBES` sigue igual y ninguna respuesta cambia.
