### PR TITLE
fix(nlp): la tarjeta del análisis rotula el modelo que se ejecutó

### DIFF
--- a/README.md
+++ b/README.md
@@ -1317,7 +1317,7 @@ ejecuta y **sustituye las medidas por su ausencia declarada**: *sin evaluar en
 este proyecto*. Y esa ausencia **es información**: dice que eso es un
 experimento, no una señal caracterizada.
 
-#### Dos trampas que aparecieron al hacerlo
+#### Dos trampas que aparecieron al hacerlo, y una tercera al ejecutarlo
 
 **El catálogo REST leía la ficha declarada.** `api/catalog.py` construía
 `ToolModelCard` desde el índice, así que con un modelo configurado la pantalla
@@ -1331,6 +1331,45 @@ lo fija.
 trampa latente que #87 describía por escrito: al no existir ya ese atributo,
 falla ruidosamente en vez de seguir probando una forma que ya no es. Ahora
 sustituyen la función de la factoría, que es el camino real.
+
+#### La tercera puerta, que sólo apareció ejecutándolo
+
+Con las dos anteriores tapadas y la suite en verde, se levantó el sistema con
+otro modelo configurado —`elozano/bert-base-cased-clickbait-news`, el que #115
+midió y descartó— para comprobarlo contra la realidad. El catálogo y
+`describe_models` decían el modelo efectivo, como debían. Y la **tarjeta del
+análisis** seguía rotulada «RoBERTa dedicado (entrenado en Webis-17)».
+
+Era la misma divergencia de #116 por tercera vez, y **la peor de las tres**: el
+catálogo lo mira quien va a inspeccionar el sistema, pero la tarjeta la mira
+quien lee el resultado. El orquestador guardaba `_CARDS`, un índice de las fichas
+**declaradas** resuelto al importar, y rotulaba con él.
+
+Ningún test lo cazaba porque ninguno comprobaba el `label` con un modelo
+configurado — y no había forma de que saltara sin ejecutar. De paso desaparece
+`_CARDS`: dejar ahí un índice declarado es dejar puesta la trampa para el
+siguiente que lo lea.
+
+#### El hueco del mapeo, medido en vez de razonado
+
+La misma ejecución dio el argumento empírico de #159, que hasta entonces era una
+deducción:
+
+```
+titular clickbait → ok      elozano dice «Clickbait», que sí está en el mapeo
+titular factual   → error   «devolvió la etiqueta "Normal", que no está en el
+                             mapeo ['Clickbait', 'Not Clickbait']»
+```
+
+`elozano` usa `Normal`/`Clickbait` y el sistema espera `Clickbait`/`Not
+Clickbait`. **Media convención coincide**, así que el modelo sustituido funciona
+con unos titulares y falla con otros — el peor reparto posible, porque una
+prueba rápida con un titular clickbait lo daría por bueno.
+
+Y falla bien: el mensaje nombra el modelo, la etiqueta que llegó y las que
+esperaba. Es el mismo criterio de #158 —el sistema dice qué pasa en vez de
+reventar por dentro— y es lo que convierte «intercambiar el modelo» en algo
+diagnosticable cuando la convención no encaja.
 
 #### Lo que queda fuera, y no como límite
 

--- a/backend/analysis/orchestrator.py
+++ b/backend/analysis/orchestrator.py
@@ -49,11 +49,11 @@ from backend.analysis.domain import (
 from backend.core.models import ToolResult
 from backend.integrations.nlp import dedicated, lexical, linear
 from backend.integrations.nlp.factory import (
+    ficha_efectiva,
     get_incoherence_detector,
     get_model_id,
     get_nlp_backend,
 )
-from backend.integrations.nlp.model_cards import cards_by_signal
 
 log = structlog.get_logger()
 
@@ -75,7 +75,9 @@ log = structlog.get_logger()
 # dimensión ni el tipo de cada señal: se leen de MODEL_CARDS (R3.9). Un desajuste
 # entre esta clave y el nombre real de la tool lo detecta antes de llegar aquí
 # test_model_cards_signals_match_registered_tools.
-_CARDS = cards_by_signal()
+# Se pide a la factoría en cada uso —igual que el backend— y no se guarda un
+# índice aquí. Un índice de módulo sería el DECLARADO, y quien lo leyera
+# rotularía el resultado con un modelo que quizá no es el que se ejecutó.
 
 # El id sale de la ficha (#116) y, desde #119, de la configuración si la hay —
 # `get_model_id` resuelve las dos cosas. Antes estaba cableado aquí y otra vez en
@@ -378,8 +380,15 @@ def _build(
     sabía, en un diccionario propio de ``vocabulario.ts`` que nadie vigilaba —
     renombrar una señal aquí no rompía ningún test, sólo hacía que la pantalla
     pintara el id crudo. Es la forma exacta del fallo de #116.
+
+    Y la ficha es la **efectiva**, no la declarada. Detectado ejecutando el
+    sistema con otro modelo configurado: el catálogo y ``describe_models`` ya
+    decían ``elozano/...`` mientras la tarjeta del análisis seguía rotulada
+    «RoBERTa dedicado (entrenado en Webis-17)». La misma divergencia de #116 por
+    una tercera puerta — y la peor de las tres, porque es la que mira quien lee
+    el resultado.
     """
-    card = _CARDS[spec.name]
+    card = ficha_efectiva(spec.name)
     return SignalResult(
         name=spec.name,
         label=card["name"],

--- a/tests/api/test_analyze.py
+++ b/tests/api/test_analyze.py
@@ -561,3 +561,24 @@ async def test_una_señal_que_no_carga_no_impide_arrancar(señales, monkeypatch)
     tiempos = await orchestrator.precalentar()
 
     assert tiempos["detect_clickbait_incoherence"] == -1.0
+
+
+@pytest.mark.asyncio
+async def test_la_tarjeta_rotula_el_modelo_que_se_ejecuto(señales, monkeypatch):
+    """La tercera puerta de la divergencia de #116, y la peor de las tres.
+
+    Detectado ejecutando el sistema con otro modelo configurado: el catálogo y
+    `describe_models` ya decían el efectivo, pero la tarjeta del análisis seguía
+    rotulada «RoBERTa dedicado (entrenado en Webis-17)» — y ésa es justo la que
+    mira quien lee el resultado.
+    """
+    señales()
+    monkeypatch.setattr(settings, "nlp_models", {"detect_clickbait": "otra/cosa"})
+
+    signals = {s.name: s for s in await _run_signals("Un titular", None)}
+    dedicada = signals["detect_clickbait"]
+
+    assert "otra/cosa" in dedicada.label
+    assert "Webis" not in dedicada.label
+    # Lo que describe a la señal y no al modelo no cambia.
+    assert dedicada.dimension == Dimension.FORM


### PR DESCRIPTION
## La tarjeta del análisis rotulaba el modelo declarado, no el que se ejecutó

Sin issue: es la corrección de un fallo introducido por #160 (#119/#87) y
detectado al ejecutar lo que aquélla entregó. Va suelta porque abrir una issue
para cerrarla en el mismo movimiento no añade trazabilidad — el rastro está en
#119, cuya sección del README recoge esto.

### Qué pasaba

#119 hizo configurable el modelo de cada señal y se ocupó de que la ficha
publicada fuera la del modelo **efectivo**, en las dos fachadas: el catálogo REST
y `describe_models`. Había una tercera puerta.

Levantando el sistema con otro modelo configurado —`elozano/bert-base-cased-clickbait-news`,
el que #115 midió y descartó—:

```
GET /tools                      → elozano/bert-base-cased-clickbait-news   ✔
POST /tools/describe_models     → elozano/bert-base-cased-clickbait-news   ✔
POST /analyze  →  signal.label  → «RoBERTa dedicado (entrenado en Webis-17)» ✘
```

El orquestador guardaba `_CARDS`, un índice de las fichas **declaradas** resuelto
al importar, y rotulaba con él cada `SignalResult`.

Es la misma divergencia que cerró #116 por tercera vez, y **la peor de las
tres**: el catálogo lo mira quien va a inspeccionar el sistema; la tarjeta la
mira quien lee el resultado.

### Qué cambia

- **`orchestrator.py`** — `_build` construye el `SignalResult` desde
  `ficha_efectiva`, y **desaparece `_CARDS`**. Dejar ahí un índice declarado es
  dejar puesta la trampa para el siguiente que lo lea.
- **`tests/api/test_analyze.py`** — un test que configura otro modelo y exige
  que el `label` lo refleje. Ninguno lo comprobaba, y por eso la suite estaba en
  verde con el fallo dentro.

### Por qué no lo cazó nada

Los tests de #119 comprobaban el `model_id` de la ficha por las dos fachadas que
sí se habían arreglado, y el `label` de la tarjeta no lo miraba ninguno. No había
forma de que saltara **sin ejecutar el sistema con un modelo configurado**, que
es justo lo que se hizo después de mergear.

### De regalo: el hueco del mapeo, medido

La misma ejecución dio el argumento empírico de **#159**, que hasta ahora era una
deducción:

```
titular clickbait → ok      elozano dice «Clickbait», que sí está en el mapeo
titular factual   → error   «devolvió la etiqueta "Normal", que no está en el
                             mapeo ['Clickbait', 'Not Clickbait']»
```

`elozano` usa `Normal`/`Clickbait` y el sistema espera `Clickbait`/`Not
Clickbait`: **media convención coincide**, así que el modelo sustituido funciona
con unos titulares y falla con otros — el peor reparto posible, porque una prueba
rápida con un titular clickbait lo daría por bueno. Queda registrado en el README
y en #159.

### Verificación

- **235 tests** (desde 234), ruff limpio, **pyright a cero**.
- Comprobado **en vivo** tras el arreglo: las tres puertas dicen
  `elozano/bert-base-cased-clickbait-news`.
